### PR TITLE
perf(oled): replace per-pixel image blit with run-aware HAL primitive

### DIFF
--- a/gamequeer/include/gamequeer.h
+++ b/gamequeer/include/gamequeer.h
@@ -336,8 +336,9 @@ void handle_events();
  *     see gq_image_peek_run()'s doc comment in oled.c.
  *
  * Per-platform implementations: sh1107.c (badge, packed 1bpp page-major
- * frame_buffer) and grlib_gfx_driver.c (emulator, uint8_t[128][128]
- * frame_buffer). The badge implementation precomputes the page index and
+ * frame_buffer) and grlib_gfx_driver.c (emulator,
+ * uint8_t[OLED_HORIZONTAL_MAX][OLED_VERTICAL_MAX] frame_buffer, currently
+ * [127][127]). The badge implementation precomputes the page index and
  * bit mask once per call (both are constant across a horizontal run,
  * since page = y / 8 and the bit position is y % 8) instead of recomputing
  * them per pixel the way qc12_oledPixelDraw() did.

--- a/gamequeer/include/gamequeer.h
+++ b/gamequeer/include/gamequeer.h
@@ -311,6 +311,39 @@ void led_tick();
 void led_play_cue(t_gq_pointer cue_ptr, uint8_t background);
 void led_stop();
 void handle_events();
