### PR TITLE
[PROTOTYPE / DO NOT MERGE] oled: row-major uncompressed byte-blit fast path

### DIFF
--- a/gamequeer/CMakeLists.txt
+++ b/gamequeer/CMakeLists.txt
@@ -27,6 +27,19 @@ option(GQ_HEADLESS "Build without X11 display (headless mode)" OFF)
 # gq_perf.h for why that matters for the zero-cost claim.
 option(GQ_PERF_INSTRUMENT "Build with GQ_PERF_INSTRUMENT performance stats (see include/gq_perf.h)" OFF)
 
+# Measurement-methodology option: gates ONLY the per-run DRAW_DECODE/
+# DRAW_WRITE sections (5/6) inside oled.c's run loops, independently of
+# GQ_PERF_INSTRUMENT's other five per-draw/per-tick sections -- see
+# GQ_PERF_INSTRUMENT_RUNS's doc block in include/gq_perf.h. Meaningless (and
+# silently a no-op) unless GQ_PERF_INSTRUMENT is also ON -- warn rather than
+# error, since a no-op is harmless and matches gq_perf.h's own degrade
+# behavior.
+option(GQ_PERF_INSTRUMENT_RUNS "Also instrument the per-run DRAW_DECODE/DRAW_WRITE sections (requires GQ_PERF_INSTRUMENT; see include/gq_perf.h)" OFF)
+
+if(GQ_PERF_INSTRUMENT_RUNS AND NOT GQ_PERF_INSTRUMENT)
+    message(WARNING "GQ_PERF_INSTRUMENT_RUNS=ON has no effect without GQ_PERF_INSTRUMENT=ON")
+endif()
+
 if(GQ_HEADLESS)
     message(STATUS "GQ_HEADLESS=ON: building without X11")
     set(GFX_SOURCE src/gfx/gfx_headless.c)
@@ -80,6 +93,11 @@ if(GQ_PERF_INSTRUMENT)
     message(STATUS "GQ_PERF_INSTRUMENT=ON: building with performance instrumentation (see include/gq_perf.h)")
     target_sources(${PROJECT_NAME} PRIVATE src/gq_perf.c)
     target_compile_definitions(${PROJECT_NAME} PRIVATE GQ_PERF_INSTRUMENT)
+
+    if(GQ_PERF_INSTRUMENT_RUNS)
+        message(STATUS "GQ_PERF_INSTRUMENT_RUNS=ON: also instrumenting per-run DRAW_DECODE/DRAW_WRITE sections")
+        target_compile_definitions(${PROJECT_NAME} PRIVATE GQ_PERF_INSTRUMENT_RUNS)
+    endif()
 endif()
 
 # Link math:

--- a/gamequeer/include/gamequeer.h
+++ b/gamequeer/include/gamequeer.h
@@ -345,6 +345,39 @@ void handle_events();
  */
 void HAL_oled_fill_run(int16_t x, int16_t y, uint16_t length, uint8_t value);
 
