### PR TITLE
feat(perf): add GQ_PERF_INSTRUMENT build flavor (emulator half)

### DIFF
--- a/gamequeer/CMakeLists.txt
+++ b/gamequeer/CMakeLists.txt
@@ -18,6 +18,15 @@ set_property(
 # path stays fully intact; only the X11 sink is replaced.
 option(GQ_HEADLESS "Build without X11 display (headless mode)" OFF)
 
+# Perf-instrumentation build option: adds a small RAM stats struct (see
+# include/gq_perf.h) with per-section count/duration/min/max timing, updated
+# by GQ_PERF_ENTER/EXIT macros around a handful of hot-path functions in
+# gamequeer.c. OFF by default and independent of GQ_HEADLESS (either can be
+# combined with the other), so a normal (non-instrumented) build never
+# compiles src/gq_perf.c and never defines GQ_PERF_INSTRUMENT -- see
+# gq_perf.h for why that matters for the zero-cost claim.
+option(GQ_PERF_INSTRUMENT "Build with GQ_PERF_INSTRUMENT performance stats (see include/gq_perf.h)" OFF)
+
 if(GQ_HEADLESS)
     message(STATUS "GQ_HEADLESS=ON: building without X11")
     set(GFX_SOURCE src/gfx/gfx_headless.c)
@@ -65,6 +74,12 @@ else()
         ${PROJECT_NAME}
         ${X11_LIBRARIES}
     )
+endif()
+
+if(GQ_PERF_INSTRUMENT)
+    message(STATUS "GQ_PERF_INSTRUMENT=ON: building with performance instrumentation (see include/gq_perf.h)")
+    target_sources(${PROJECT_NAME} PRIVATE src/gq_perf.c)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE GQ_PERF_INSTRUMENT)
 endif()
 
 # Link math:

