### PR TITLE
fix(gqc): declare all runtime deps and add gqc console-script entry point

### DIFF
--- a/gqc/pyproject.toml
+++ b/gqc/pyproject.toml
@@ -19,10 +19,18 @@ classifiers = [
 dependencies = [
     "click>=8.0",
     "pyparsing>=3.1",
+    "rich>=13.7",
+    "webcolors>=24.6.0",
+    "ffmpeg-python>=0.2",
+    "pillow>=10.3",
+    "tabulate>=0.9",
 ]
 
 [project.optional-dependencies]
 test = ["pytest>=8.2"]
+
+[project.scripts]
+gqc = "gqc.gqc:gqc_cli"
 
 [project.urls]
 Homepage = "https://github.com/duplico/gamequeer"


### PR DESCRIPTION
## Summary

- `gqc/pyproject.toml`'s `[project] dependencies` only declared `click` and `pyparsing`. Audited every import across `gqc/src/gqc/*.py` and found five more runtime deps actually imported but undeclared: `rich` (parser.py, cues.py, datamodel.py, linker.py, gqc.py), `webcolors` (cues.py, datamodel.py), `ffmpeg-python` (`import ffmpeg` in anim.py), `pillow` (`from PIL import Image` in anim.py, datamodel.py), and `tabulate` (linker.py). A clean `pip install` of the package outside the Docker builder image would fail at import time.
- Version floors mirror the values already vetted in the repo's top-level `requirements.txt` (used by `builder.Dockerfile` and `gqc/Makefile init`), so this doesn't introduce new, unvetted floors.
- Added a `[project.scripts]` entry (`gqc = "gqc.gqc:gqc_cli"`), pointing at the existing `click` group function in `gqc.py`. Every current invocation in the repo (top-level `Makefile`, `examples/Makefile`, `gqc/examples/skel/Makefile`, `builder.Dockerfile`, CI) uses `python -m gqc`, which is unaffected by adding a console-script.

## Test plan

- [x] Fresh venv (pyenv 3.12.5, matching CI's Python 3.12): `pip install -e "gqc/[test]"` succeeds and pulls in all 5 newly declared deps plus their transitive deps.
- [x] `gqc --help` and `gqc compile --help` work via the new console-script entry point.
- [x] End-to-end compile via the new `gqc` command: `gqc compile --no-mem-map -o /tmp/out gamequeer/tests/golden/hello.gq` produces a valid `.gqgame`.
- [x] `python -m gqc compile ...` (the existing invocation path) still works unchanged.
- [x] `pytest tests` still exits 5 ("no tests collected"), matching CI's expected behavior.
- [x] `python -m build` (non-editable) produces a wheel with `entry_points.txt` present; installing that wheel into a brand-new venv gives a working `gqc` command.
- [x] Docker builder harness: built `gqc/dist/{gqc-0.0.1.tar.gz,gqc-0.0.1-py3-none-any.whl}` via the cached `gamequeer-builder:latest` image (same command as `make gqc`, run without `-it` since this is a non-interactive shell) — succeeds.
- [x] Ran a golden-fixture compile (`gamequeer/tests/golden/hello.gq`) inside the Docker builder image via `python -m gqc` — succeeds, matching the `make golden-fixture` target's invocation style.
- [x] `.github/workflows/ci.yml` needs no change — it already installs via `pip install -e "gqc/[test]"`, the same path validated above.

Closes #279

(AI-generated via Claude Code w/ Claude Fable 5)