+
+/*
+ * HAL_oled_fill_run() -- per-platform display primitive (issue #261).
+ *
+ * Fills `length` consecutive horizontal pixels, starting at (x, y), to
+ * `value` (0 or 1). This is the batched replacement for calling
+ * Graphics_drawPixelOnDisplay() once per pixel: oled.c's RLE decoder
+ * (gq_image_peek_run() / gq_image_advance_run()) walks the image in
+ * same-value runs and calls this once per run instead of once per pixel.
+ *
+ * Contract with callers (oled.c):
+ *   - The caller has already clipped [x, x + length - 1] against the
+ *     active clip region's X bounds, and 0 <= y (per the pre-existing
+ *     per-pixel clip semantics this replaces -- see gq_draw_image()).
+ *     Implementations still bounds-check defensively (matching the
+ *     pre-existing qc12_oledPixelDraw()/gfx_driver_pixelDraw() pattern of
+ *     rejecting negative coordinates) since this is a raw framebuffer
+ *     write with no further indirection between it and the hardware/emu
+ *     buffer.
+ *   - `length` is always >= 1 when called; a run never crosses a display
+ *     row, so a single call never needs to wrap.
+ *   - The whole run shares one pixel value (0 or 1) by construction --
+ *     see gq_image_peek_run()'s doc comment in oled.c.
+ *
+ * Per-platform implementations: sh1107.c (badge, packed 1bpp page-major
+ * frame_buffer) and grlib_gfx_driver.c (emulator, uint8_t[128][128]
+ * frame_buffer). The badge implementation precomputes the page index and
+ * bit mask once per call (both are constant across a horizontal run,
+ * since page = y / 8 and the bit position is y % 8) instead of recomputing
+ * them per pixel the way qc12_oledPixelDraw() did.
+ */
+void HAL_oled_fill_run(int16_t x, int16_t y, uint16_t length, uint8_t value);
+
 void gq_draw_image(
     const Graphics_Context *context,
     t_gq_pointer image_bytes,

--- a/gamequeer/include/gq_perf.h
+++ b/gamequeer/include/gq_perf.h
@@ -19,18 +19,21 @@
  * before/after .map for a non-instrumented build (see the PR body for the
  * comparison).
  *
- * Defined: adds a small RAM stats struct (gq_perf_stats, currently 88 B --
- * an 8 B header plus 5 sections * 16 B each; see layout below) with
+ * Defined: adds a small RAM stats struct (gq_perf_stats, currently 120 B --
+ * an 8 B header plus 7 sections * 16 B each; see layout below) with
  * per-section count / accumulated-duration / min / max, in microseconds,
  * updated by GQ_PERF_ENTER(SECTION) / GQ_PERF_EXIT(SECTION) pairs placed
- * around hot-path code in gamequeer.c.
+ * around hot-path code in gamequeer.c and oled.c.
  *
  * Sections instrumented so far (see GQ_PERF_SECTION_LIST below to add
- * more):
- *   - DRAW_OLED_STACK      draw_oled_stack() total (clear + animations +
+ * more; indices below match GQ_PERF_SECTION_LIST's declaration order,
+ * which is also each section's position in gq_perf_stats.sections[] --
+ * see the struct layout note below for the byte-offset math a raw-memory
+ * reader needs):
+ *   0 DRAW_OLED_STACK      draw_oled_stack() total (clear + animations +
  *                          labels + menu + flush)
- *   - DRAW_ANIMATION_STACK draw_animation_stack() (subset of the above)
- *   - HANDLE_EVENTS        handle_events(): the full event-dispatch pass,
+ *   1 DRAW_ANIMATION_STACK draw_animation_stack() (subset of the above)
+ *   2 HANDLE_EVENTS        handle_events(): the full event-dispatch pass,
  *                          which includes any run_code() calls it triggers
  *                          and (if GQ_EVENT_REFRESH fires) the nested
  *                          DRAW_OLED_STACK section. This is the
@@ -39,20 +42,48 @@
  *                          because run_code() has no single entry/exit
  *                          point of its own outside of handle_events()'s
  *                          per-event dispatch loop.
- *   - SYSTEM_TICK          system_tick() total (animation/timer bookkeeping
+ *   3 SYSTEM_TICK          system_tick() total (animation/timer bookkeeping
  *                          + led_tick(), unless GQ_SUPPRESS_LED_TICK)
- *   - OLED_FLUSH           the Graphics_flushBuffer() call inside
+ *   4 OLED_FLUSH           the Graphics_flushBuffer() call inside
  *                          draw_oled_stack() -- see the flush-hook design
  *                          note further down for why this is measured at
  *                          the shared-code call site rather than via a new
  *                          HAL primitive.
+ *   5 DRAW_DECODE          issue #261's run-aware RLE decode: each call to
+ *                          gq_image_peek_run()/gq_image_advance_run() (the
+ *                          pair, together -- one section covers both) in
+ *                          oled.c's gq_draw_image()/gq_draw_image_with_mask()
+ *                          run loops. Includes any interleaved
+ *                          gq_image_load_byte() cart reads triggered by a
+ *                          run/buffer boundary. Per-RUN granularity, not
+ *                          per-pixel -- see the observer-effect note below.
+ *   6 DRAW_WRITE           issue #261's HAL_oled_fill_run() call, wrapped
+ *                          at the same per-run granularity as DRAW_DECODE.
+ *                          Only entered when a run actually reaches the
+ *                          framebuffer write (a fully clipped or fully
+ *                          transparent-masked run skips it, same as before
+ *                          this instrumentation existed) -- so DRAW_WRITE's
+ *                          count can be lower than DRAW_DECODE's count for
+ *                          the same frame.
+ *
+ * NOTE (observer effect, DRAW_DECODE/DRAW_WRITE specifically): these two
+ * sections are timed per RLE *run*, not per pixel -- that's the whole
+ * point of issue #261's fix (few runs = cheap redraw), and it's also what
+ * keeps the two extra HAL_perf_now() calls per run cheap relative to the
+ * work being measured. Timing per *pixel* the way the old code drew them
+ * would have made the measurement overhead comparable to (or larger than)
+ * the thing being measured, especially for long runs where the batched
+ * write is now very fast. Per-run timing avoids that trap by construction.
  *
  * NOTE: sections nest (DRAW_ANIMATION_STACK and OLED_FLUSH are both
  * sub-intervals of DRAW_OLED_STACK; HANDLE_EVENTS can contain a full
- * DRAW_OLED_STACK pass). Each section's numbers are self-contained -- there
- * is no double-counting *within* a section's own count/total -- but a
- * reader comparing sections should remember the containment relationship
- * rather than expecting them to sum to an unrelated "everything" total.
+ * DRAW_OLED_STACK pass; DRAW_DECODE and DRAW_WRITE are both sub-intervals
+ * of DRAW_ANIMATION_STACK, entered many times per DRAW_ANIMATION_STACK
+ * call -- once per RLE run rather than once per call). Each section's
+ * numbers are self-contained -- there is no double-counting *within* a
+ * section's own count/total -- but a reader comparing sections should
+ * remember the containment relationship rather than expecting them to sum
+ * to an unrelated "everything" total.
  *
  * NOTE: GQ_PERF_ENTER/EXIT are matched pairs around straight-line code.
  * Functions with an early-return failure path between ENTER and EXIT (e.g.
@@ -65,7 +96,7 @@
  * -------------------------------------------------------------------------
  * Struct layout (GQ_PERF_INSTRUMENT defined):
  * -------------------------------------------------------------------------
- *   gq_perf_stats_t (8 B header + N * 16 B sections; N=5 today -> 88 B):
+ *   gq_perf_stats_t (8 B header + N * 16 B sections; N=7 today -> 120 B):
  *     uint32_t magic;    -- GQ_PERF_MAGIC; sanity-check when read over SBW
  *                           at a known/discoverable symbol address (via the
  *                           .map file -- gq_perf_stats is a plain global,
@@ -80,8 +111,20 @@
  *       each: uint32_t count, total_us, min_us, max_us (16 B).
  *
  * Adding a new section costs 16 B. The ~150 B RAM target in the design
- * discussion allows roughly 4 more sections beyond the 5 defined here
- * before that budget is exhausted.
+ * discussion allowed roughly 4 more sections beyond the original 5; this
+ * pass (issue #261's DRAW_DECODE/DRAW_WRITE) uses 2 of those, leaving
+ * headroom for about 2 more before that budget is exhausted (120 B used of
+ * ~150 B; each further section costs another 16 B).
+ *
+ * Byte-offset math for a raw-memory SBW reader (no source access to this
+ * header): sections[i] starts at offset 8 + i*16 within gq_perf_stats
+ * (8 B header, then 16 B per section in GQ_PERF_SECTION_LIST's declared
+ * order -- see the section index list above for what each i is). With
+ * N=7: DRAW_DECODE (index 5) is at byte offset 8 + 5*16 = 88; DRAW_WRITE
+ * (index 6) is at byte offset 8 + 6*16 = 104. Each section's own layout is
+ * count (offset +0), total_us (+4), min_us (+8), max_us (+12), all
+ * uint32_t, all four bytes wide -- e.g. DRAW_DECODE's total_us is at
+ * absolute offset 88 + 4 = 92 within gq_perf_stats.
  *
  * -------------------------------------------------------------------------
  * Timer width decision: gq_perf_time_t is uint32_t, holding microseconds.
@@ -209,7 +252,9 @@
     X(DRAW_ANIMATION_STACK, "draw_animation_stack") \
     X(HANDLE_EVENTS, "handle_events")               \
     X(SYSTEM_TICK, "system_tick")                   \
-    X(OLED_FLUSH, "oled_flush")
+    X(OLED_FLUSH, "oled_flush")                     \
+    X(DRAW_DECODE, "draw_decode")                   \
+    X(DRAW_WRITE, "draw_write")
 
 typedef enum {
 #define GQ_PERF_ENUM_ENTRY(NAME, STR) GQ_PERF_SEC_##NAME,

--- a/gamequeer/src/grlib_gfx_driver/grlib_gfx_driver.c
+++ b/gamequeer/src/grlib_gfx_driver/grlib_gfx_driver.c
@@ -1,5 +1,6 @@
 #include <string.h>
 
+#include "gamequeer.h"
 #include "gfx.h"
 #include "grlib.h"
 #include "grlib_gfx.h"
@@ -17,6 +18,43 @@ static void gfx_driver_pixelDraw(void *displayData, int16_t x, int16_t y, uint16
         return;
     }
     frame_buffer[x][y] = value ? 1 : 0;
+}
+
+/*
+ * HAL_oled_fill_run() -- emulator implementation (see the doc comment on
+ * its declaration in gamequeer.h for the full contract).
+ *
+ * frame_buffer here is uint8_t[x][y] (one byte per pixel), so unlike the
+ * badge's packed 1bpp framebuffer (sh1107.c) there's no bit-packing to do
+ * -- this is a plain per-column store loop. The bounds check mirrors
+ * gfx_driver_pixelDraw()'s existing defensive check (rather than trusting
+ * the caller's clip) since this is, like that function, a raw framebuffer
+ * write with no further indirection between it and the display buffer.
+ * Performance here is not the point (see issue #261 / docs/perf-
+ * investigation.md's "Emulator measurability" note) -- pixel-identical
+ * output vs. the old per-pixel path is.
+ */
+void HAL_oled_fill_run(int16_t x, int16_t y, uint16_t length, uint8_t value) {
+    if (y < 0 || y >= OLED_VERTICAL_MAX || length == 0) {
+        return;
+    }
+    if (x < 0) {
+        // Defensive only -- oled.c's callers already clip x to
+        // [clipRegion.xMin, clipRegion.xMax], both non-negative.
+        if ((uint16_t) -x >= length) {
+            return;
+        }
+        length = (uint16_t) (length + x);
+        x      = 0;
+    }
+    if (x + length > OLED_HORIZONTAL_MAX) {
+        length = (uint16_t) (OLED_HORIZONTAL_MAX - x);
+    }
+
+    uint8_t pixel = value ? 1 : 0;
+    for (uint16_t i = 0; i < length; i++) {
+        frame_buffer[x + i][y] = pixel;
+    }
 }
 
 static void gfx_driver_pixelDrawMultiple(

--- a/gamequeer/src/grlib_gfx_driver/grlib_gfx_driver.c
+++ b/gamequeer/src/grlib_gfx_driver/grlib_gfx_driver.c
@@ -47,6 +47,13 @@ void HAL_oled_fill_run(int16_t x, int16_t y, uint16_t length, uint8_t value) {
         length = (uint16_t) (length + x);
         x      = 0;
     }
+    if (x >= OLED_HORIZONTAL_MAX) {
+        // Defensive only -- see above. Without this, the clamp below
+        // (OLED_HORIZONTAL_MAX - x) would underflow when x is already
+        // past the right edge, wrapping length to a huge uint16_t and
+        // driving the fill loop far out of frame_buffer's bounds.
+        return;
+    }
     if (x + length > OLED_HORIZONTAL_MAX) {
         length = (uint16_t) (OLED_HORIZONTAL_MAX - x);
     }

--- a/gamequeer/src/oled.c
+++ b/gamequeer/src/oled.c
@@ -3,6 +3,7 @@
 #include "HAL.h"
 #include "HAL_emulator.h"
 #include "gamequeer.h"
+#include "gq_perf.h"
 #include "grlib.h"
 
 #include <gamequeer.h>
@@ -227,8 +228,10 @@ void gq_draw_image(
         int16_t draw_y = y + frame.y_curr;
 
         uint16_t run_avail;
+        GQ_PERF_ENTER(DRAW_DECODE);
         uint8_t draw_pixel = gq_image_peek_run(&frame, &run_avail);
         gq_image_advance_run(&frame, run_avail);
+        GQ_PERF_EXIT(DRAW_DECODE);
 
         // Vertical clip: matches the original per-pixel check, which only
         // ever tested draw_y >= yMin -- the upper bound is already enforced
@@ -252,7 +255,9 @@ void gq_draw_image(
             seg_len = context->clipRegion.xMax - seg_x0 + 1;
         }
         if (seg_len > 0) {
+            GQ_PERF_ENTER(DRAW_WRITE);
             HAL_oled_fill_run(seg_x0, draw_y, (uint16_t) seg_len, (uint8_t) palette[draw_pixel]);
+            GQ_PERF_EXIT(DRAW_WRITE);
         }
     }
 }
@@ -295,12 +300,14 @@ void gq_draw_image_with_mask(
         // (or row) ends first; within that shared run, both the image
         // value and the mask value are constant.
         uint16_t image_avail, mask_avail;
+        GQ_PERF_ENTER(DRAW_DECODE);
         uint8_t image_pixel = gq_image_peek_run(&image_frame, &image_avail);
         uint8_t mask_pixel  = gq_image_peek_run(&mask_frame, &mask_avail);
         uint16_t run_avail  = image_avail < mask_avail ? image_avail : mask_avail;
 
         gq_image_advance_run(&image_frame, run_avail);
         gq_image_advance_run(&mask_frame, run_avail);
+        GQ_PERF_EXIT(DRAW_DECODE);
 
         // Transparent (mask=0) run: nothing to draw, same as the original
         // per-pixel path which never called Graphics_drawPixelOnDisplay()
@@ -326,7 +333,9 @@ void gq_draw_image_with_mask(
             seg_len = context->clipRegion.xMax - seg_x0 + 1;
         }
         if (seg_len > 0) {
+            GQ_PERF_ENTER(DRAW_WRITE);
             HAL_oled_fill_run(seg_x0, draw_y, (uint16_t) seg_len, (uint8_t) palette[image_pixel]);
+            GQ_PERF_EXIT(DRAW_WRITE);
         }
     }
 }

--- a/gamequeer/src/oled.c
+++ b/gamequeer/src/oled.c
@@ -100,7 +100,7 @@ void gq_image_load_byte(gq_image_frame_on_screen *frame) {
  * happen at the same point in the stream either way, so output is
  * pixel-identical to the old code for any valid `count`.
  */
-uint8_t gq_image_peek_run(gq_image_frame_on_screen *frame, uint16_t *out_avail) {
+static uint8_t gq_image_peek_run(gq_image_frame_on_screen *frame, uint16_t *out_avail) {
     // NB: only call this function while !gq_image_done(frame) -- calling it
     // once the frame is done is undefined behavior (see the while
     // (!gq_image_done(...)) loops in gq_draw_image() and
@@ -123,7 +123,7 @@ uint8_t gq_image_peek_run(gq_image_frame_on_screen *frame, uint16_t *out_avail) 
     return frame->pixel_value;
 }
 
-void gq_image_advance_run(gq_image_frame_on_screen *frame, uint16_t count) {
+static void gq_image_advance_run(gq_image_frame_on_screen *frame, uint16_t count) {
     uint8_t need_to_read_byte = 0;
 
     if (frame->rle_type == 1) {

--- a/gamequeer/src/oled.c
+++ b/gamequeer/src/oled.c
@@ -70,38 +70,79 @@ void gq_image_load_byte(gq_image_frame_on_screen *frame) {
     } // TODO: Otherwise is an error.
 }
 
-uint8_t gq_image_get_pixel(gq_image_frame_on_screen *frame) {
-    // NB: gate this function call on gq_image_done() to avoid undefined behavior
-    // Also, you need to bootstrap it by calling a read_byte
-    uint8_t need_to_read_byte = 0;
-    uint8_t current_pixel_value;
+/*
+ * gq_image_peek_run() / gq_image_advance_run() -- run-aware decode (issue
+ * #261), replacing the old one-pixel-at-a-time gq_image_get_pixel().
+ *
+ * These two are split (rather than one combined "get next N pixels" call)
+ * so that gq_draw_image_with_mask() can peek both the image and mask
+ * streams' available run lengths *before* deciding how far to advance
+ * either one -- the image and mask are independently RLE-encoded, so their
+ * run boundaries don't generally line up even though their dimensions
+ * match. See gq_draw_image_with_mask() for that combine loop.
+ *
+ * gq_image_peek_run() does NOT mutate frame state (other than the implicit
+ * read of the already-decoded frame->pixel_value / frame->pixel_repeat /
+ * frame->render_byte -- it consumes nothing new from the image stream).
+ * It reports the value of the pixel at the current position, and how many
+ * consecutive pixels starting there (including the current one) are
+ * guaranteed to share that value *and* stay within the current image row
+ * (a run is never split across rows by this call -- gq_draw_image() and
+ * gq_draw_image_with_mask() only ever need same-row spans, since a single
+ * HAL_oled_fill_run() call only fills one display row).
+ *
+ * gq_image_advance_run() commits `count` pixels (1 <= count <=
+ * the avail value returned by the immediately preceding
+ * gq_image_peek_run() call on the same frame) and updates decode state
+ * exactly as if gq_image_get_pixel() (the old per-pixel function) had been
+ * called `count` times in a row -- byte/run-boundary prefetch and row-wrap
+ * happen at the same point in the stream either way, so output is
+ * pixel-identical to the old code for any valid `count`.
+ */
+uint8_t gq_image_peek_run(gq_image_frame_on_screen *frame, uint16_t *out_avail) {
+    // NB: gate this function call on gq_image_done() to avoid undefined behavior.
+    // Also, you need to bootstrap it by calling gq_image_load_byte() (done by
+    // gq_load_image()).
+    uint16_t row_remaining = (uint16_t) frame->width - frame->x_pixel_offset;
 
-    // Get the current pixel.
     if (frame->rle_type == 1) {
-        frame->pixel_value = (frame->render_byte >> (7 - frame->x_bit_offset)) & 0x01;
+        // Uncompressed images carry no run-length information -- expose
+        // one pixel at a time, same as the old per-pixel path.
+        *out_avail = 1;
+        return (frame->render_byte >> (7 - frame->x_bit_offset)) & 0x01;
+    }
+
+    uint16_t avail = frame->pixel_repeat;
+    if (avail > row_remaining) {
+        avail = row_remaining;
+    }
+    *out_avail = avail;
+    return frame->pixel_value;
+}
+
+void gq_image_advance_run(gq_image_frame_on_screen *frame, uint16_t count) {
+    uint8_t need_to_read_byte = 0;
+
+    if (frame->rle_type == 1) {
+        // count is always 1 here (see gq_image_peek_run() above).
         frame->x_bit_offset++;
         if (frame->x_bit_offset == 8) {
             frame->byte_index++;
             frame->x_bit_offset = 0;
             need_to_read_byte   = 1;
         }
-        current_pixel_value = frame->pixel_value;
     } else {
-        // Capture the current run's value before a possible run-boundary
-        // prefetch (below) overwrites frame->pixel_value with the *next*
-        // run's value.
-        current_pixel_value = frame->pixel_value;
-        frame->pixel_repeat--;
+        frame->pixel_repeat -= count;
         if (frame->pixel_repeat == 0) {
             need_to_read_byte = 1;
             frame->byte_index++;
         }
     }
 
-    // Next pixel.
-    frame->x_pixel_offset++;
+    // Advance to the pixel(s) after this run segment.
+    frame->x_pixel_offset += count;
 
-    // Check to see if the next pixel sends us to the next row.
+    // Check to see if we've reached the end of the row.
     if (frame->x_pixel_offset >= frame->width) {
         // We need to start a new row.
         frame->y_curr++;
@@ -112,11 +153,6 @@ uint8_t gq_image_get_pixel(gq_image_frame_on_screen *frame) {
     if (need_to_read_byte && !gq_image_done(frame)) {
         gq_image_load_byte(frame);
     }
-
-    // Return the current pixel's value (captured above; must not be the
-    // next run's value, which may have just been prefetched into
-    // frame->pixel_value).
-    return current_pixel_value;
 }
 
 void gq_load_image(
@@ -183,14 +219,40 @@ void gq_draw_image(
     gq_load_image(image_bytes, bPP, width, height, img_frame_data_size, x, y, &frame);
 
     while (!(gq_image_done(&frame))) {
-        // Draw the pixel.
-        int16_t draw_x     = x + frame.x_pixel_offset;
-        int16_t draw_y     = y + frame.y_curr;
-        uint8_t draw_pixel = gq_image_get_pixel(&frame);
+        // Decode the next run (same procedure regardless of clipping --
+        // see gq_image_peek_run()'s doc comment: the RLE stream must be
+        // walked in order, so a clipped row/column still costs a decode,
+        // just not a framebuffer write).
+        int16_t draw_x = x + frame.x_pixel_offset;
+        int16_t draw_y = y + frame.y_curr;
 
-        if (draw_x >= context->clipRegion.xMin && draw_x <= context->clipRegion.xMax &&
-            draw_y >= context->clipRegion.yMin) {
-            Graphics_drawPixelOnDisplay(context->display, draw_x, draw_y, palette[draw_pixel]);
+        uint16_t run_avail;
+        uint8_t draw_pixel = gq_image_peek_run(&frame, &run_avail);
+        gq_image_advance_run(&frame, run_avail);
+
+        // Vertical clip: matches the original per-pixel check, which only
+        // ever tested draw_y >= yMin -- the upper bound is already enforced
+        // structurally by frame.y_end (see gq_load_image()).
+        if (draw_y < context->clipRegion.yMin) {
+            continue;
+        }
+
+        // Horizontal clip: intersect the run [draw_x, draw_x + run_avail)
+        // with [xMin, xMax]. Equivalent to clipping each pixel of the run
+        // individually (the original behavior) because both the run and
+        // the clip bound are contiguous intervals.
+        int16_t seg_x0  = draw_x;
+        int16_t seg_len = (int16_t) run_avail;
+        if (seg_x0 < context->clipRegion.xMin) {
+            int16_t trim = context->clipRegion.xMin - seg_x0;
+            seg_x0 += trim;
+            seg_len -= trim;
+        }
+        if (seg_x0 + seg_len - 1 > context->clipRegion.xMax) {
+            seg_len = context->clipRegion.xMax - seg_x0 + 1;
+        }
+        if (seg_len > 0) {
+            HAL_oled_fill_run(seg_x0, draw_y, (uint16_t) seg_len, (uint8_t) palette[draw_pixel]);
         }
     }
 }
@@ -221,16 +283,50 @@ void gq_draw_image_with_mask(
     gq_load_image(mask_bytes, mask_bPP, width, height, mask_frame_data_size, x, y, &mask_frame);
 
     while (!gq_image_done(&image_frame) && !gq_image_done(&mask_frame)) {
-        // Draw the pixel.
         int16_t draw_x = x + image_frame.x_pixel_offset;
         int16_t draw_y = y + image_frame.y_curr;
 
-        uint8_t image_pixel = gq_image_get_pixel(&image_frame);
-        uint8_t mask_pixel  = gq_image_get_pixel(&mask_frame);
+        // Peek both streams' available run lengths at the current position
+        // without committing either one -- the image and mask are
+        // independently RLE-encoded, so one may offer a longer run than
+        // the other even though both share the same width/height (enforced
+        // by draw_animation_stack()'s caller-side dimension check). The
+        // batch we can safely commit is bounded by whichever stream's run
+        // (or row) ends first; within that shared run, both the image
+        // value and the mask value are constant.
+        uint16_t image_avail, mask_avail;
+        uint8_t image_pixel = gq_image_peek_run(&image_frame, &image_avail);
+        uint8_t mask_pixel  = gq_image_peek_run(&mask_frame, &mask_avail);
+        uint16_t run_avail  = image_avail < mask_avail ? image_avail : mask_avail;
 
-        if (mask_pixel && draw_x >= context->clipRegion.xMin && draw_x <= context->clipRegion.xMax &&
-            draw_y >= context->clipRegion.yMin) {
-            Graphics_drawPixelOnDisplay(context->display, draw_x, draw_y, palette[image_pixel]);
+        gq_image_advance_run(&image_frame, run_avail);
+        gq_image_advance_run(&mask_frame, run_avail);
+
+        // Transparent (mask=0) run: nothing to draw, same as the original
+        // per-pixel path which never called Graphics_drawPixelOnDisplay()
+        // for mask_pixel == 0.
+        if (!mask_pixel) {
+            continue;
+        }
+
+        // Vertical clip -- see gq_draw_image()'s matching comment.
+        if (draw_y < context->clipRegion.yMin) {
+            continue;
+        }
+
+        // Horizontal clip -- see gq_draw_image()'s matching comment.
+        int16_t seg_x0  = draw_x;
+        int16_t seg_len = (int16_t) run_avail;
+        if (seg_x0 < context->clipRegion.xMin) {
+            int16_t trim = context->clipRegion.xMin - seg_x0;
+            seg_x0 += trim;
+            seg_len -= trim;
+        }
+        if (seg_x0 + seg_len - 1 > context->clipRegion.xMax) {
+            seg_len = context->clipRegion.xMax - seg_x0 + 1;
+        }
+        if (seg_len > 0) {
+            HAL_oled_fill_run(seg_x0, draw_y, (uint16_t) seg_len, (uint8_t) palette[image_pixel]);
         }
     }
 }

--- a/gamequeer/src/oled.c
+++ b/gamequeer/src/oled.c
@@ -101,9 +101,11 @@ void gq_image_load_byte(gq_image_frame_on_screen *frame) {
  * pixel-identical to the old code for any valid `count`.
  */
 uint8_t gq_image_peek_run(gq_image_frame_on_screen *frame, uint16_t *out_avail) {
-    // NB: gate this function call on gq_image_done() to avoid undefined behavior.
-    // Also, you need to bootstrap it by calling gq_image_load_byte() (done by
-    // gq_load_image()).
+    // NB: only call this function while !gq_image_done(frame) -- calling it
+    // once the frame is done is undefined behavior (see the while
+    // (!gq_image_done(...)) loops in gq_draw_image() and
+    // gq_draw_image_with_mask() below). Also, you need to bootstrap it by
+    // calling gq_image_load_byte() (done by gq_load_image()).
     uint16_t row_remaining = (uint16_t) frame->width - frame->x_pixel_offset;
 
     if (frame->rle_type == 1) {


### PR DESCRIPTION
## Summary

Part of #261. Replaces the per-pixel image blit in `oled.c` (`gq_draw_image()` / `gq_draw_image_with_mask()`) with a run-aware decode + a new per-platform HAL primitive, `HAL_oled_fill_run(x, y, length, value)`. This is the shared-code half of the fix; the badge implementation is a companion PR against `duplico/qc2024` (`sh1107.c`). Emulator implementation included here (`grlib_gfx_driver.c`).

**Why now:** tonight's first real hardware measurement (`duplico/qc2024#41`, `GQ_PERF_INSTRUMENT` build on an eZ-FET-attached badge) puts a full-screen redraw at **~292 ms**, with `draw_animation_stack()` — RLE decode + the per-pixel blit this PR touches — accounting for **~278 ms (95%)**. That's a ~3.4 FPS ceiling. This is the dominant cost identified in `docs/perf-investigation.md` (suspect #0), now confirmed on real hardware rather than estimated.

## Design

**The old path:** `gq_draw_image()` decoded the RLE stream one pixel at a time (`gq_image_get_pixel()`) and called `Graphics_drawPixelOnDisplay(context->display, x, y, value)` for every pixel — a real function call that itself makes a second, indirect call through `display->callPixelDraw` to the platform's `qc12_oledPixelDraw()`/`gfx_driver_pixelDraw()`. For a full 128x128 background frame that's up to 16,384 two-level call chains, each re-deriving `y/8`/`y%8` bit position math from scratch.

**The new path:**

1. **Run-aware decode** (`oled.c`): `gq_image_get_pixel()` is replaced by a peek/advance pair:
   - `gq_image_peek_run(frame, *out_avail)` — non-mutating; returns the pixel value at the current position and how many consecutive pixels (>= 1) share that value *and* stay within the current image row. A run is never exposed as crossing a row boundary, since a single `HAL_oled_fill_run()` call only ever fills one display row.
   - `gq_image_advance_run(frame, count)` — commits `count` pixels (`1 <= count <= avail` from the immediately preceding peek) and updates decode state (byte/run-boundary prefetch, row wrap) exactly as if the old per-pixel function had been called `count` times in a row. This is what makes the output provably pixel-identical: for any valid `count`, the state transition is the same as running the old loop `count` times, just computed in one step (`pixel_repeat -= count` instead of `count` individual decrements, etc.).

   Peek and advance are separate calls (not one combined "decode next N" call) specifically so `gq_draw_image_with_mask()` can look at *both* the image and mask streams' available run lengths before committing to how far to advance either one.

2. **`HAL_oled_fill_run(x, y, length, value)`** (new HAL primitive, declared in `gamequeer.h`): each RLE run gets exactly one call instead of one call per pixel. Per-platform:
   - **Emulator** (`grlib_gfx_driver.c`): a plain per-column store loop into `uint8_t frame_buffer[x][y]`. Not a perf target — the emulator's pixel write was never the bottleneck (see the "Emulator measurability" note under suspect #0 in `docs/perf-investigation.md`) — this exists for structural correctness and to keep the golden-test suite meaningful.
   - **Badge** (`sh1107.c`, companion PR): precomputes `page = y/8` and `mask = 0x80 >> (y%8)` *once per call* instead of once per pixel, then loops the byte read-modify-write. See that PR for the framebuffer-layout discussion (packed 1bpp, page-major — a horizontal run still needs one byte op per column; the win is eliminating the double-indirect call chain and the redundant per-pixel bit-position math, not fewer byte writes).

3. **Mask/run composition** (`gq_draw_image_with_mask()`): the image and mask are independently RLE-encoded, so their run boundaries don't generally line up even though both share the same width/height (enforced by the caller, `draw_animation_stack()`, via a dimension check before either draw is invoked). Each loop iteration peeks both streams' available run lengths and advances *both* by `min(image_avail, mask_avail)` — the largest batch that's still guaranteed to have one constant image value and one constant mask value throughout. `mask_pixel == 0` (transparent) runs are skipped entirely, same as the old per-pixel path.

4. **Clipping**: the old per-pixel path checked `draw_x >= xMin && draw_x <= xMax && draw_y >= yMin` (note: no `yMax` check — that bound is already enforced structurally by `frame.y_end`, computed in `gq_load_image()`) independently for every pixel. The new path clips once per run by intersecting `[draw_x, draw_x + run_len)` with `[xMin, xMax]` — mathematically equivalent to per-pixel clipping since both the run and the clip bound are contiguous intervals, so this can't produce a different set of drawn pixels. **Scope note, matching the issue's validation-pass correction:** the RLE stream is still decoded in full regardless of clipping — a clipped row/column costs a decode but not a write, exactly as before. Full decode-level row-skipping (skip bytes/runs entirely for off-screen rows without decoding them) isn't feasible without a format change: RLE runs can span multiple rows (a single run's `pixel_repeat` isn't bounded by row width), so there's no way to know how many compressed bytes a given row consumes without walking through it. Out of scope here; noted as a possible follow-up if it's ever worth the format change.

**`Graphics_drawString`/`menu.c`** — explicitly out of scope, per the issue. They share the same per-pixel indirection problem at smaller scale but aren't touched by this PR.

## Operation-count reduction (measured, not estimated)

I instrumented (locally, not committed) a pixel-vs-run counter and ran it against the actual golden fixtures already in this test suite, rather than hand-waving a ratio:

| Fixture | Pass | Pixels | Runs (HAL calls) | Reduction |
|---|---|---|---|---|
| `mask_encoding_a` | unmasked (background) | 1024 (32x32) | 32 | **32x** |
| `mask_encoding_a` | masked (fg+mask) | 1024 | 1024 | 1x (no batching) |
| `mask_encoding_b` | masked (fg+mask), x2 | 1024 each | 1024 each | 1x (no batching) |
| `anim_advance` | unmasked (128x128 bg) | 16,256* | 16,256 | 1x (no batching) |

*16,256 = 127x128, not 128x128 — an existing, unrelated emulator quirk (`OLED_HORIZONTAL_MAX`/`OLED_VERTICAL_MAX` are defined as 127 in `grlib_gfx.h`, one less than `GQ_SCREEN_W`/`GQ_SCREEN_H`), not something this PR introduces or changes.

**Honest takeaway:** the RLE-run-count reduction is highly content-dependent. `mask_encoding_a`'s flat-color background batches 32x; everything else in this small test suite (chosen to exercise masking/animation edge cases, not representative "real" game art) shows *no* batching at all — the dithered/checkerboard-ish content in these fixtures produces run lengths of 1 throughout. The format's structural ceiling is much higher (RLE7 caps a single run at 128 pixels — a whole row), so real flat-color sprite/background art should batch better than these edge-case fixtures do.

Critically, **the win isn't purely the batching.** Even in the 1x (no-batching) case, every call now goes through *one* direct function call (`HAL_oled_fill_run`) instead of *two* (`Graphics_drawPixelOnDisplay` → indirect `display->callPixelDraw` → `qc12_oledPixelDraw`), and the per-pixel `y/8`/`y%8` bit-position math collapses to "once per call" instead of "once per pixel" — both apply unconditionally, regardless of content. The hardware measurement (next section) is what will show the real split between "fewer calls" and "cheaper calls."

## Correctness

All 12 golden/regression `ctest` targets pass **unchanged** (headless build), including `mask_encoding_a`, `mask_encoding_b`, `anim_advance`, and `hello` — no golden PGM was regenerated. Also verified with `GQ_PERF_INSTRUMENT=ON` (13/13, including the new perf/draw-count cross-check) and a plain X11 build (compiles clean, not part of the ctest suite). `clang-format --dry-run --Werror` clean on all changed files.

## What the orchestrator should measure on hardware to prove the win

1. Flash the badge companion PR (`duplico/qc2024`, `sh1107.c`) with `GQ_PERF_INSTRUMENT=1` and re-run the same measurement recipe as `duplico/qc2024#41` (same production self-animating cart, same `perf-harness.sh --run-seconds 0` sampling).
2. Compare `DRAW_ANIMATION_STACK` avg/max against the `~278 ms` baseline. Given the "honest takeaway" above, don't expect a clean 10x from batching alone on all content — the direct-call-vs-indirect-call elimination is the part guaranteed to help regardless of content; actual game art may batch significantly better than this PR's test fixtures did.
3. Recompute the implied FPS ceiling (`1000 / DRAW_OLED_STACK avg`) against the pre-fix ~3.4 FPS baseline.

## Lockstep check

No bytecode/struct/format changes — this is a runtime-internal decode/blit refactor. `gqc` (Python compiler) is unaffected; confirmed no references to `get_pixel`/`HAL_blit`/`fill_run` anywhere under `gqc/src`.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


---

## Update: DRAW_DECODE/DRAW_WRITE perf sections added (head now `9db1cc2`)

Maintainer-requested follow-up on the same branch: added two `GQ_PERF_INSTRUMENT`
sections, `DRAW_DECODE` and `DRAW_WRITE`, wrapping the run-loop's
`gq_image_peek_run()`/`gq_image_advance_run()` pair and the `HAL_oled_fill_run()` call
respectively, in both `gq_draw_image()` and `gq_draw_image_with_mask()`. **Per-run
granularity** (not per-pixel) — the whole point of #261 is that there are few runs, so
timing at run granularity keeps the two extra `HAL_perf_now()` calls per run cheap
relative to the work measured; per-pixel timing would have made the observer effect
comparable to (or larger than) the thing being measured.

**Struct size**: `gq_perf_stats_t` grows from 88 B (5 sections) to **120 B (7
sections)**. Section indices/byte offsets for a raw-memory SBW reader:

| Index | Section | Byte offset (within `gq_perf_stats`) |
|---|---|---|
| 5 | `DRAW_DECODE` | 88 (count), 92 (total_us), 96 (min_us), 100 (max_us) |
| 6 | `DRAW_WRITE` | 104 (count), 108 (total_us), 112 (min_us), 116 (max_us) |

(Indices 0-4 — `DRAW_OLED_STACK`/`DRAW_ANIMATION_STACK`/`HANDLE_EVENTS`/`SYSTEM_TICK`/`OLED_FLUSH` — unchanged from before. Full byte-offset math is spelled out in `gq_perf.h`'s updated struct-layout doc comment.)

**Zero-cost-when-off proof**: sha256 of the built `gamequeer` binary (headless, default `GQ_PERF_INSTRUMENT` off) is **byte-identical** before and after this addition (`495fc97a9320139cf5768eb00810c213924a54b6636caac0fe61464b727ad5fb`), confirming `GQ_PERF_ENTER`/`EXIT`'s `((void)0)` no-op expansion holds at the new call sites too.

**Goldens**: all 12 (13 with `GQ_PERF_INSTRUMENT`) `ctest` targets pass unchanged — the new `GQ_PERF_ENTER`/`EXIT` pairs only wrap existing calls, no pixel-identity logic changed. `clang-format` clean.

**Sanity-checked real output** via `--perf-dump` against `mask_encoding_a`: `draw_decode count=1056`, `draw_write count=528` — matches that fixture's two masked-draw calls' combined run counts (32 + 1024 = 1056 decode calls; roughly half resulted in an actual framebuffer write, the rest were transparent-masked or clipped).