--- a/gamequeer/include/gq_perf.h
+++ b/gamequeer/include/gq_perf.h
@@ -1,0 +1,281 @@
+#ifndef GQ_PERF_H
+#define GQ_PERF_H
+
+#include <stdint.h>
+
+/* -------------------------------------------------------------------------
+ * GQ_PERF_INSTRUMENT -- opt-in, build-time performance instrumentation.
+ * -------------------------------------------------------------------------
+ * This is the emulator half of the instrumentation pass called for in
+ * qc2024's docs/perf-investigation.md, "Before changing code": a way to get
+ * real per-section timings instead of the static cycle estimates in that
+ * doc's "End-to-end per-frame cost estimate" table.
+ *
+ * Undefined (default, all normal builds including the firmware): every
+ * macro below expands to a no-op, and gq_perf_stats / gq_perf_record() /
+ * HAL_perf_now() are not declared. This header can be #included
+ * unconditionally from shared code with zero footprint -- no new symbols,
+ * no new stack slots, no new branches. Verified by a byte-identical
+ * before/after .map for a non-instrumented build (see the PR body for the
+ * comparison).
+ *
+ * Defined: adds a small RAM stats struct (gq_perf_stats, currently 88 B --
+ * an 8 B header plus 5 sections * 16 B each; see layout below) with
+ * per-section count / accumulated-duration / min / max, in microseconds,
+ * updated by GQ_PERF_ENTER(SECTION) / GQ_PERF_EXIT(SECTION) pairs placed
+ * around hot-path code in gamequeer.c.
+ *
+ * Sections instrumented so far (see GQ_PERF_SECTION_LIST below to add
+ * more):
+ *   - DRAW_OLED_STACK      draw_oled_stack() total (clear + animations +
+ *                          labels + menu + flush)
+ *   - DRAW_ANIMATION_STACK draw_animation_stack() (subset of the above)
+ *   - HANDLE_EVENTS        handle_events(): the full event-dispatch pass,
+ *                          which includes any run_code() calls it triggers
+ *                          and (if GQ_EVENT_REFRESH fires) the nested
+ *                          DRAW_OLED_STACK section. This is the
+ *                          "handle_events/run_code aggregate" section:
+ *                          reported as one number by design, not split,
+ *                          because run_code() has no single entry/exit
+ *                          point of its own outside of handle_events()'s
+ *                          per-event dispatch loop.
+ *   - SYSTEM_TICK          system_tick() total (animation/timer bookkeeping
+ *                          + led_tick(), unless GQ_SUPPRESS_LED_TICK)
+ *   - OLED_FLUSH           the Graphics_flushBuffer() call inside
+ *                          draw_oled_stack() -- see the flush-hook design
+ *                          note further down for why this is measured at
+ *                          the shared-code call site rather than via a new
+ *                          HAL primitive.
+ *
+ * NOTE: sections nest (DRAW_ANIMATION_STACK and OLED_FLUSH are both
+ * sub-intervals of DRAW_OLED_STACK; HANDLE_EVENTS can contain a full
+ * DRAW_OLED_STACK pass). Each section's numbers are self-contained -- there
+ * is no double-counting *within* a section's own count/total -- but a
+ * reader comparing sections should remember the containment relationship
+ * rather than expecting them to sum to an unrelated "everything" total.
+ *
+ * NOTE: GQ_PERF_ENTER/EXIT are matched pairs around straight-line code.
+ * Functions with an early-return failure path between ENTER and EXIT (e.g.
+ * draw_animation_stack()'s cart-read-failure returns) will simply not
+ * record that call -- the section's count/total under-reports failure-path
+ * calls. This is an accepted limitation for a profiling aid, not a
+ * correctness issue: failure paths are rare (cart read failure) and are
+ * not the hot path this instrumentation targets.
+ *
+ * -------------------------------------------------------------------------
+ * Struct layout (GQ_PERF_INSTRUMENT defined):
+ * -------------------------------------------------------------------------
+ *   gq_perf_stats_t (8 B header + N * 16 B sections; N=5 today -> 88 B):
+ *     uint32_t magic;    -- GQ_PERF_MAGIC; sanity-check when read over SBW
+ *                           at a known/discoverable symbol address (via the
+ *                           .map file -- gq_perf_stats is a plain global,
+ *                           deliberately not static, so it is visible
+ *                           there).
+ *     uint16_t version;  -- GQ_PERF_VERSION; bump whenever this layout
+ *                           changes so an out-of-sync SBW reader script can
+ *                           detect the mismatch instead of misparsing.
+ *     uint16_t reserved; -- padding today; available for a future flags
+ *                           field without changing the struct size.
+ *     gq_perf_section_t sections[GQ_PERF_SEC_COUNT];
+ *       each: uint32_t count, total_us, min_us, max_us (16 B).
+ *
+ * Adding a new section costs 16 B. The ~150 B RAM target in the design
+ * discussion allows roughly 4 more sections beyond the 5 defined here
+ * before that budget is exhausted.
+ *
+ * -------------------------------------------------------------------------
+ * Timer width decision: gq_perf_time_t is uint32_t, holding microseconds.
+ * -------------------------------------------------------------------------
+ * Section durations range from ~50 us (a single small op) to ~50 ms (a
+ * full-screen redraw with a masked sprite; see the per-frame cost table in
+ * docs/perf-investigation.md). A 16-bit microsecond counter only covers
+ * 65.535 ms before wrapping -- too tight a margin against the ~50 ms upper
+ * end of a single measured interval (the *comparison* logic in
+ * gq_perf_record() implicitly assumes a single delta never exceeds the
+ * counter's wrap period; a 16-bit-us counter leaves under 15 ms of margin,
+ * which a slow flush or a big masked-sprite frame could plausibly eat).
+ * uint32_t microseconds wraps every ~71.6 minutes, giving enormous margin
+ * for a single section, and is cheap to accumulate/compare on both a 64-bit
+ * host and a 16-bit-native MSP430 (32-bit ops on MSP430 are 2-3 instructions
+ * via the CPU's word ops, not emulated software math like 64-bit would be).
+ * gq_perf_record()'s unsigned-subtraction delta math
+ * (HAL_perf_now() - entry_time) is correct across exactly one wrap of the
+ * *counter itself*, which is what matters here, not one wrap of the
+ * accumulated `total_us` field (that field can itself wrap over a very long
+ * run; see gq_perf_record()'s comment).
+ *
+ * -------------------------------------------------------------------------
+ * HAL_perf_now() -- per-platform timing source.
+ * -------------------------------------------------------------------------
+ * Only the emulator side is implemented as of this header (see HAL.c,
+ * clock_gettime(CLOCK_MONOTONIC) scaled to microseconds). The firmware
+ * (ccs_workspace/qc2024/) implementation is a SEPARATE, NOT-YET-DONE task
+ * in that repo -- do not assume it exists. Requirements for whoever
+ * implements it there:
+ *
+ *   - Free-running, monotonically increasing, wrapping 32-bit counter in
+ *     microseconds (matches gq_perf_time_t = uint32_t). Wraps every ~71.6
+ *     minutes (2^32 us); fine, per the timer-width note above.
+ *   - Must be safely callable from BOTH main-loop context and ISR context.
+ *     A future extension may want to time led_tick(), which the RTC ISR
+ *     calls directly (qc2024's main.c:627) -- so HAL_perf_now() itself must
+ *     not require interrupts to be enabled, must not block, and must not
+ *     race a concurrent read from interrupt level. A single free-running
+ *     hardware counter register read is safe (MSP430 16-bit register reads
+ *     are atomic). If the implementation software-extends a 16-bit hardware
+ *     timer to 32 bits via an overflow ISR incrementing a
+ *     `volatile uint16_t` high-word counter, HAL_perf_now() needs the
+ *     standard "read high, read low, read high again, retry if the high
+ *     word changed" pattern to avoid a torn read when preempted mid-read by
+ *     its own overflow ISR.
+ *   - Suggested timer: the RTC (100 Hz heartbeat, qc2024's main.c) and
+ *     TA0/TA2 (TLC5948A grayscale clock, qc2024's tlc5948a.c/.h -- see
+ *     TLC_GSCLK_TIMER_* macros and the TA2CTL setup in tlc5948a.c) are
+ *     already committed as of this writing. TA1, TA3, and TB0 appear
+ *     unused (grep qc2024's C sources and headers for "TA1"/"TA3"/"TB0" to reconfirm
+ *     before implementing -- this comment is a starting point, not a
+ *     verified-current fact, and firmware code changes independently of
+ *     this submodule). Recommended approach: run one of the free 16-bit
+ *     Timer_A/B blocks continuously in up mode from SMCLK (8 MHz) or ACLK,
+ *     with its own overflow ISR incrementing the high-word counter above;
+ *     HAL_perf_now() combines (high_word << 16 | TAxR) using the
+ *     torn-read-safe pattern, then scales to microseconds by the timer's
+ *     known tick period -- prefer a multiply (or a shift, if the tick
+ *     period is chosen as a power-of-two divisor of 1 us) over a divide,
+ *     since GQ_PERF_INSTRUMENT builds are a development/measurement
+ *     flavor where extra cycles are acceptable but an actual hardware
+ *     divide instruction cost is still worth avoiding by construction.
+ *     Confirm the MSP430FR2476 family user's guide for the exact
+ *     Timer_A/B inventory and capture/compare resource counts before
+ *     committing to a specific block.
+ *   - Resolution: microsecond resolution comfortably covers the documented
+ *     section range (~50 us to ~50 ms). Do not narrow gq_perf_time_t to
+ *     16 bits for the firmware side -- HAL_perf_now()'s return type and
+ *     gq_perf_record()'s parameter type must stay in lockstep with this
+ *     header's uint32_t choice, or the accumulation math silently
+ *     truncates.
+ *
+ * -------------------------------------------------------------------------
+ * Flush-section hook placement.
+ * -------------------------------------------------------------------------
+ * GQ_PERF_ENTER(OLED_FLUSH) / GQ_PERF_EXIT(OLED_FLUSH) are placed in shared
+ * code (gamequeer.c, draw_oled_stack()) directly around the
+ * Graphics_flushBuffer() call -- NOT inside qc2024's sh1107.c oled_flush().
+ * Graphics_flushBuffer() (grlib/grlib/context.c) is already the single
+ * dispatch point shared by both platforms: on the badge it calls through
+ * the Graphics_Display's pfnFlush pointer to oled_flush() (see qc2024's
+ * sh1107.c, the g_sh1107OledDisplay pfnFlush entry), and on the emulator it
+ * dispatches to gfx_flush() via grlib_gfx_driver.c. That means no new HAL
+ * notify functions are needed for this section -- the existing indirection
+ * already gives a shared, platform-agnostic measurement point that brackets
+ * the real flush cost on either target.
+ *
+ * If finer-grained timing *within* oled_flush() is wanted later (e.g.
+ * separating the 16 page-address-set command sequences from the 2048 data
+ * bytes -- relevant to Issue #16's proposed DMA/ISR-streaming flush), that
+ * finer split is not visible from shared code and would need two new
+ * HAL-callable notify functions (e.g. HAL_perf_flush_begin() /
+ * HAL_perf_flush_end(), or more granular ones) called from inside
+ * sh1107.c. Not implemented here; documented as a follow-up option.
+ *
+ * -------------------------------------------------------------------------
+ * OPTIONAL extension points (documented only, NOT implemented here):
+ * -------------------------------------------------------------------------
+ *   - D0/D1 GPIO toggle hooks: add GQ_PERF_GPIO_ENTER(SEC)/_EXIT(SEC)
+ *     variants (or extend the existing macros under a second build flag)
+ *     that toggle a spare GPIO pin firmware-side, so section boundaries are
+ *     visible on a scope/logic analyzer independent of reading the RAM
+ *     struct over SBW. Needs a firmware-side pin assignment (D0/D1 or
+ *     whichever header pins are free on the badge) and a HAL_perf_gpio_*()
+ *     primitive; out of scope for the emulator-only pass this header is
+ *     part of.
+ *   - Exposing stats as GQI_* builtins: register new read-only builtin int
+ *     variables (alongside GQI_GAME_ID etc. in gamequeer.h) that surface
+ *     e.g. GQI_PERF_DRAW_OLED_STACK_COUNT / _AVG_US, so a game (an on-badge
+ *     profiler cart) could display live stats without an SBW connection.
+ *     Would need gqc-side symbol table changes (linker.py's
+ *     create_reserved_variables()) to keep the compiler in lockstep --
+ *     flagged here as compiler-impacting, not attempted in this pass.
+ * ---------------------------------------------------------------------- */
+
+/* ---- Section list (X-macro): add new sections here only. ----
+ * X(ENUM_SUFFIX, "display name") -- ENUM_SUFFIX becomes GQ_PERF_SEC_<name>
+ * and the token pasted into GQ_PERF_ENTER/EXIT's local variable name, so it
+ * must be a valid identifier fragment (no spaces/quotes). "display name" is
+ * the string used by tools reading the struct (e.g. the emulator's
+ * --perf-dump text output). */
+#define GQ_PERF_SECTION_LIST(X)                     \
+    X(DRAW_OLED_STACK, "draw_oled_stack")           \
+    X(DRAW_ANIMATION_STACK, "draw_animation_stack") \
+    X(HANDLE_EVENTS, "handle_events")               \
+    X(SYSTEM_TICK, "system_tick")                   \
+    X(OLED_FLUSH, "oled_flush")
+
+typedef enum {
+#define GQ_PERF_ENUM_ENTRY(NAME, STR) GQ_PERF_SEC_##NAME,
+    GQ_PERF_SECTION_LIST(GQ_PERF_ENUM_ENTRY)
+#undef GQ_PERF_ENUM_ENTRY
+    GQ_PERF_SEC_COUNT
+} gq_perf_section_id_t;
+
+#ifdef GQ_PERF_INSTRUMENT
+
+/* ASCII "QPFR" -- distinctive 4 bytes to scan for / sanity-check when the
+ * struct is located and read over SBW by address. */
+#define GQ_PERF_MAGIC   0x51504652u
+#define GQ_PERF_VERSION 1u
+
+/* Microseconds; see the timer-width design note above for why uint32_t. */
+typedef uint32_t gq_perf_time_t;
+
+typedef struct {
+    uint32_t count;
+    uint32_t total_us;
+    uint32_t min_us;
+    uint32_t max_us;
+} gq_perf_section_t;
+
+typedef struct {
+    uint32_t magic;
+    uint16_t version;
+    uint16_t reserved;
+    gq_perf_section_t sections[GQ_PERF_SEC_COUNT];
+} gq_perf_stats_t;
+
+/* Plain global (not static): must be a stable, .map-discoverable symbol so
+ * it can be located and read by address over SBW. */
+extern gq_perf_stats_t gq_perf_stats;
+
+/* Display-name table, indexed by gq_perf_section_id_t; used by the
+ * emulator's --perf-dump output. */
+extern const char *const gq_perf_section_names[GQ_PERF_SEC_COUNT];
+
+/* Per-platform timing source. Implemented for the emulator in HAL.c; the
+ * firmware implementation is a separate task -- see the design note above. */
+gq_perf_time_t HAL_perf_now(void);
+
+/* Records one completed section measurement. Note: total_us accumulates
+ * across the whole run and is itself a uint32_t, so it can in principle
+ * wrap on an extremely long-running instrumented session (e.g. billions of
+ * microseconds -- over an hour of continuous max-rate section entries);
+ * this is a development/measurement build, not a production counter, so
+ * that is treated as an accepted limitation rather than guarded against. */
+void gq_perf_record(gq_perf_section_id_t sec, gq_perf_time_t duration_us);
+
+/* GQ_PERF_ENTER(SEC)/GQ_PERF_EXIT(SEC) must appear as a matched pair in the
+ * same lexical scope (SEC's token-pasted local variable must stay in
+ * scope), following the style of this header's un-parenthesized statement
+ * macros (see GQ_EVENT_SET/_CLR in gamequeer.h) -- callers add the
+ * trailing semicolon. */
+#define GQ_PERF_ENTER(SEC) gq_perf_time_t _gq_perf_t0_##SEC = HAL_perf_now()
+#define GQ_PERF_EXIT(SEC)  gq_perf_record(GQ_PERF_SEC_##SEC, (gq_perf_time_t) (HAL_perf_now() - _gq_perf_t0_##SEC))
+
+#else /* !GQ_PERF_INSTRUMENT */
+
+/* Zero-cost: no declarations, no symbols, no stack slots. */
+#define GQ_PERF_ENTER(SEC) ((void) 0)
+#define GQ_PERF_EXIT(SEC)  ((void) 0)
+
+#endif /* GQ_PERF_INSTRUMENT */
+
+#endif /* GQ_PERF_H */

