### PR TITLE
fix: remove redundant unmasked pre-draw in gq_draw_image_with_mask (#262)

### DIFF
--- a/gamequeer/src/oled.c
+++ b/gamequeer/src/oled.c
@@ -199,7 +199,6 @@ void gq_draw_image_with_mask(
     uint32_t mask_frame_data_size,
     t_gq_int x,
     t_gq_int y) {
-    gq_draw_image(context, image_bytes, image_bPP, width, height, img_frame_data_size, x, y);
     // Structs for the image and mask.
     gq_image_frame_on_screen image_frame = {0};
     gq_image_frame_on_screen mask_frame  = {0};


### PR DESCRIPTION
## What

Removes the vestigial `gq_draw_image(...)` call at the top of `gq_draw_image_with_mask()` in `gamequeer/src/oled.c`. That call unconditionally rendered the sprite's full, unmasked pixel data before the function's own masked draw loop ran and rendered the (correct) masked result.

## Why

- **Performance**: every masked sprite paid the per-pixel render cost twice. This was suspect #4 in the badge perf investigation (`docs/perf-investigation.md` in `duplico/qc2024`), estimated as a free fix that halves masked-sprite draw cost on both hardware and emulator.
- **Correctness bug found during validation**: the masked loop only calls `Graphics_drawPixelOnDisplay` where `mask_pixel` is true — it never erases pixels the pre-draw already painted in the "transparent" (mask=0) region. So the pre-draw wasn't just redundant work, it was actively leaking unmasked pixel data into areas the mask says should be transparent. See evidence below.

## Verified redundant / safe to remove

The masked loop's `image_frame` / `mask_frame` structs (lines 204-205 pre-fix) are freshly zero-initialized and load their own image data via `gq_load_image()` — there's no state shared with the `frame` struct used inside `gq_draw_image()`. The masked loop recomputes `draw_x`/`draw_y` identically and applies the same clip-region checks. Removing the pre-draw call has no effect on the masked loop's own correctness.

## How validated

Built and ran in the Linux emulator (Docker `gamequeer-builder`, `cmake` + headless build from #270's harness, used locally for validation only — not included in this PR).

- Authored a minimal test game (`stage.bganim` = solid black 128x128, `fganim(1)` = solid white 32x32 square, `fgmask(1)` = top-half-white/bottom-half-black 32x32 mask) and compiled it with `gqc`.
- **Before the fix**: the sprite rendered as a fully solid 32x32 white square — the mask was not honored; bottom half leaked the pre-draw's raw image pixels.
- **After the fix**: only the top half of the sprite (the masked-visible region) renders white; the bottom half correctly shows the black background.
- Diffed the two headless framebuffer dumps pixel-by-pixel: the *only* differing pixels are within the sprite's masked-out region (x: 0-31, y: 15-31 of the 32x32 sprite) — confirming the fix changes nothing outside the masked area.
- `clang-format --dry-run --Werror` against `gamequeer/.clang-format`: clean (pure line deletion, no reformatting needed).
- Full `gamequeer` CMake build (X11 target) and `gqc compile` on `examples/games/tutorial_1.gq` both succeed with no new warnings/errors.

## Lockstep check

No bytecode, struct, or `gqc` compiler changes — pure C runtime fix. `gqc` side unaffected.

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)