### PR TITLE
Fix builder image build broken by stale Yarn apt repo

### DIFF
--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -3,6 +3,9 @@ ARG base_img=mcr.microsoft.com/vscode/devcontainers/python:3.10-${base_tag}
 
 FROM ${base_img} AS builder-install
 
+# Base image ships a stale Yarn apt repo whose GPG key has rotated; we use npm, not yarn.
+RUN rm -f /etc/apt/sources.list.d/yarn.list
+
 # Dependencies for C
 RUN apt-get update --fix-missing && apt-get -y upgrade && apt-get install -y --no-install-recommends \
     apt-utils \


### PR DESCRIPTION
## Summary

- The Microsoft devcontainer base image (\`mcr.microsoft.com/vscode/devcontainers/python:3.10-bullseye\`) pre-configures a Yarn Debian apt repo whose signing key has since rotated. As of recent rebuilds, the first \`apt-get update\` in \`builder.Dockerfile\` fails with \`NO_PUBKEY 62D54FD4003F6525\`, breaking the entire builder image build.
- gamequeer uses npm (see \`gq-game-language/install-langium-deps.sh\`), not yarn, so the yarn repo isn't needed.
- This PR adds one line to drop \`/etc/apt/sources.list.d/yarn.list\` before the first \`apt-get update\`.

## Test plan

- [x] \`make builder-build\` completes successfully on a clean Docker state
- [x] \`make gamequeer\` (using the rebuilt image) builds the emulator binary
- [x] Compile \`examples/games/tutorial_1.gq\` via the examples Makefile inside the builder container — succeeds
- [x] Run the resulting \`tutorial_1.gqgame\` in the emulator — renders correctly under WSLg X11

(AI-generated via Claude Code w/ Claude Opus 4.7 (1M context))