### PR TITLE
ci: add GitHub Actions for gqc tests and VM native build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install gqc (editable)
-        run: pip install -e gqc/
+      - name: Install gqc (editable, with test deps)
+        run: pip install -e "gqc/[test]"
 
       - name: Run pytest
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  push:
+    branches: ["default"]
+  pull_request:
+    branches: ["default"]
+
+jobs:
+  gqc-tests:
+    name: gqc Python compiler tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        # gamequeer has no submodules; omit submodules: recursive
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install gqc (editable)
+        run: pip install -e gqc/
+
+      - name: Run pytest
+        run: |
+          # The test suite is currently all TODO stubs; pytest exits 5 ("no tests
+          # collected") until real tests are written.  Treat exit 5 as success so
+          # CI stays green, but still fail on import/syntax errors (any other
+          # non-zero exit).
+          #
+          # Note: do NOT write `pytest ...; code=$?` on separate lines under
+          # `set -e` (GitHub's default shell) — the command line itself would
+          # abort before $? is captured.  Use a list operator instead:
+          pytest tests || code=$?
+          if [ "${code:-0}" -ne 0 ] && [ "${code:-0}" -ne 5 ]; then
+            exit "${code}"
+          fi
+        working-directory: gqc/
+
+  gamequeer-vm-build:
+    name: gamequeer C VM native build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update -q
+          # cmake: build system; libx11-dev: required by the Linux HAL / gfx layer.
+          # libm is part of libc on glibc systems and needs no separate package.
+          sudo apt-get install -y cmake libx11-dev
+
+      - name: Configure (CMake)
+        # Native host build — faster than the repo's Docker path
+        # (make builder-build && make), and sufficient for verifying the VM
+        # sources compile.  The Docker path remains available as a fallback
+        # for a fully-reproducible environment.
+        run: cmake -B build
+        working-directory: gamequeer/
+
+      - name: Build
+        run: cmake --build build --parallel
+        working-directory: gamequeer/

--- a/gqc/pyproject.toml
+++ b/gqc/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "click>=8.0", "pyparsing>=3.1", "pytest>=8.2"]
+requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -16,6 +16,13 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
+dependencies = [
+    "click>=8.0",
+    "pyparsing>=3.1",
+]
+
+[project.optional-dependencies]
+test = ["pytest>=8.2"]
 
 [project.urls]
 Homepage = "https://github.com/duplico/gamequeer"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` with two jobs that run on every push/PR to `default`
- **Relocated from qc2024**: this CI was originally authored and verified passing against the `duplico/qc2024` parent repo, where it was recognized as misplaced — gamequeer-native code belongs in the gamequeer repo; this PR re-homes it here with corrected paths (`gqc/` → `gqc/`, `gamequeer/` → `gamequeer/`)
- The qc2024 firmware build separately cross-compiles these same VM sources for the MSP430 target in CCS (Code Composer Studio); badge-level integration is covered there

## Jobs

### `gqc-tests` — Python compiler test suite

Sets up Python 3.12, editable-installs `gqc/`, and runs `pytest tests`. The test suite is currently all TODO stubs, so pytest exits **5** ("no tests collected"). The workflow tolerates exit 5 as success so CI stays green while real tests are written, but still fails on import/syntax errors (any other non-zero exit). Uses a `||` list-operator pattern (`pytest ... || code=$?`) to safely capture the exit code under `bash -e` — the naive `pytest ...; code=$?` pattern aborts under `set -e` before `$?` is ever read.

### `gamequeer-vm-build` — C VM native CMake build

Installs `cmake` and `libx11-dev` via apt, then runs `cmake -B build && cmake --build build --parallel` inside `gamequeer/`. This is a deliberate choice over the repo's Docker path (`make builder-build && make`) — the native build is faster for CI and the host x86 build needs only X11 and libm (the latter is part of glibc). The Docker path remains available as a fallback for a fully-reproducible environment.

## Local verification

Both steps were verified locally in the worktree before authoring the YAML:

- `cd gqc && pip install -e . && pytest tests` → exit 5 (no tests collected), as expected
- `cd gamequeer && cmake -B build && cmake --build build --parallel` → `[100%] Built target gamequeer`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude claude-sonnet-4-6 <noreply@anthropic.com>