+/*
+ * HAL_oled_blit_byte() -- PROTOTYPE (row-major-framebuffer feasibility
+ * spike, not for merge). See docs/ or the PR description this ships with
+ * for the full row-major + transpose-on-flush design.
+ *
+ * Writes `bit_count` (1-8) consecutive horizontal pixels starting at
+ * (x, y) directly from one source byte's bits, MSB-first (bit 7 of
+ * `src_byte` is the pixel at x, bit 6 is x+1, ... bit (8-bit_count) is the
+ * last pixel written) -- this is the exact bit order gqc's uncompressed
+ * frame encoder uses (Frame.uncompressed_bytes(), `0b10000000 >> run`),
+ * so a fully-aligned, fully-visible 8-pixel span can be forwarded from the
+ * decoded cart byte straight into this call with NO per-pixel unpacking,
+ * unlike HAL_oled_fill_run() (which still costs one RMW per pixel/column
+ * on a page-major destination and gains nothing extra from 8 pixels
+ * sharing a source byte). This primitive exists specifically to give
+ * uncompressed (typically dithered) image content a near-memcpy draw path
+ * symmetric with RLE content's whole-byte-run fill, once the destination
+ * framebuffer is stored row-major (see sh1107.c's ROW_BUFFER()) -- on a
+ * page-major destination this call has no fast path available (still one
+ * RMW per bit) and is not meaningfully better than 8 calls to
+ * HAL_oled_fill_run(x+i, y, 1, bit_i).
+ *
+ * Contract with callers (oled.c):
+ *   - 1 <= bit_count <= 8.
+ *   - The caller has already verified [x, x + bit_count - 1] lies fully
+ *     within the active clip region and 0 <= y -- this primitive does NOT
+ *     clip or split a partially-visible span; callers fall back to
+ *     per-pixel HAL_oled_fill_run() calls for any span that needs
+ *     clipping. (Prototype scope: full clip-aware blit deferred; see PR
+ *     description.)
+ */
+void HAL_oled_blit_byte(int16_t x, int16_t y, uint8_t src_byte, uint8_t bit_count);
+
 void gq_draw_image(
     const Graphics_Context *context,
     t_gq_pointer image_bytes,

--- a/gamequeer/include/gq_perf.h
+++ b/gamequeer/include/gq_perf.h
@@ -19,6 +19,13 @@
  * before/after .map for a non-instrumented build (see the PR body for the
  * comparison).
  *
+ * NOTE: a SECOND, separate flag, GQ_PERF_INSTRUMENT_RUNS, gates only the
+ * two per-RUN sections (5 DRAW_DECODE, 6 DRAW_WRITE) independently of
+ * GQ_PERF_INSTRUMENT's other five per-draw/per-tick sections -- see that
+ * flag's own doc block further down for why (measurement-methodology tool:
+ * isolates per-run instrumentation overhead from the outer sections it
+ * would otherwise contaminate).
+ *
  * Defined: adds a small RAM stats struct (gq_perf_stats, currently 120 B --
  * an 8 B header plus 7 sections * 16 B each; see layout below) with
  * per-section count / accumulated-duration / min / max, in microseconds,
@@ -315,11 +322,77 @@ void gq_perf_record(gq_perf_section_id_t sec, gq_perf_time_t duration_us);
 #define GQ_PERF_ENTER(SEC) gq_perf_time_t _gq_perf_t0_##SEC = HAL_perf_now()
 #define GQ_PERF_EXIT(SEC)  gq_perf_record(GQ_PERF_SEC_##SEC, (gq_perf_time_t) (HAL_perf_now() - _gq_perf_t0_##SEC))
 
