### PR TITLE
fix(gq_perf): drop implausible duration_us samples in gq_perf_record()

### DIFF
--- a/gamequeer/include/gq_perf.h
+++ b/gamequeer/include/gq_perf.h
@@ -100,15 +100,16 @@
  * correctness issue: failure paths are rare (cart read failure) and are
  * not the hot path this instrumentation targets.
  *
- * NOTE (implausible-sample clamp): gq_perf_record() drops, rather than
+ * NOTE (implausible-sample drop): gq_perf_record() drops, rather than
  * clamps the value of, any single duration_us sample exceeding
- * GQ_PERF_MAX_PLAUSIBLE_US (defined just above gq_perf_time_t below) --
- * count/total_us/min_us/max_us are all left untouched for that call, same
- * as the early-return-failure-path case just above. This guards against a
- * garbage HAL_perf_now() delta (root-caused to a firmware timing-source
- * race, fixed separately) silently poisoning total_us/max_us with a
- * ~2^32 us outlier; the resulting under-report of that one call is the same
- * accepted limitation as the failure-path case, not a correctness issue.
+ * GQ_PERF_MAX_PLAUSIBLE_US (defined just below the gq_perf_time_t typedef,
+ * further down in this header) -- count/total_us/min_us/max_us are all left
+ * untouched for that call, same as the early-return-failure-path case just
+ * above. This guards against a garbage HAL_perf_now() delta (root-caused
+ * to a firmware timing-source race, fixed separately) silently poisoning
+ * total_us/max_us with a ~2^32 us outlier; the resulting under-report of
+ * that one call is the same accepted limitation as the failure-path case,
+ * not a correctness issue.
  *
  * -------------------------------------------------------------------------
  * Struct layout (GQ_PERF_INSTRUMENT defined):
@@ -338,7 +339,7 @@ gq_perf_time_t HAL_perf_now(void);
  * duration_us above GQ_PERF_MAX_PLAUSIBLE_US is dropped, not clamped: the
  * sample is discarded and count/total_us/min_us/max_us are all left
  * unchanged, rather than folding an implausible value into the
- * accumulators at the ceiling. See the implausible-sample-clamp NOTE above
+ * accumulators at the ceiling. See the implausible-sample-drop NOTE above
  * for the rationale and threshold. */
 void gq_perf_record(gq_perf_section_id_t sec, gq_perf_time_t duration_us);
 

--- a/gamequeer/include/gq_perf.h
+++ b/gamequeer/include/gq_perf.h
@@ -100,6 +100,16 @@
  * correctness issue: failure paths are rare (cart read failure) and are
  * not the hot path this instrumentation targets.
  *
+ * NOTE (implausible-sample clamp): gq_perf_record() drops, rather than
+ * clamps the value of, any single duration_us sample exceeding
+ * GQ_PERF_MAX_PLAUSIBLE_US (defined just above gq_perf_time_t below) --
+ * count/total_us/min_us/max_us are all left untouched for that call, same
+ * as the early-return-failure-path case just above. This guards against a
+ * garbage HAL_perf_now() delta (root-caused to a firmware timing-source
+ * race, fixed separately) silently poisoning total_us/max_us with a
+ * ~2^32 us outlier; the resulting under-report of that one call is the same
+ * accepted limitation as the failure-path case, not a correctness issue.
+ *
  * -------------------------------------------------------------------------
  * Struct layout (GQ_PERF_INSTRUMENT defined):
  * -------------------------------------------------------------------------
