### PR TITLE
chore(gitignore): ignore build-headless/ directory

### DIFF
--- a/gamequeer/.gitignore
+++ b/gamequeer/.gitignore
@@ -1,1 +1,2 @@
 build/
+build-headless/


### PR DESCRIPTION
## Summary
- `build-headless/` (created by the `test-headless` Makefile target via `cmake -B build-headless -DGQ_HEADLESS=ON`) was untracked and showed up as noise in `git status` after running the headless test suite.
- Adds `build-headless/` to `gamequeer/.gitignore` alongside the existing `build/` entry.

Closes #280

## Test plan
- [x] Trivial one-line `.gitignore` addition; no build/test impact.

(AI-generated via Claude Code w/ Claude Fable 5)