+/* -------------------------------------------------------------------------
+ * GQ_PERF_INSTRUMENT_RUNS -- opt-in, SEPARATE from GQ_PERF_INSTRUMENT.
+ * -------------------------------------------------------------------------
+ * Gates ONLY the per-RUN DRAW_DECODE (5) / DRAW_WRITE (6) ENTER/EXIT pairs
+ * in oled.c's gq_draw_image()/gq_draw_image_with_mask() run loops, via the
+ * GQ_PERF_ENTER_RUNS/GQ_PERF_EXIT_RUNS macros below. It exists to answer a
+ * measurement-methodology question that GQ_PERF_INSTRUMENT alone can't: how
+ * much overhead do those two HAL_perf_now() calls per RLE run add, and do
+ * they contaminate the ENCLOSING per-draw sections (0 DRAW_OLED_STACK, 1
+ * DRAW_ANIMATION_STACK)? On real hardware the run loop fires ~10-100x per
+ * tick and DRAW_DECODE/DRAW_WRITE can fire hundreds of thousands to
+ * millions of times over a measurement window (see the perf-investigation
+ * hardware notes), so their entry/exit overhead -- while individually tiny
+ * -- is large in aggregate and sits entirely inside sections 0/1's timed
+ * interval.
+ *
+ * This flag does NOT change gq_perf_stats's layout: it is still 8 B header
+ * + 7 * 16 B sections = 120 B either way (GQ_PERF_SECTION_LIST is
+ * unconditional -- see above), so a raw-memory SBW reader's byte-offset
+ * math is unaffected by whether this flag is set. When
+ * GQ_PERF_INSTRUMENT_RUNS is NOT defined, sections 5/6 simply never get a
+ * GQ_PERF_ENTER/EXIT call and stay all-zero (count/total_us/min_us/max_us
+ * == 0) for the life of the run -- easily distinguished in a dump from "ran
+ * but recorded nothing".
+ *
+ * Meaningless (and silently a no-op, not an error) unless
+ * GQ_PERF_INSTRUMENT is also defined: GQ_PERF_ENTER_RUNS/_EXIT_RUNS are
+ * defined below, inside the `#ifdef GQ_PERF_INSTRUMENT` block, precisely so
+ * that "RUNS but not INSTRUMENT" degrades to the same zero-cost no-op as
+ * plain "neither defined", rather than needing its own separate guard at
+ * every call site in oled.c.
+ *
+ * Two independent measurement configurations this enables, matching the
+ * build system's two flags:
+ *   GQ_PERF_INSTRUMENT only          -- sections 0-4 active, 5/6 compiled
+ *                                       out of the run loop entirely (no
+ *                                       HAL_perf_now() calls at all in the
+ *                                       hot loop). CLEAN draw_oled_stack /
+ *                                       draw_animation_stack timings, free
+ *                                       of per-run instrumentation
+ *                                       overhead.
+ *   GQ_PERF_INSTRUMENT +
+ *   GQ_PERF_INSTRUMENT_RUNS          -- all 7 sections active (today's
+ *                                       behavior prior to this flag's
+ *                                       introduction). Comparing this
+ *                                       configuration's sections 0/1
+ *                                       against the RUNS-off configuration's
+ *                                       sections 0/1, on the same fixture,
+ *                                       quantifies the per-run
+ *                                       instrumentation's contamination of
+ *                                       the enclosing per-draw timings.
+ * ---------------------------------------------------------------------- */
+
+#ifdef GQ_PERF_INSTRUMENT_RUNS
+#define GQ_PERF_ENTER_RUNS(SEC) GQ_PERF_ENTER(SEC)
+#define GQ_PERF_EXIT_RUNS(SEC)  GQ_PERF_EXIT(SEC)
+#else /* !GQ_PERF_INSTRUMENT_RUNS */
+#define GQ_PERF_ENTER_RUNS(SEC) ((void) 0)
+#define GQ_PERF_EXIT_RUNS(SEC)  ((void) 0)
+#endif /* GQ_PERF_INSTRUMENT_RUNS */
+
 #else /* !GQ_PERF_INSTRUMENT */
 
 /* Zero-cost: no declarations, no symbols, no stack slots. */
-#define GQ_PERF_ENTER(SEC) ((void) 0)
-#define GQ_PERF_EXIT(SEC)  ((void) 0)
+#define GQ_PERF_ENTER(SEC)      ((void) 0)
+#define GQ_PERF_EXIT(SEC)       ((void) 0)
+
+/* Same zero-cost no-op regardless of GQ_PERF_INSTRUMENT_RUNS: that flag is
+ * only meaningful nested inside GQ_PERF_INSTRUMENT (see above). */
+#define GQ_PERF_ENTER_RUNS(SEC) ((void) 0)
+#define GQ_PERF_EXIT_RUNS(SEC)  ((void) 0)
 
 #endif /* GQ_PERF_INSTRUMENT */
 

--- a/gamequeer/src/grlib_gfx_driver/grlib_gfx_driver.c
+++ b/gamequeer/src/grlib_gfx_driver/grlib_gfx_driver.c
@@ -64,6 +64,30 @@ void HAL_oled_fill_run(int16_t x, int16_t y, uint16_t length, uint8_t value) {
     }
 }
 
+/*
+ * HAL_oled_blit_byte() -- emulator implementation (PROTOTYPE; see the doc
+ * comment on its declaration in gamequeer.h). The emulator's frame_buffer
+ * is one byte per pixel (not bit-packed), so there is no row/page-major
+ * mismatch to exploit here -- this is a plain per-bit unpack-and-store
+ * loop, same cost as 8 HAL_oled_fill_run(x+i, y, 1, ...) calls. Provided
+ * only so shared oled.c code compiles and renders correctly on the
+ * emulator for a correctness sanity check; not a perf target on this
+ * platform (see HAL_oled_fill_run()'s matching note above).
+ */
+void HAL_oled_blit_byte(int16_t x, int16_t y, uint8_t src_byte, uint8_t bit_count) {
+    if (y < 0 || y >= OLED_VERTICAL_MAX || bit_count == 0 || bit_count > 8) {
+        return;
+    }
+    for (uint8_t i = 0; i < bit_count; i++) {
+        int16_t px = x + i;
+        if (px < 0 || px >= OLED_HORIZONTAL_MAX) {
+            continue;
+        }
+        uint8_t pixel       = (src_byte >> (7 - i)) & 0x01;
+        frame_buffer[px][y] = pixel;
+    }
+}
+
 static void gfx_driver_pixelDrawMultiple(
     void *displayData,
     int16_t x,

--- a/gamequeer/src/oled.c
+++ b/gamequeer/src/oled.c
@@ -158,6 +158,34 @@ static void gq_image_advance_run(gq_image_frame_on_screen *frame, uint16_t count
     }
 }
 
