### PR TITLE
fix(vm): enforce GQ_MIN_FRAME_DURATION for all animation frames

### DIFF
--- a/gamequeer/src/gamequeer.c
+++ b/gamequeer/src/gamequeer.c
@@ -240,6 +240,19 @@ void unload_game() {
     GQ_EVENT_SET(GQ_EVENT_REFRESH);
 }
 
+// Applies GQ_MIN_FRAME_DURATION to a frame's raw ticks_per_frame value. Used
+// both when an animation is (re)loaded and on every subsequent frame advance
+// in system_tick(), so every frame of every animation -- not just frame 0 --
+// is shown for at least GQ_MIN_FRAME_DURATION ticks.
+static uint16_t gq_clamp_frame_duration(uint16_t ticks_per_frame) {
+#ifdef GQ_MIN_FRAME_DURATION
+    if (ticks_per_frame < GQ_MIN_FRAME_DURATION) {
+        return GQ_MIN_FRAME_DURATION;
+    }
+#endif
+    return ticks_per_frame;
+}
+
 uint8_t load_animation(uint8_t index, t_gq_pointer anim_ptr) {
     if (index >= MAX_CONCURRENT_ANIMATIONS) {
         return 0;
@@ -258,12 +271,7 @@ uint8_t load_animation(uint8_t index, t_gq_pointer anim_ptr) {
     // Invalidate any cached frame metadata from a previous animation (or
     // previous frame index) in this slot -- see frame_meta's comment.
     anim->frame_meta.data_pointer = 0;
-    anim->ticks                   = anim->anim.ticks_per_frame;
-#ifdef GQ_MIN_FRAME_DURATION
-    if (anim->ticks < GQ_MIN_FRAME_DURATION) {
-        anim->ticks = GQ_MIN_FRAME_DURATION;
-    }
-#endif
+    anim->ticks                   = gq_clamp_frame_duration(anim->anim.ticks_per_frame);
 
     GQ_EVENT_SET(GQ_EVENT_REFRESH);
 
@@ -454,7 +462,7 @@ void system_tick() {
         // The frame index changed, so the cached frame metadata (if any) is
         // now stale -- see gq_anim_onscreen's frame_meta comment.
         current_animations[i].frame_meta.data_pointer = 0;
-        current_animations[i].ticks                   = current_animations[i].anim.ticks_per_frame;
+        current_animations[i].ticks = gq_clamp_frame_duration(current_animations[i].anim.ticks_per_frame);
         if (current_animations[i].frame >= current_animations[i].anim.frame_count) {
             // Animation is complete
             current_animations[i].in_use = 0;

--- a/gamequeer/tests/CMakeLists.txt
+++ b/gamequeer/tests/CMakeLists.txt
@@ -184,4 +184,4 @@ add_golden_test(golden_framebuffer_anim_advance_frame0 anim_advance
 add_golden_test(golden_framebuffer_anim_advance_frame1 anim_advance
     TICKS 22 GOLDEN_SUFFIX anim_advance_frame1)
 add_golden_test(golden_framebuffer_anim_advance_frame2 anim_advance
-    TICKS 33 GOLDEN_SUFFIX anim_advance_frame2)
+    TICKS 43 GOLDEN_SUFFIX anim_advance_frame2)

--- a/gamequeer/tests/golden/anim_advance.gq
+++ b/gamequeer/tests/golden/anim_advance.gq
@@ -19,16 +19,16 @@
  * collapse to a single extracted frame) as a plain bganim, started from the
  * `enter` event.
  *
- * Timing -- empirically verified by dumping every tick from 1..34 and
+ * Timing -- empirically verified by dumping every tick from 1..45 and
  * diffing the PGMs, rather than trusted from the frame_rate arithmetic
  * alone (gqc's Animation.__init__ computes ticks_per_frame = 100/frame_rate
- * = 100/10 = 10, but gamequeer.c's `load_animation()` clamps the *first*
- * frame's `ticks` up to `GQ_MIN_FRAME_DURATION` (20, include/gamequeer.h)
- * since 10 < 20 -- `system_tick()`'s own per-advance reset does *not*
- * re-apply that clamp, so frame 0's duration (20 ticks) and every
- * subsequent frame's duration (10 ticks, the unclamped value) actually
- * differ. This asymmetry is pre-existing/unrelated to #264 and out of
- * scope here; it's just why the tick counts below aren't evenly spaced):
+ * = 100/10 = 10, but gamequeer.c clamps every frame's `ticks` up to
+ * `GQ_MIN_FRAME_DURATION` (20, include/gamequeer.h) since 10 < 20 -- see
+ * gq_clamp_frame_duration(), shared by both load_animation() and
+ * system_tick()'s per-advance reset as of gamequeer#288, which fixed a
+ * prior asymmetry where only frame 0's duration was clamped and every
+ * later frame ran at the unclamped 10-tick rate. With the clamp applied
+ * uniformly, every frame of this animation is shown for 20 ticks):
  *
  *   tick 1:  `enter` fires (first handle_events() pass), runs `play bganim
  *            pop`, which calls load_animation() (frame=0, ticks clamped to
@@ -40,22 +40,26 @@
  *   tick 22: the counter hits 0 -> frame advances to 1, the cache is
  *            invalidated (frame_meta.data_pointer zeroed), a fresh cart
  *            read repopulates it, and REFRESH fires -- frame 1 is drawn.
- *   ticks 23..32: same idle window (unclamped ticks_per_frame=10 this
- *            time); still frame 1's pixels -- confirmed identical for
- *            every tick count in [22, 32].
- *   tick 33: frame advances to 2 and is drawn, by the same mechanism.
+ *   ticks 23..42: same idle window (clamped ticks_per_frame=20 again);
+ *            still frame 1's pixels -- confirmed identical for every
+ *            tick count in [22, 42].
+ *   tick 43: frame advances to 2 and is drawn, by the same mechanism.
  *
  * Three ctest cases share this one compiled cart (see tests/CMakeLists.txt):
  *   golden_framebuffer_anim_advance_frame0 (TICKS=1)  -- frame 0.
  *   golden_framebuffer_anim_advance_frame1 (TICKS=22) -- frame 1: proves the
  *     cache invalidates and the *new* frame's metadata is actually read
- *     (a stale/frozen cache would still show frame 0's pixels here).
- *   golden_framebuffer_anim_advance_frame2 (TICKS=33) -- frame 2: proves
+ *     (a stale/frozen cache would still show frame 0's pixels here). This
+ *     boundary happens to be unchanged by the uniform-clamp fix, since
+ *     frame 0's duration was already clamped to 20 ticks before it too.
+ *   golden_framebuffer_anim_advance_frame2 (TICKS=43) -- frame 2: proves
  *     invalidation isn't a one-shot fluke and keeps working on the *second*
  *     advance too (guards against a fix that only clears the cache once).
+ *     This boundary moved from 33 to 43 once frame 1's duration was also
+ *     clamped to 20 ticks (was 10, unclamped) by the uniform-clamp fix.
  * Each of the three goldens differs pixel-for-pixel from the other two
  * (confirmed via md5sum of the dumped PGMs when this fixture was authored:
- * three distinct hashes across the [1,21]/[22,32]/33+ tick ranges).
+ * three distinct hashes across the [1,21]/[22,42]/43+ tick ranges).
  *
  * Negative-control validation performed when authoring this fixture (per
  * the PR body): with the `frame_meta.data_pointer = 0` invalidation lines

--- a/gqc/src/gqc/datamodel.py
+++ b/gqc/src/gqc/datamodel.py
@@ -418,7 +418,7 @@ class Animation:
             hash_task = animation_progress.add_task(f" [dim]-- digest", total=1, start=False)
             
             if 100 % frame_rate != 0:
-                print(f"[red][bold]WARNING[/bold][/red]: [blue][italic]{self.name}[/italic][/blue] frame rate {frame_rate} not a factor of 100; setting to {100 / self.tiks_per_frame}")
+                print(f"[red][bold]WARNING[/bold][/red]: [blue][italic]{self.name}[/italic][/blue] frame rate {frame_rate} not a factor of 100; setting to {100 / self.ticks_per_frame}")
                 frame_rate = 100 / self.ticks_per_frame
 
             if frame_rate > 5:

--- a/gqc/src/gqc/datamodel.py
+++ b/gqc/src/gqc/datamodel.py
@@ -422,7 +422,7 @@ class Animation:
                 frame_rate = 100 / self.ticks_per_frame
 
             if frame_rate > 5:
-                print(f"[red][bold]WARNING[/bold][/red]: [blue][italic]{self.name}[/italic][/blue] frame rate {frame_rate} exceeds 5 FPS; badge performance may suffer.")
+                print(f"[red][bold]WARNING[/bold][/red]: [blue][italic]{self.name}[/italic][/blue] frame rate {frame_rate} exceeds 5 FPS; every frame will be clamped to a minimum on-screen duration of 20 ticks (5 FPS) on the badge.")
 
             make_animation_kwargs = dict()
             if dithering:


### PR DESCRIPTION
## Summary

`load_animation()` clamps only a freshly-loaded animation's *first* frame duration to `GQ_MIN_FRAME_DURATION` (20 ticks, `include/gamequeer.h`), but `system_tick()`'s per-frame-advance reset never reapplied that clamp. For any animation authored above 5 FPS, frame 0 lingered 20 ticks while every subsequent frame ran at the faster, unclamped rate. On real hardware this shows up as the animation hitching on its first frame, then speeding up for the rest of the loop.

This factors the clamp into a single `gq_clamp_frame_duration()` helper shared by both `load_animation()` and `system_tick()`'s frame-advance branch, so both paths enforce `GQ_MIN_FRAME_DURATION` for every frame and can't drift out of sync again.

Closes #288.

## Behavioral change (please read)

Any shipped game/animation authored above 5 FPS (e.g. `pop` in `gqc/examples/skel/games/working_samples/tutorial_1.gq`, `frame_rate = 10`) will now animate **uniformly slower** — every frame clamped to 20 ticks (5 FPS) — instead of hitching on frame 0 and then speeding up for later frames. Verified in the emulator: `pop` now advances frames every 20 ticks throughout, rather than 20 ticks for frame 0 and 10 ticks for every frame after.

## Golden fixture retiming

`tests/golden/anim_advance.gq` (from #282) locks in three tick counts corresponding to the fixture's three animation frames:
- `frame0` (`TICKS=1`) — unchanged.
- `frame1` (`TICKS=22`) — unchanged (frame 0's duration was already clamped to 20 ticks before this fix, so the frame0->frame1 boundary doesn't move).
- `frame2` (`TICKS=33` -> `TICKS=43`) — moved, since frame 1's duration is now also clamped to 20 ticks (was 10, unclamped).

Both the `TICKS` value in `tests/CMakeLists.txt` and the fixture's header-comment derivation were updated; no golden PGM needed regenerating (the pixel content of "frame 2" hasn't changed, only the tick count needed to reach it). Re-derived and cross-checked empirically (dumped/diffed every tick 1..45, `md5sum` per tick) rather than trusting `ticks_per_frame` arithmetic alone — see commit for the exact boundaries. Also ran a negative control: reverting the fix and rebuilding, `TICKS=50` (well inside the new clamp window) no longer matches the `frame2` golden, confirming the retimed test is exercising real behavior, not a coincidental boundary match.

`mask_encoding_{a,b}` and `redundant_write` fixtures use static/single-frame content and are unaffected by this change (confirmed: full `ctest` suite green, and those fixtures never invoke `system_tick()`'s frame-advance branch).

## gqc lockstep note

Also updated `gqc`'s `>5 FPS` compile-time warning in `gqc/src/gqc/datamodel.py` from a vague "badge performance may suffer" to an accurate description of the clamp:

> frame rate {rate} exceeds 5 FPS; every frame will be clamped to a minimum on-screen duration of 20 ticks (5 FPS) on the badge.

This is a one-line message-only change (no bytecode/struct format impact), but flagging it explicitly since it touches the `gqc` compiler side.

## Verification

- Docker/cmake headless build (`GQ_HEADLESS=ON`) + native build both compile clean.
- Full `ctest` suite: 11/11 passing (golden framebuffer + draw-count tests).
- `clang-format --dry-run --Werror` clean on `src/gamequeer.c`.
- Emulator sanity: compiled `gqc/examples/skel/games/working_samples/tutorial_1.gq` and scripted a button-A press via `--input`; confirmed `pop` (frame_rate=10) now advances every 20 ticks uniformly (tick 22 and tick 43 boundaries), matching the retimed `anim_advance.gq` fixture exactly.
- gqc's updated warning text confirmed to print correctly when compiling `tutorial_1.gq`'s `pop` animation.

(AI-generated via Claude Code w/ Fable 5)