--- a/gamequeer/src/HAL.c
+++ b/gamequeer/src/HAL.c
@@ -300,7 +300,11 @@ void HAL_sleep() {
  * single measured interval, not across the whole process lifetime.
  */
 gq_perf_time_t HAL_perf_now(void) {
-    struct timespec ts;
+    /* Zero-initialized so a (practically unreachable, but not impossible)
+     * clock_gettime() failure degrades to a benign 0 reading rather than an
+     * undefined one -- acceptable for a development/measurement-only build
+     * per this header's accepted-limitation philosophy (see gq_perf.h). */
+    struct timespec ts = {0};
     clock_gettime(CLOCK_MONOTONIC, &ts);
     return (gq_perf_time_t) ((uint64_t) ts.tv_sec * 1000000u + (uint64_t) ts.tv_nsec / 1000u);
 }

--- a/gamequeer/src/HAL.c
+++ b/gamequeer/src/HAL.c
@@ -3,9 +3,11 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/time.h>
+#include <time.h>
 #include <unistd.h>
 
 #include "gamequeer.h"
+#include "gq_perf.h"
 #include "grlib_gfx.h"
 
 uint8_t flash_cart[CART_FLASH_SIZE_MBYTES * 1024 * 1024];
@@ -281,3 +283,25 @@ void HAL_sleep() {
     gettimeofday(&pre_event_loop, NULL);
 #endif /* GQ_HEADLESS */
 }
+
+#ifdef GQ_PERF_INSTRUMENT
+/*
+ * Emulator implementation of HAL_perf_now() -- see gq_perf.h for the full
+ * timing-source design note, including what a firmware implementation must
+ * provide (this is the emulator half only; the firmware side is a separate,
+ * not-yet-done task in ccs_workspace/qc2024/).
+ *
+ * CLOCK_MONOTONIC is immune to wall-clock adjustments (NTP steps, etc.),
+ * which matters for a duration measurement even though this build never
+ * runs long enough in practice for that to bite. Scaled to whole
+ * microseconds and truncated to uint32_t, matching gq_perf_time_t; this
+ * wraps every ~71.6 minutes, which is fine per gq_perf.h's timer-width
+ * note -- gq_perf_record()'s delta math only needs correctness across a
+ * single measured interval, not across the whole process lifetime.
+ */
+gq_perf_time_t HAL_perf_now(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (gq_perf_time_t) ((uint64_t) ts.tv_sec * 1000000u + (uint64_t) ts.tv_nsec / 1000u);
+}
+#endif /* GQ_PERF_INSTRUMENT */

--- a/gamequeer/src/HAL.c
+++ b/gamequeer/src/HAL.c
@@ -300,12 +300,21 @@ void HAL_sleep() {
  * single measured interval, not across the whole process lifetime.
  */
 gq_perf_time_t HAL_perf_now(void) {
-    /* Zero-initialized so a (practically unreachable, but not impossible)
-     * clock_gettime() failure degrades to a benign 0 reading rather than an
-     * undefined one -- acceptable for a development/measurement-only build
-     * per this header's accepted-limitation philosophy (see gq_perf.h). */
-    struct timespec ts = {0};
-    clock_gettime(CLOCK_MONOTONIC, &ts);
-    return (gq_perf_time_t) ((uint64_t) ts.tv_sec * 1000000u + (uint64_t) ts.tv_nsec / 1000u);
+    /* Cache the last successful reading. A bare 0 on clock_gettime() failure
+     * is not actually benign here: gq_perf_record()'s delta math (see
+     * gq_perf.h) is HAL_perf_now() - entry_time, so a lone 0 on either side
+     * of an ENTER/EXIT pair underflows to a spurious ~UINT32_MAX-us duration
+     * and poisons that section's max_us. Falling back to the last known-good
+     * timestamp instead keeps a single (practically unreachable, but not
+     * impossible) clock_gettime() failure from corrupting stats -- at worst
+     * it slightly under/over-counts one interval, which is an accepted
+     * limitation for a development/measurement-only build (see gq_perf.h). */
+    static gq_perf_time_t last_good_us = 0;
+    struct timespec ts;
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+        return last_good_us;
+    }
+    last_good_us = (gq_perf_time_t) ((uint64_t) ts.tv_sec * 1000000u + (uint64_t) ts.tv_nsec / 1000u);
+    return last_good_us;
 }
 #endif /* GQ_PERF_INSTRUMENT */

--- a/gamequeer/src/gamequeer.c
+++ b/gamequeer/src/gamequeer.c
@@ -6,6 +6,7 @@
 #include "HAL.h"
 #include "gamequeer.h"
 #include "gamequeer_bytecode.h"
+#include "gq_perf.h"
 #include "grlib.h"
 
 gq_header game;
@@ -279,6 +280,7 @@ uint8_t load_animation(uint8_t index, t_gq_pointer anim_ptr) {
 }
 
 void draw_animation_stack() {
+    GQ_PERF_ENTER(DRAW_ANIMATION_STACK);
     uint8_t anim_index = 0;
     do {
         if (current_animations[anim_index].in_use) {
@@ -373,6 +375,7 @@ void draw_animation_stack() {
             break;
         }
     } while (1);
+    GQ_PERF_EXIT(DRAW_ANIMATION_STACK);
 }
 
 void draw_label_stack() {
@@ -405,6 +408,7 @@ uint32_t gq_draw_oled_stack_count = 0;
 #endif
 
 void draw_oled_stack() {
+    GQ_PERF_ENTER(DRAW_OLED_STACK);
 #ifdef GQ_HEADLESS
     gq_draw_oled_stack_count++;
 #endif
@@ -426,11 +430,21 @@ void draw_oled_stack() {
         draw_menu_text();
     }
 
+    // Measured directly around Graphics_flushBuffer() rather than via a new
+    // HAL primitive -- see gq_perf.h's "Flush-section hook placement" note
+    // for why this shared-code call site already brackets the real flush
+    // cost on both the badge (dispatches to sh1107.c's oled_flush() via the
+    // grlib pfnFlush pointer) and the emulator (dispatches to gfx_flush()).
+    GQ_PERF_ENTER(OLED_FLUSH);
     Graphics_flushBuffer(&g_sContext);
+    GQ_PERF_EXIT(OLED_FLUSH);
+
+    GQ_PERF_EXIT(DRAW_OLED_STACK);
 }
 
 void system_tick() {
     // Should be called by the 100 Hz system tick
+    GQ_PERF_ENTER(SYSTEM_TICK);
 
     // Handle the LEDs
 #ifndef GQ_SUPPRESS_LED_TICK
@@ -479,6 +493,7 @@ void system_tick() {
         }
         GQ_EVENT_SET(GQ_EVENT_REFRESH);
     }
+    GQ_PERF_EXIT(SYSTEM_TICK);
 }
 
 t_gq_int get_badge_word(t_gq_int badge_id) {
@@ -537,6 +552,12 @@ t_gq_int get_badge_bit(t_gq_int badge_id) {
 }
 
 void handle_events() {
+    // "handle_events/run_code aggregate" section: covers the full
+    // event-dispatch pass, including any run_code() calls it triggers and
+    // (if GQ_EVENT_REFRESH fires) a nested DRAW_OLED_STACK pass -- see
+    // gq_perf.h's HANDLE_EVENTS entry for why this is reported as one
+    // number rather than split further.
+    GQ_PERF_ENTER(HANDLE_EVENTS);
     for (uint16_t event_type = 0x0000; event_type < GQ_EVENT_COUNT; event_type++) {
         if (GQ_EVENT_GET(event_type)) {
             GQ_EVENT_CLR(event_type);
@@ -573,4 +594,5 @@ void handle_events() {
             }
         }
     }
+    GQ_PERF_EXIT(HANDLE_EVENTS);
 }

--- a/gamequeer/src/gq_perf.c
+++ b/gamequeer/src/gq_perf.c
@@ -1,0 +1,44 @@
+/* GQ_PERF_INSTRUMENT support code. See include/gq_perf.h for the full
+ * design note (struct layout, timer-width rationale, HAL_perf_now()
+ * firmware-implementation requirements).
+ *
+ * This translation unit is only added to the build when GQ_PERF_INSTRUMENT
+ * is ON (see CMakeLists.txt) -- a normal build never compiles or links it,
+ * which is part of the zero-cost claim: not just "the macros expand to
+ * nothing" but "this object file doesn't exist in a normal build".
+ */
+
+#include "gq_perf.h"
+
+#ifdef GQ_PERF_INSTRUMENT
+
+gq_perf_stats_t gq_perf_stats = {
+    .magic    = GQ_PERF_MAGIC,
+    .version  = GQ_PERF_VERSION,
+    .reserved = 0,
+    .sections = {{0}},
+};
+
+const char *const gq_perf_section_names[GQ_PERF_SEC_COUNT] = {
+#define GQ_PERF_NAME_ENTRY(NAME, STR) STR,
+    GQ_PERF_SECTION_LIST(GQ_PERF_NAME_ENTRY)
+#undef GQ_PERF_NAME_ENTRY
+};
+
+void gq_perf_record(gq_perf_section_id_t sec, gq_perf_time_t duration_us) {
+    gq_perf_section_t *s = &gq_perf_stats.sections[sec];
+    s->count++;
+    s->total_us += duration_us;
+    /* s->count == 1 is the first sample for this section: min_us/max_us
+     * both start at the struct's zero-init value, which is not a valid
+     * "no samples yet" sentinel for min (0 would never be beaten by a real
+     * duration), so seed both from the first sample explicitly. */
+    if (s->count == 1 || duration_us < s->min_us) {
+        s->min_us = duration_us;
+    }
+    if (s->count == 1 || duration_us > s->max_us) {
+        s->max_us = duration_us;
+    }
+}
+
+#endif /* GQ_PERF_INSTRUMENT */

--- a/gamequeer/src/main.c
+++ b/gamequeer/src/main.c
@@ -7,6 +7,7 @@
 
 #include "HAL.h"
 #include "gfx.h"
+#include "gq_perf.h"
 #include "grlib.h"
 #include "grlib_gfx.h"
 
@@ -65,6 +66,45 @@ static int dump_draw_count(const char *path) {
 #endif
 }
 
+#ifdef GQ_PERF_INSTRUMENT
+/* Write the current gq_perf_stats contents as plain text: the struct header
+ * (magic/version) followed by one line per section (count, accumulated
+ * duration, min, max, and a derived average -- all in microseconds).
+ * See include/gq_perf.h for the struct layout and section list.
+ *
+ * This whole function (and the --perf-dump flag that calls it, further
+ * down) is compiled out entirely -- not just internally short-circuited --
+ * in a non-instrumented build. Unlike dump_draw_count()'s
+ * always-present-but-internally-gated pattern above, --perf-dump must not
+ * add ANY bytes to a non-instrumented binary: this feature exists
+ * specifically to validate the zero-cost claim for GQ_PERF_INSTRUMENT via a
+ * byte-identical .map/binary comparison (see gq_perf.h), so even a
+ * recognized-but-errors-out flag would break that proof. */
+static int dump_perf_stats(const char *path) {
+    FILE *f = fopen(path, "wb");
+    if (!f) {
+        fprintf(stderr, "dump_perf_stats: cannot open %s for writing\n", path);
+        return 0;
+    }
+    fprintf(f, "magic=0x%08lx version=%u\n", (unsigned long) gq_perf_stats.magic, (unsigned) gq_perf_stats.version);
+    for (int i = 0; i < GQ_PERF_SEC_COUNT; i++) {
+        const gq_perf_section_t *s = &gq_perf_stats.sections[i];
+        uint32_t avg_us            = s->count ? (s->total_us / s->count) : 0;
+        fprintf(
+            f,
+            "%-24s count=%-8lu total_us=%-12lu min_us=%-8lu max_us=%-8lu avg_us=%-8lu\n",
+            gq_perf_section_names[i],
+            (unsigned long) s->count,
+            (unsigned long) s->total_us,
+            (unsigned long) s->min_us,
+            (unsigned long) s->max_us,
+            (unsigned long) avg_us);
+    }
+    fclose(f);
+    return 1;
+}
+#endif /* GQ_PERF_INSTRUMENT */
+
 static int dump_framebuffer(const char *path) {
     FILE *f = fopen(path, "wb");
     if (!f) {
@@ -97,14 +137,19 @@ int main(int argc, char *argv[]) {
      *   --input FILE         : replay button events from a script (see HAL_input_load)
      *   --draw-count-out PATH: write the draw_oled_stack() invocation count
      *                          (decimal, headless builds only)
+     *   --perf-dump PATH     : write gq_perf_stats as text (GQ_PERF_INSTRUMENT
+     *                          builds only; see dump_perf_stats() above)
      * Defaults: unlimited ticks, no dump, no scripted input, no draw-count
-     * output (same as before).
+     * output, no perf dump (same as before).
      */
     long ticks_limit           = -1; /* -1 = run forever */
     const char *dump           = NULL;
     const char *input          = NULL;
     const char *cart           = NULL;
     const char *draw_count_out = NULL;
+#ifdef GQ_PERF_INSTRUMENT
+    const char *perf_dump = NULL;
+#endif
 
     /* Build a filtered argv for HAL_init that strips our new flags so it
      * still sees the cart path at argv[1]. */
@@ -160,6 +205,17 @@ int main(int argc, char *argv[]) {
                 return 1;
             }
             draw_count_out = argv[++i];
+#ifdef GQ_PERF_INSTRUMENT
+        } else if (strcmp(argv[i], "--perf-dump") == 0) {
+            /* Only require that a next argument exists; a path legitimately
+             * starting with '-' should not be rejected. */
+            if (i + 1 >= argc) {
+                fprintf(stderr, "main: --perf-dump requires a value\n");
+                free(hal_argv);
+                return 1;
+            }
+            perf_dump = argv[++i];
+#endif /* GQ_PERF_INSTRUMENT */
         } else {
             if (cart == NULL) {
                 cart = argv[i];
@@ -211,6 +267,14 @@ int main(int argc, char *argv[]) {
             return 1;
         }
     }
+
+#ifdef GQ_PERF_INSTRUMENT
+    if (perf_dump != NULL) {
+        if (!dump_perf_stats(perf_dump)) {
+            return 1;
+        }
+    }
+#endif /* GQ_PERF_INSTRUMENT */
 
     return 0;
 }

--- a/gamequeer/tests/CMakeLists.txt
+++ b/gamequeer/tests/CMakeLists.txt
@@ -185,3 +185,26 @@ add_golden_test(golden_framebuffer_anim_advance_frame1 anim_advance
     TICKS 22 GOLDEN_SUFFIX anim_advance_frame1)
 add_golden_test(golden_framebuffer_anim_advance_frame2 anim_advance
     TICKS 43 GOLDEN_SUFFIX anim_advance_frame2)
+
+# ---- perf_draw_count_cross_check: GQ_PERF_INSTRUMENT-only ----------------
+# Only registered when this build is ALSO configured with
+# -DGQ_PERF_INSTRUMENT=ON (a plain -DGQ_HEADLESS=ON build has no --perf-dump
+# flag at all -- see main.c's GQ_PERF_INSTRUMENT-gated CLI parsing). Cross-
+# checks gq_perf_stats's DRAW_OLED_STACK section count against the existing,
+# independently-implemented gq_draw_oled_stack_count (--draw-count-out) for
+# the same run: two different instrumentation mechanisms measuring the same
+# event, which is a cheap sanity check that GQ_PERF_ENTER/EXIT is wired up
+# correctly around draw_oled_stack(). See run_perf_draw_count_cross_check.cmake.
+if(GQ_PERF_INSTRUMENT)
+    add_test(
+        NAME perf_draw_count_cross_check
+        COMMAND
+            ${CMAKE_COMMAND}
+            -DEXE=$<TARGET_FILE:gamequeer>
+            -DFIXTURE=${GOLDEN_DIR}/anim_advance.gqgame
+            -DDRAW_COUNT=${CMAKE_CURRENT_BINARY_DIR}/perf_draw_count_cross_check_drawcount.txt
+            -DPERF_DUMP=${CMAKE_CURRENT_BINARY_DIR}/perf_draw_count_cross_check_perfdump.txt
+            -DTICKS=43
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/run_perf_draw_count_cross_check.cmake"
+    )
+endif()

--- a/gamequeer/tests/run_perf_draw_count_cross_check.cmake
+++ b/gamequeer/tests/run_perf_draw_count_cross_check.cmake
@@ -1,0 +1,85 @@
+# run_perf_draw_count_cross_check.cmake — CTest script asserting that
+# GQ_PERF_INSTRUMENT's draw_oled_stack section count matches the (separate,
+# independently-implemented) --draw-count-out instrumentation for the same
+# run. These are two different counters, incremented in two different
+# places (gq_draw_oled_stack_count in gamequeer.c vs.
+# gq_perf_stats.sections[GQ_PERF_SEC_DRAW_OLED_STACK].count via
+# GQ_PERF_ENTER/EXIT in the same function) -- agreement is a cheap
+# cross-check that the perf-instrumentation macros are firing exactly once
+# per draw_oled_stack() call, no more and no less. Only meaningful (and
+# only registered) in a build configured with both GQ_HEADLESS=ON and
+# GQ_PERF_INSTRUMENT=ON.
+#
+# Parameters (passed via -D):
+#   EXE          — path to the headless+perf-instrumented gamequeer binary
+#   FIXTURE      — path to the .gqgame cart fixture
+#   DRAW_COUNT   — path where the --draw-count-out output will be written
+#   PERF_DUMP    — path where the --perf-dump output will be written
+#   TICKS        — number of system_tick iterations to run
+#
+# Exits with FATAL_ERROR if the emulator fails, either output is missing,
+# the perf-dump's draw_oled_stack count line can't be parsed, or the two
+# counts disagree.
+
+cmake_minimum_required(VERSION 3.18)
+
+# ---- 1. Run the headless+perf-instrumented emulator, both flags at once --
+
+execute_process(
+    COMMAND "${EXE}" --ticks "${TICKS}" --draw-count-out "${DRAW_COUNT}" --perf-dump "${PERF_DUMP}" "${FIXTURE}"
+    RESULT_VARIABLE run_result
+    OUTPUT_VARIABLE run_stdout
+    ERROR_VARIABLE  run_stderr
+)
+
+if(NOT run_result EQUAL 0)
+    message(FATAL_ERROR
+        "Emulator exited with code ${run_result}\n"
+        "stdout: ${run_stdout}\n"
+        "stderr: ${run_stderr}"
+    )
+endif()
+
+# ---- 2. Read the --draw-count-out count -----------------------------------
+
+if(NOT EXISTS "${DRAW_COUNT}")
+    message(FATAL_ERROR "Emulator did not produce draw-count output: ${DRAW_COUNT}")
+endif()
+
+file(READ "${DRAW_COUNT}" draw_count)
+string(STRIP "${draw_count}" draw_count)
+
+# ---- 3. Read and parse the --perf-dump draw_oled_stack count --------------
+
+if(NOT EXISTS "${PERF_DUMP}")
+    message(FATAL_ERROR "Emulator did not produce perf-dump output: ${PERF_DUMP}")
+endif()
+
+file(READ "${PERF_DUMP}" perf_dump_contents)
+
+# Each section line looks like:
+#   draw_oled_stack          count=2        total_us=77 ...
+# Match the draw_oled_stack line specifically and capture its count value.
+string(REGEX MATCH "draw_oled_stack[ \t]+count=([0-9]+)" perf_match "${perf_dump_contents}")
+if(NOT perf_match)
+    message(FATAL_ERROR
+        "Could not find a 'draw_oled_stack count=<N>' line in perf-dump output:\n"
+        "${perf_dump_contents}"
+    )
+endif()
+set(perf_count "${CMAKE_MATCH_1}")
+
+# ---- 4. Compare ------------------------------------------------------------
+
+if(NOT draw_count EQUAL perf_count)
+    message(FATAL_ERROR
+        "draw_oled_stack count mismatch between the two independent counters!\n"
+        "  --draw-count-out (gq_draw_oled_stack_count): ${draw_count}\n"
+        "  --perf-dump (GQ_PERF_SEC_DRAW_OLED_STACK):    ${perf_count}\n"
+        "These are incremented in different places for different purposes; "
+        "disagreement suggests GQ_PERF_ENTER/EXIT(DRAW_OLED_STACK) is not "
+        "firing exactly once per draw_oled_stack() call."
+    )
+endif()
+
+message(STATUS "Perf/draw-count cross-check PASSED (both report ${draw_count} draw_oled_stack() call(s))")


### PR DESCRIPTION
## Summary

Track A2 of the qc2024 perf effort — implements the `GQ_PERF_INSTRUMENT` build flavor called for in qc2024's `docs/perf-investigation.md`, "Before changing code": a way to get real per-section timings instead of the static cycle estimates in that doc's per-frame cost table. **This PR is the emulator half only** — the badge firmware (`ccs_workspace/`) implementation of `HAL_perf_now()` is a separate, not-yet-done task; `include/gq_perf.h` documents in detail what that implementation must provide.

- **New `-DGQ_PERF_INSTRUMENT=ON` CMake option** (independent of `-DGQ_HEADLESS`), OFF by default.
- **`gq_perf_stats`**: a plain global RAM struct at a stable, `.map`-discoverable symbol (for future SBW reads by address) — magic + version header (8 B) + 5 sections × 16 B (count/total_us/min_us/max_us) = **88 B total**, well under the ~150 B target.
- **`GQ_PERF_ENTER(SECTION)` / `GQ_PERF_EXIT(SECTION)`** macros, wired around: `draw_oled_stack` (total), `draw_animation_stack`, `handle_events` (the "handle_events/run_code aggregate"), `system_tick`, and `oled_flush` (measured directly around the shared `Graphics_flushBuffer()` call site in `gamequeer.c` — see the header's "Flush-section hook placement" note for why that avoids needing any new HAL primitive).
- **`HAL_perf_now()`**: emulator implementation via `clock_gettime(CLOCK_MONOTONIC)` scaled to microseconds (`src/HAL.c`). `gq_perf_time_t` is `uint32_t` microseconds (wraps ~71.6 min) — see the header for the width rationale (a 16-bit µs counter leaves too little margin against the ~50 ms upper end of a single section).
- **`--perf-dump PATH`** emulator CLI flag (GQ_PERF_INSTRUMENT builds only), following the existing `--draw-count-out` pattern.
- **Committed cross-check test** (`perf_draw_count_cross_check`, only registered when `GQ_PERF_INSTRUMENT=ON`): asserts the `DRAW_OLED_STACK` section's count matches the existing, independently-implemented `gq_draw_oled_stack_count` (`--draw-count-out`) for the same run — two different instrumentation mechanisms measuring the same event.
- **Documented-only extension points** (not implemented): D0/D1 GPIO toggle hooks, and exposing stats as `GQI_*` builtins for an on-badge profiler cart (flagged as `gqc`-compiler-impacting if ever attempted).

## Zero-cost proof

A `-DGQ_HEADLESS=ON` build **without** `GQ_PERF_INSTRUMENT` produces a **byte-for-byte identical binary** to `origin/default` (sha256 verified, stronger than a `.map`-only comparison):

```
f3b87c38183c5662bf55cb9f8ddafcd4b06539088ec292bbcd7c4e6b89ec0810  build-baseline/gamequeer   (origin/default)
f3b87c38183c5662bf55cb9f8ddafcd4b06539088ec292bbcd7c4e6b89ec0810  build-noninstr/gamequeer   (this branch, GQ_PERF_INSTRUMENT=OFF)
```

This holds because: `GQ_PERF_ENTER`/`GQ_PERF_EXIT` compile to `((void)0)`; `src/gq_perf.c` is not even added to the build (`target_sources` is conditional on the CMake option); and the new `--perf-dump` flag + `dump_perf_stats()` in `main.c` are **preprocessor-gated out entirely** (not just internally short-circuited) — unlike the existing `--draw-count-out` precedent (which is always-present-but-errors), `--perf-dump` had to be fully absent from a non-instrumented binary specifically to preserve this byte-identical proof.

## Emulator validation

Ran `redundant_write.gqgame` (30 ticks) and `anim_advance.gqgame` (43 ticks) instrumented builds with `--perf-dump` + `--draw-count-out` together:

```
$ ./gamequeer --ticks 43 --perf-dump /tmp/perf.txt --draw-count-out /tmp/dc.txt tests/golden/anim_advance.gqgame
magic=0x51504652 version=1
draw_oled_stack          count=3        total_us=421      min_us=138   max_us=142   avg_us=140
draw_animation_stack     count=3        total_us=190      min_us=63    max_us=64    avg_us=63
handle_events            count=43       total_us=423      min_us=0     max_us=142   avg_us=9
system_tick              count=43       total_us=1         min_us=0    max_us=1     avg_us=0
oled_flush               count=3        total_us=230       min_us=74   max_us=79    avg_us=76
--- draw-count-out ---
3
```

`draw_oled_stack` count (3) matches `--draw-count-out` (3) — the committed cross-check test asserts exactly this. `handle_events`/`system_tick` counts (43) match the tick count. Numbers are plausible and non-zero; per the perf-investigation doc, emulator render cost is not representative of the badge (RLE decode dominates there, not per-pixel indirection), so these are sanity-check magnitudes, not the numbers the firmware-side implementation will eventually produce.

## Test plan

- [x] `-DGQ_HEADLESS=ON` (no `GQ_PERF_INSTRUMENT`): 11/11 golden ctest suite passes, byte-identical binary vs. `origin/default`.
- [x] `-DGQ_HEADLESS=ON -DGQ_PERF_INSTRUMENT=ON`: 11/11 golden tests + 1 new cross-check test = 12/12 pass.
- [x] `clang-format` clean on all new/modified files.
- [x] No new compiler warnings introduced (`-Wall -Wextra -Wpedantic`) in either flavor — remaining warnings are pre-existing and identical to baseline.

## Firmware follow-up (not in this PR)

`include/gq_perf.h`'s `HAL_perf_now()` doc comment is a full design note for the `ccs_workspace/qc2024/` implementation: free-running 32-bit-microsecond counter, ISR-safe (torn-read-safe if software-extending a 16-bit hardware timer), candidate unused MSP430FR2476 timers (TA1/TA3/TB0 as of this writing — RTC and TA0/TA2 are already committed to the RTC heartbeat and TLC5948A grayscale clock respectively), and why the flush section doesn't need a new HAL primitive.

Referenced context: qc2024's `docs/perf-investigation.md`, "Before changing code" section — this PR is that instrumentation pass's emulator half.

(AI-generated via Claude Code w/ Claude Sonnet 5)