+/*
+ * gq_image_advance_byte() -- PROTOTYPE (row-major-framebuffer feasibility
+ * spike, not for merge). Fast-path advance for gq_draw_image()'s
+ * uncompressed byte-blit case below: consumes exactly 8 pixels (one full
+ * decoded source byte) in one call, equivalent to calling
+ * gq_image_advance_run(frame, 1) eight times in a row for an
+ * rle_type == 1 frame that starts byte-aligned (frame->x_bit_offset == 0
+ * on entry, which the caller's guard already ensures). Skips the
+ * per-pixel x_bit_offset increment/compare loop that eight individual
+ * gq_image_advance_run() calls would otherwise pay.
+ */
+static void gq_image_advance_byte(gq_image_frame_on_screen *frame) {
+    frame->byte_index++;
+    frame->x_pixel_offset = (uint16_t) (frame->x_pixel_offset + 8);
+
+    if (frame->x_pixel_offset >= (uint16_t) frame->width) {
+        frame->y_curr++;
+        frame->x_pixel_offset = 0;
+    }
+
+    // A full source byte was just consumed -- always load the next one
+    // (mirrors gq_image_advance_run()'s need_to_read_byte == 1 case for
+    // rle_type == 1, which is unconditional there too).
+    if (!gq_image_done(frame)) {
+        gq_image_load_byte(frame);
+    }
+}
+
 void gq_load_image(
     t_gq_pointer image_bytes,
     int16_t bPP,
@@ -229,6 +257,36 @@ void gq_draw_image(
         int16_t draw_x = x + frame.x_pixel_offset;
         int16_t draw_y = y + frame.y_curr;
 
+        // PROTOTYPE fast path (row-major framebuffer spike, not for
+        // merge): an uncompressed source byte that is (a) currently
+        // byte-aligned in the decode stream, (b) entirely within the
+        // current image row, and (c) entirely within the clip region
+        // can be forwarded straight from the decoded cart byte to the
+        // framebuffer in one call, skipping the generic one-pixel-at-a-
+        // time peek/advance/write path below entirely. This is the
+        // "near-memcpy" draw path uncompressed/dithered content needs to
+        // reach uniform cost with RLE/flat content -- see
+        // HAL_oled_blit_byte()'s doc comment (gamequeer.h) for why this
+        // is only a real win once the destination framebuffer is
+        // row-major. Falls through to the general per-run path for RLE
+        // content and any row/clip edge that doesn't satisfy all three
+        // conditions -- correctness for those cases is unchanged from
+        // before this prototype.
+        if (frame.rle_type == 1 && frame.x_bit_offset == 0 &&
+            (uint16_t) (frame.x_pixel_offset + 8) <= (uint16_t) frame.width && draw_y >= context->clipRegion.yMin &&
+            draw_y <= context->clipRegion.yMax && draw_x >= context->clipRegion.xMin &&
+            (draw_x + 7) <= context->clipRegion.xMax) {
+            GQ_PERF_ENTER(DRAW_DECODE);
+            uint8_t src_byte = frame.render_byte;
+            gq_image_advance_byte(&frame);
+            GQ_PERF_EXIT(DRAW_DECODE);
+
+            GQ_PERF_ENTER(DRAW_WRITE);
+            HAL_oled_blit_byte(draw_x, draw_y, src_byte, 8);
+            GQ_PERF_EXIT(DRAW_WRITE);
+            continue;
+        }
+
         uint16_t run_avail;
         GQ_PERF_ENTER(DRAW_DECODE);
         uint8_t draw_pixel = gq_image_peek_run(&frame, &run_avail);
@@ -264,6 +322,23 @@ void gq_draw_image(
     }
 }
 
+/*
+ * PROTOTYPE scope note (row-major-framebuffer feasibility spike, not for
+ * merge): unlike gq_draw_image() above, this function does NOT get the
+ * uncompressed byte-blit fast path. The image and mask streams are
+ * independently RLE-encoded and can fall out of byte-alignment with each
+ * other even when both happen to be uncompressed (e.g. a mid-row clip or
+ * a mismatched run boundary), and merging two full source bytes through
+ * the mask correctly needs its own bitwise-AND/OR merge primitive that
+ * isn't implemented here. Masked draws still benefit from the row-major
+ * HAL_oled_fill_run() below being whole-byte-fast for RLE runs; they just
+ * don't get the near-memcpy path for uncompressed/dithered masked
+ * sprites. Flagged as a deferred follow-up, not attempted in this
+ * prototype -- the primary measurement target (uniformity across
+ * flat/dithered content) is the unmasked animation background path,
+ * which is what draw_animation_stack() actually exercises for
+ * tutorial_1.gq's dithered "pop" animation.
+ */
 void gq_draw_image_with_mask(
     const Graphics_Context *context,
     t_gq_pointer image_bytes,

--- a/gamequeer/src/oled.c
+++ b/gamequeer/src/oled.c
@@ -230,10 +230,10 @@ void gq_draw_image(
         int16_t draw_y = y + frame.y_curr;
 
         uint16_t run_avail;
-        GQ_PERF_ENTER(DRAW_DECODE);
+        GQ_PERF_ENTER_RUNS(DRAW_DECODE);
         uint8_t draw_pixel = gq_image_peek_run(&frame, &run_avail);
         gq_image_advance_run(&frame, run_avail);
-        GQ_PERF_EXIT(DRAW_DECODE);
+        GQ_PERF_EXIT_RUNS(DRAW_DECODE);
 
         // Vertical clip: matches the original per-pixel check, which only
         // ever tested draw_y >= yMin -- the upper bound is already enforced
@@ -257,9 +257,9 @@ void gq_draw_image(
             seg_len = context->clipRegion.xMax - seg_x0 + 1;
         }
         if (seg_len > 0) {
-            GQ_PERF_ENTER(DRAW_WRITE);
+            GQ_PERF_ENTER_RUNS(DRAW_WRITE);
             HAL_oled_fill_run(seg_x0, draw_y, (uint16_t) seg_len, (uint8_t) palette[draw_pixel]);
-            GQ_PERF_EXIT(DRAW_WRITE);
+            GQ_PERF_EXIT_RUNS(DRAW_WRITE);
         }
     }
 }
@@ -302,14 +302,14 @@ void gq_draw_image_with_mask(
         // (or row) ends first; within that shared run, both the image
         // value and the mask value are constant.
         uint16_t image_avail, mask_avail;
-        GQ_PERF_ENTER(DRAW_DECODE);
+        GQ_PERF_ENTER_RUNS(DRAW_DECODE);
         uint8_t image_pixel = gq_image_peek_run(&image_frame, &image_avail);
         uint8_t mask_pixel  = gq_image_peek_run(&mask_frame, &mask_avail);
         uint16_t run_avail  = image_avail < mask_avail ? image_avail : mask_avail;
 
         gq_image_advance_run(&image_frame, run_avail);
         gq_image_advance_run(&mask_frame, run_avail);
-        GQ_PERF_EXIT(DRAW_DECODE);
+        GQ_PERF_EXIT_RUNS(DRAW_DECODE);
 
         // Transparent (mask=0) run: nothing to draw, same as the original
         // per-pixel path which never called Graphics_drawPixelOnDisplay()
@@ -335,9 +335,9 @@ void gq_draw_image_with_mask(
             seg_len = context->clipRegion.xMax - seg_x0 + 1;
         }
         if (seg_len > 0) {
-            GQ_PERF_ENTER(DRAW_WRITE);
+            GQ_PERF_ENTER_RUNS(DRAW_WRITE);
             HAL_oled_fill_run(seg_x0, draw_y, (uint16_t) seg_len, (uint8_t) palette[image_pixel]);
-            GQ_PERF_EXIT(DRAW_WRITE);
+            GQ_PERF_EXIT_RUNS(DRAW_WRITE);
         }
     }
 }

