### PR TITLE
ci: run headless golden-framebuffer suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,10 @@ jobs:
 
       - name: Configure headless build (golden framebuffer suite)
         # GQ_HEADLESS swaps the X11 gfx backend for a no-op stub (see
-        # src/gfx/gfx_headless.c), so no extra apt packages are needed beyond
-        # the cmake already installed above — no libx11-dev/DISPLAY required.
+        # src/gfx/gfx_headless.c), so this configure step itself needs no
+        # extra apt packages. libx11-dev was already installed above, but
+        # only for the earlier native build — it (and a DISPLAY) is not
+        # required for this headless one.
         # This also registers the tests/ CTest tree (see CMakeLists.txt: only
         # added when GQ_HEADLESS=ON), which runs the golden-framebuffer
         # regression suite (gamequeer#268/#270/#275) against the .gqgame

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         working-directory: gqc/
 
   gamequeer-vm-build:
-    name: gamequeer C VM native build
+    name: gamequeer C VM native build + headless golden suite
     runs-on: ubuntu-latest
 
     steps:
@@ -64,3 +64,22 @@ jobs:
       - name: Build
         run: cmake --build build --parallel
         working-directory: gamequeer/
+
+      - name: Configure headless build (golden framebuffer suite)
+        # GQ_HEADLESS swaps the X11 gfx backend for a no-op stub (see
+        # src/gfx/gfx_headless.c), so no extra apt packages are needed beyond
+        # the cmake already installed above — no libx11-dev/DISPLAY required.
+        # This also registers the tests/ CTest tree (see CMakeLists.txt: only
+        # added when GQ_HEADLESS=ON), which runs the golden-framebuffer
+        # regression suite (gamequeer#268/#270/#275) against the .gqgame
+        # fixtures already committed under tests/golden/.
+        run: cmake -B build-headless -DGQ_HEADLESS=ON
+        working-directory: gamequeer/
+
+      - name: Build (headless)
+        run: cmake --build build-headless --parallel
+        working-directory: gamequeer/
+
+      - name: Run golden framebuffer regression suite
+        run: ctest --output-on-failure
+        working-directory: gamequeer/build-headless


### PR DESCRIPTION
## Summary

- CI's `gamequeer-vm-build` job configured/built the emulator natively but never built it headless (`-DGQ_HEADLESS=ON`) or ran `ctest`, so the 8-test golden-framebuffer regression suite (`golden_framebuffer`, `mask_encoding_a`/`b`, `redundant_write` initial/phase_a/phase_b, plus 2 draw-count tests) landed by #270/#275 was never CI-gated.
- Extends the existing `gamequeer-vm-build` job (rather than adding a new job) with a headless configure + build + `ctest --output-on-failure` sequence, reusing the checkout and keeping total CI time small — locally the headless build+suite runs in well under a second.
- No new apt packages needed: `GQ_HEADLESS` swaps the X11 gfx backend for a no-op stub (`src/gfx/gfx_headless.c`), so the headless configure/build requires neither `libx11-dev` nor a `DISPLAY`. Verified by reading `gamequeer/CMakeLists.txt` (X11 `find_package`/link only happens in the non-headless branch) and confirmed locally (no libx11-dev installed in this dev environment, headless configure/build succeeded).

## Local verification

```
$ cmake -B build-headless -DGQ_HEADLESS=ON   # no X11 needed
$ cmake --build build-headless --parallel
$ cd build-headless && ctest --output-on-failure
100% tests passed, 0 tests failed out of 8
```

## Relation to #269

Partially addresses #269 ("Minimal headless CI"). Of that issue's 4 steps: (1) gqc pytest and (2) emulator build were already CI-gated before this PR; (4) golden-framebuffer test is added here. (3) `clang-format --dry-run -Werror` is **not** covered by this PR and remains open work under #269.

## CI evidence

This PR's own CI run confirms the golden suite actually executes and passes (not silently skipped): [run 29318150994](https://github.com/duplico/gamequeer/actions/runs/29318150994), job "gamequeer C VM native build + headless golden suite".

Log excerpt from the "Run golden framebuffer regression suite" step:

```
Test project /home/runner/work/gamequeer/gamequeer/gamequeer/build-headless
    Start 1: golden_framebuffer
1/8 Test #1: golden_framebuffer ......................................   Passed    0.01 sec
    Start 2: golden_framebuffer_mask_encoding_a
2/8 Test #2: golden_framebuffer_mask_encoding_a ......................   Passed    0.01 sec
    Start 3: golden_framebuffer_mask_encoding_b
3/8 Test #3: golden_framebuffer_mask_encoding_b ......................   Passed    0.00 sec
    Start 4: golden_framebuffer_redundant_write_initial
4/8 Test #4: golden_framebuffer_redundant_write_initial ..............   Passed    0.00 sec
    Start 5: golden_framebuffer_redundant_write_phase_a
5/8 Test #5: golden_framebuffer_redundant_write_phase_a ..............   Passed    0.00 sec
    Start 6: golden_framebuffer_redundant_write_phase_b
6/8 Test #6: golden_framebuffer_redundant_write_phase_b ..............   Passed    0.00 sec
    Start 7: golden_framebuffer_redundant_write_draw_count_phase_a
7/8 Test #7: golden_framebuffer_redundant_write_draw_count_phase_a ...   Passed    0.00 sec
    Start 8: golden_framebuffer_redundant_write_draw_count_phase_b
8/8 Test #8: golden_framebuffer_redundant_write_draw_count_phase_b ...   Passed    0.00 sec

100% tests passed, 0 tests failed out of 8

Total Test time (real) =   0.27 sec
```

All 8 registered tests ran and passed (count matches `ctest`'s own "out of 8" tally — none silently skipped).

Both CI jobs pass: `gqc-tests` (pre-existing, unaffected) and `gamequeer-vm-build` (this PR's target).

---
(AI-generated via Claude Code w/ Sonnet 5)
