### PR TITLE
fix(menu): raise REFRESH on menu_close and gate POS-mode BUTTON_R redraw

### DIFF
--- a/gamequeer/src/menu.c
+++ b/gamequeer/src/menu.c
@@ -168,9 +168,12 @@ void menu_choice_load(t_gq_pointer menu_ptr, t_gq_pointer menu_prompt) {
 }
 
 void menu_close() {
-    *menu_active = 0;
+    t_gq_int was_active = *menu_active;
+    *menu_active        = 0;
 
-    if (*menu_active) {
+    if (was_active) {
+        // The menu was actually showing something on screen; closing it is
+        // always a real visual change, so raise the redraw event.
         GQ_EVENT_SET(GQ_EVENT_REFRESH);
     }
 }
@@ -524,9 +527,9 @@ uint8_t handle_event_menu_text(uint16_t event_type) {
                     if (menu_text_result[menu_option_selected]) {
                         menu_select_symbol_type_from_index();
                     }
+                    GQ_EVENT_SET(GQ_EVENT_REFRESH);
                 }
             }
-            GQ_EVENT_SET(GQ_EVENT_REFRESH);
             break;
         case GQ_EVENT_BUTTON_CLICK:
             // Toggle the selection mode


### PR DESCRIPTION
## Summary

Addresses the substantive item (b) and the minor item (c) from #278 ("REFRESH-invariant hazards"). Item (a) (`unload_game()`) is *not* touched here -- see "On item (a) / issue disposition" below for why.

- **`menu.c:menu_close()` (item b, the real bug):** `*menu_active` was zeroed and then checked -- `if (*menu_active)` was therefore always false, so closing a menu never raised `GQ_EVENT_REFRESH`. Every caller (`handle_event_menu_choice`'s and `handle_event_menu_text()`'s `BUTTON_A` confirm paths) relied on this to trigger the redraw that clears the menu overlay off-screen. Fixed by capturing whether the menu was active *before* zeroing it, and raising `REFRESH` only in that case.
- **`handle_event_menu_text()` POS-mode `BUTTON_R` (item c, minor):** raised `REFRESH` unconditionally even when the rightmost-boundary check blocked the cursor from moving. Moved the `GQ_EVENT_SET(GQ_EVENT_REFRESH)` inside the `if (menu_option_selected < GQ_STR_SIZE - 2)` block so it only fires when the cursor actually advances, matching the gating style already used for `BUTTON_L`/`BUTTON_R` in `handle_event_menu_choice()`.

## On item (a) / issue disposition

`unload_game()`'s "wire it up or delete it" question was already resolved defensively in #274's second review round: it now raises `GQ_EVENT_REFRESH` unconditionally at the end (so it's safe *if* something starts calling it), but it's still dead code with zero call sites in the tree. That's a design decision (does anything need to call `unload_game()`, or should it be deleted?), not a correctness fix, so I've left it alone here.

Given that, I'm intentionally **not** writing "Closes #278" -- the missed-redraw bug (the one with real user-visible impact) and the minor redundant-redraw nit are both fixed in this PR, but the architectural question in (a) is still open and belongs to a maintainer call, not something this PR should silently resolve by closing the issue. Recommend closing #278 once (a) is either actioned (wire up a caller) or explicitly deferred/tracked separately -- happy to do either follow-up on request.

## Validation

**Golden/regression suite:** full `ctest` 8/8 passing on both fresh `build/` (X11) and `build-headless/` (`-DGQ_HEADLESS=ON`) builds.

**Interactive menu-close validation (headless emulator, scripted `--input`):** examples/ games with menus (`tutorial_1.gq`, `sample_working*.gq`) require GIF/PNG animation assets and ffmpeg-based compilation, so for a clean, deterministic pixel-diff I authored a minimal no-asset fixture (`menu_close.gq`, not committed -- validation-only) with a single stage that opens a choice menu on entry and does nothing else visually on close (`event menu` only writes a non-visual volatile int, isolating whether `menu_close()` itself triggers the redraw):

```
stage menu_test {
    menu confirm prompt "Pick?";
    event menu {
        result = GQI_MENU_VALUE;
    }
}
```

Using `--ticks`/`--input`/`--dump`, I drove: tick 1 = harmless `CLICK` (menu opens, dumps `open.pgm`), tick 2 = `A` (confirms and closes the menu, dumps `closed.pgm`), and dumped the same sequence against both the pre-fix and post-fix `menu.c` (via `git stash` to isolate just this file, matching the negative-control methodology used in #274/#276).

Pixel counts (127x127 framebuffer, white = lit pixel):

| Build | `open.pgm` (tick 1) | `closed.pgm` (tick 2, after `A`) |
|---|---|---|
| pre-fix (buggy `menu_close`) | 1101 white px | **1101 white px (byte-identical to `open.pgm`)** -- stale menu frame confirmed |
| post-fix (this PR) | 1101 white px | **0 white px** -- screen correctly redrawn/cleared |

This directly demonstrates the bug (the menu overlay was never cleared after close -- the pre-fix `closed.pgm` is byte-for-byte identical to the still-open frame) and confirms the fix (post-fix `closed.pgm` correctly shows the redrawn, menu-free screen).

## Test plan
- [x] `ctest` 8/8 passing (X11 + headless builds)
- [x] `clang-format` run on `gamequeer/src/menu.c` (per `.clang-format`)
- [x] Scripted headless pixel-diff validation of the menu-close fix (pre-fix vs. post-fix, see above)
- [x] Code-reading confirmation that item (a) is out of scope / already partially addressed by #274

(AI-generated via Claude Code w/ Claude Fable 5)