--- a/gamequeer/tests/CMakeLists.txt
+++ b/gamequeer/tests/CMakeLists.txt
@@ -211,7 +211,19 @@ add_golden_test(golden_framebuffer_anim_advance_frame2 anim_advance
 # the same run: two different instrumentation mechanisms measuring the same
 # event, which is a cheap sanity check that GQ_PERF_ENTER/EXIT is wired up
 # correctly around draw_oled_stack(). See run_perf_draw_count_cross_check.cmake.
+# EXPECT_RUNS_INSTRUMENTED also tells the script whether to additionally
+# assert on the draw_decode section's zero/nonzero state, which is a direct
+# check that GQ_PERF_INSTRUMENT_RUNS (see include/gq_perf.h) is wired up:
+# draw_decode must be all-zero when GQ_PERF_INSTRUMENT_RUNS is OFF (its
+# GQ_PERF_ENTER_RUNS/EXIT_RUNS calls compile out) and nonzero when it's ON,
+# for the same anim_advance.gqgame fixture, which does draw RLE-encoded
+# content and so is guaranteed to hit the run loop at least once.
 if(GQ_PERF_INSTRUMENT)
+    if(GQ_PERF_INSTRUMENT_RUNS)
+        set(_expect_runs_instrumented ON)
+    else()
+        set(_expect_runs_instrumented OFF)
+    endif()
     add_test(
         NAME perf_draw_count_cross_check
         COMMAND
@@ -221,6 +233,7 @@ if(GQ_PERF_INSTRUMENT)
             -DDRAW_COUNT=${CMAKE_CURRENT_BINARY_DIR}/perf_draw_count_cross_check_drawcount.txt
             -DPERF_DUMP=${CMAKE_CURRENT_BINARY_DIR}/perf_draw_count_cross_check_perfdump.txt
             -DTICKS=43
+            -DEXPECT_RUNS_INSTRUMENTED=${_expect_runs_instrumented}
             -P "${CMAKE_CURRENT_SOURCE_DIR}/run_perf_draw_count_cross_check.cmake"
     )
 endif()

--- a/gamequeer/tests/run_perf_draw_count_cross_check.cmake
+++ b/gamequeer/tests/run_perf_draw_count_cross_check.cmake
@@ -10,16 +10,28 @@
 # only registered) in a build configured with both GQ_HEADLESS=ON and
 # GQ_PERF_INSTRUMENT=ON.
 #
+# Also asserts on the draw_decode section's zero/nonzero state as a direct
+# check that GQ_PERF_INSTRUMENT_RUNS (see include/gq_perf.h) is wired up
+# correctly -- draw_decode's GQ_PERF_ENTER_RUNS/EXIT_RUNS calls compile out
+# entirely when GQ_PERF_INSTRUMENT_RUNS is OFF, so its count must be exactly
+# 0 in that configuration and nonzero when GQ_PERF_INSTRUMENT_RUNS is ON,
+# for the same fixture/tick count (anim_advance.gqgame is guaranteed to
+# exercise the RLE run loop at least once by TICKS=43).
+#
 # Parameters (passed via -D):
-#   EXE          — path to the headless+perf-instrumented gamequeer binary
-#   FIXTURE      — path to the .gqgame cart fixture
-#   DRAW_COUNT   — path where the --draw-count-out output will be written
-#   PERF_DUMP    — path where the --perf-dump output will be written
-#   TICKS        — number of system_tick iterations to run
+#   EXE                     — path to the headless+perf-instrumented gamequeer binary
+#   FIXTURE                 — path to the .gqgame cart fixture
+#   DRAW_COUNT              — path where the --draw-count-out output will be written
+#   PERF_DUMP               — path where the --perf-dump output will be written
+#   TICKS                   — number of system_tick iterations to run
+#   EXPECT_RUNS_INSTRUMENTED — ON if this build has GQ_PERF_INSTRUMENT_RUNS
+#                              defined (draw_decode expected nonzero), OFF
+#                              otherwise (draw_decode expected exactly 0)
 #
 # Exits with FATAL_ERROR if the emulator fails, either output is missing,
-# the perf-dump's draw_oled_stack count line can't be parsed, or the two
-# counts disagree.
+# the perf-dump's draw_oled_stack count line can't be parsed, the two
+# draw_oled_stack counts disagree, or draw_decode's zero/nonzero state
+# doesn't match EXPECT_RUNS_INSTRUMENTED.
 
 cmake_minimum_required(VERSION 3.18)
 
@@ -83,3 +95,33 @@ if(NOT draw_count EQUAL perf_count)
 endif()
 
 message(STATUS "Perf/draw-count cross-check PASSED (both report ${draw_count} draw_oled_stack() call(s))")
+
+# ---- 5. Cross-check draw_decode's zero/nonzero state against
+#         EXPECT_RUNS_INSTRUMENTED (GQ_PERF_INSTRUMENT_RUNS wiring check) --
+
+string(REGEX MATCH "draw_decode[ \t]+count=([0-9]+)" decode_match "${perf_dump_contents}")
+if(NOT decode_match)
+    message(FATAL_ERROR
+        "Could not find a 'draw_decode count=<N>' line in perf-dump output:\n"
+        "${perf_dump_contents}"
+    )
+endif()
+set(decode_count "${CMAKE_MATCH_1}")
+
+if(EXPECT_RUNS_INSTRUMENTED)
+    if(decode_count EQUAL 0)
+        message(FATAL_ERROR
+            "GQ_PERF_INSTRUMENT_RUNS is ON but draw_decode count is 0 -- "
+            "GQ_PERF_ENTER_RUNS/EXIT_RUNS(DRAW_DECODE) does not appear to be firing."
+        )
+    endif()
+    message(STATUS "draw_decode count=${decode_count} (nonzero, as expected with GQ_PERF_INSTRUMENT_RUNS=ON)")
+else()
+    if(NOT decode_count EQUAL 0)
+        message(FATAL_ERROR
+            "GQ_PERF_INSTRUMENT_RUNS is OFF but draw_decode count is ${decode_count} (expected 0) -- "
+            "GQ_PERF_ENTER_RUNS/EXIT_RUNS(DRAW_DECODE) appears to still be firing."
+        )
+    endif()
+    message(STATUS "draw_decode count=0 (as expected with GQ_PERF_INSTRUMENT_RUNS=OFF)")
+endif()


### PR DESCRIPTION
## PROTOTYPE -- feasibility spike, DO NOT MERGE

This is throwaway measurement code for a go/no-go decision on redesigning the
badge's framebuffer as row-major (matching gqc's cart image byte packing)
with transpose-at-flush, instead of the current page-major-only layout that
makes issue #261's run-blit fix content-dependent (flat frames ~29 ms,
dithered/uncompressed frames ~395 ms).