@@ -280,6 +290,18 @@ typedef enum {
 /* Microseconds; see the timer-width design note above for why uint32_t. */
 typedef uint32_t gq_perf_time_t;
 
+/* Plausibility ceiling for a single gq_perf_record() sample, in
+ * microseconds. Defense-in-depth against a garbage HAL_perf_now() delta
+ * (e.g. a firmware timing-source race producing a near-2^32 us reading,
+ * ~4.2e9 us) silently poisoning a section's total_us/max_us forever -- see
+ * gq_perf_record()'s comment for how samples above this ceiling are
+ * handled. 1 second is ~20x the largest plausible *real* interval (a
+ * HANDLE_EVENTS section containing a full DRAW_OLED_STACK pass with a
+ * masked-sprite redraw, per the ~50 ms upper end in the timer-width note
+ * above) and ~4000x below a garbage ~2^32 us reading, leaving a wide,
+ * unambiguous margin between the two. */
+#define GQ_PERF_MAX_PLAUSIBLE_US 1000000u
+
 typedef struct {
     uint32_t count;
     uint32_t total_us;
@@ -311,7 +333,13 @@ gq_perf_time_t HAL_perf_now(void);
  * wrap on an extremely long-running instrumented session (e.g. billions of
  * microseconds -- over an hour of continuous max-rate section entries);
  * this is a development/measurement build, not a production counter, so
- * that is treated as an accepted limitation rather than guarded against. */
+ * that is treated as an accepted limitation rather than guarded against.
+ *
+ * duration_us above GQ_PERF_MAX_PLAUSIBLE_US is dropped, not clamped: the
+ * sample is discarded and count/total_us/min_us/max_us are all left
+ * unchanged, rather than folding an implausible value into the
+ * accumulators at the ceiling. See the implausible-sample-clamp NOTE above
+ * for the rationale and threshold. */
 void gq_perf_record(gq_perf_section_id_t sec, gq_perf_time_t duration_us);
 
 /* GQ_PERF_ENTER(SEC)/GQ_PERF_EXIT(SEC) must appear as a matched pair in the

--- a/gamequeer/src/gq_perf.c
+++ b/gamequeer/src/gq_perf.c
@@ -29,7 +29,7 @@ void gq_perf_record(gq_perf_section_id_t sec, gq_perf_time_t duration_us) {
     /* Defense-in-depth: drop implausible samples (e.g. a garbage
      * HAL_perf_now() delta from a firmware timing-source race) before they
      * can poison this section's accumulators. See gq_perf.h's
-     * implausible-sample-clamp NOTE and GQ_PERF_MAX_PLAUSIBLE_US for the
+     * implausible-sample-drop NOTE and GQ_PERF_MAX_PLAUSIBLE_US for the
      * threshold and rationale. Dropped, not clamped: count/total_us/min_us/
      * max_us are all left untouched for this call. */
     if (duration_us > GQ_PERF_MAX_PLAUSIBLE_US) {

--- a/gamequeer/src/gq_perf.c
+++ b/gamequeer/src/gq_perf.c
@@ -26,6 +26,16 @@ const char *const gq_perf_section_names[GQ_PERF_SEC_COUNT] = {
 };
 
 void gq_perf_record(gq_perf_section_id_t sec, gq_perf_time_t duration_us) {
+    /* Defense-in-depth: drop implausible samples (e.g. a garbage
+     * HAL_perf_now() delta from a firmware timing-source race) before they
+     * can poison this section's accumulators. See gq_perf.h's
+     * implausible-sample-clamp NOTE and GQ_PERF_MAX_PLAUSIBLE_US for the
+     * threshold and rationale. Dropped, not clamped: count/total_us/min_us/
+     * max_us are all left untouched for this call. */
+    if (duration_us > GQ_PERF_MAX_PLAUSIBLE_US) {
+        return;
+    }
+
     gq_perf_section_t *s = &gq_perf_stats.sections[sec];
     s->count++;
     s->total_us += duration_us;


### PR DESCRIPTION
## Summary

Defense-in-depth fix for `GQ_PERF_INSTRUMENT` stats trustworthiness. On
hardware, a single bogus ~4.27e9 us (~2^32) duration sample has been
observed poisoning a section's `total_us` and `max_us` forever (while
`count` and `min_us` stay sane). The real root cause is a firmware
timing-source race being fixed separately (out of scope for this PR); this
change makes `gq_perf_record()` itself robust to any single bad
`HAL_perf_now()` delta, on either platform (firmware or emulator).

- `gq_perf_record(sec, duration_us)` now drops (does not clamp the value
  of) any sample exceeding a new `GQ_PERF_MAX_PLAUSIBLE_US` ceiling
  (1,000,000 us / 1 second), defined in `gq_perf.h` next to the
  `gq_perf_time_t` typedef. Dropped samples leave `count`, `total_us`,
  `min_us`, and `max_us` completely untouched -- matching the header's
  existing documented philosophy for early-return failure paths ("this
  section's count/total under-reports failure-path calls... an accepted
  limitation for a profiling aid, not a correctness issue").
- Threshold rationale: the largest plausible *real* interval (a
  `HANDLE_EVENTS` section containing a full `DRAW_OLED_STACK` pass with a
  masked-sprite redraw) is documented at ~50 ms in the header's
  timer-width design note. 1 second gives ~20x headroom over that, while
  staying ~4000x below a garbage ~2^32 us reading -- a wide, unambiguous
  margin between real and garbage.
- Struct layout, size (120 B), and `GQ_PERF_VERSION` are **unchanged** --
  this is purely a guard inside `gq_perf_record()` plus one `#define`, so
  a raw-memory SBW reader is unaffected.
- Both the function-comment in `gq_perf.h` and the big design-note block
  (next to the existing early-return-failure-path NOTE) were updated to
  document the clamp behavior and threshold.
- All of this is inside the existing `#ifdef GQ_PERF_INSTRUMENT` guard, so
  a non-instrumented build remains zero-cost (no new symbols/code).

## Test plan

- [x] `cmake -B build-headless -DGQ_HEADLESS=ON && cmake --build build-headless` (non-instrumented) -- `ctest`: 23/23 golden-framebuffer tests pass.
- [x] `cmake -B build-perf -DGQ_HEADLESS=ON -DGQ_PERF_INSTRUMENT=ON -DGQ_PERF_INSTRUMENT_RUNS=ON && cmake --build build-perf` -- `ctest`: 24/24 tests pass (includes `perf_draw_count_cross_check`), confirming the clamp is a no-op for all real samples produced by the golden suite.
- [x] Standalone assertion harness linking `gq_perf.c` directly (`gcc -DGQ_PERF_INSTRUMENT`) verifying: normal samples accumulate correctly; an implausible ~2^32 us sample is dropped with zero effect on `count`/`total_us`/`min_us`/`max_us` (including as the very first sample ever recorded for a section, where the `count==1` seed logic could otherwise be corrupted); the exact ceiling value (`GQ_PERF_MAX_PLAUSIBLE_US`) is still accepted; one microsecond over the ceiling is dropped.
- [x] `clang-format --dry-run --Werror` clean on both changed files.

AI disclosure: implemented with Claude Sonnet 5 via Claude Code.