## What this does

Adds a new fast path in `gq_draw_image()`: a fully-aligned, fully-visible
8-pixel span of **uncompressed** source data is forwarded straight from the
decoded cart byte to the framebuffer via a new `HAL_oled_blit_byte()`
primitive, instead of the existing one-pixel-at-a-time peek/advance/write
loop. This is only a real win once the destination framebuffer is row-major
-- see the counterpart firmware PR (`duplico/qc2024`, branch
`george/rowmajor-fb-proto-1784087654`) for the `sh1107.c` side.

- `gq_draw_image_with_mask()` is explicitly **out of scope** for this pass
  (see its doc comment) -- masked draws still benefit from the row-major
  `HAL_oled_fill_run()` being whole-byte-fast for RLE runs, just not the
  near-memcpy path for uncompressed masked sprites.
- Cart image format (`.gqgame`) is **unchanged** -- this only changes how
  the VM decodes/dispatches already-existing uncompressed/RLE bytes.
- Emulator (`grlib_gfx_driver.c`) gets a correctness-only trivial
  implementation of `HAL_oled_blit_byte()` (per-bit loop) -- not a perf
  target there, since the emulator's framebuffer is one byte per pixel
  already (no row/page-major mismatch to exploit).

## Verification

- `make test-headless`: **12/12 golden tests pass**, including the dithered
  `anim_advance` fixture and both `mask_encoding_a`/`_b` fixtures --
  validates this shared decode-path logic is pixel-identical to before.
- `clang-format` applied per `.clang-format`.
- No CCS/hardware build from this repo (that's the firmware PR).

## Lockstep

No bytecode/struct changes -- `gqc` is unaffected.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>