### PR TITLE
perf(oled): row-level decode advance for uncompressed rows

### DIFF
--- a/gamequeer/src/oled.c
+++ b/gamequeer/src/oled.c
@@ -187,6 +187,45 @@ static void gq_image_advance_byte(gq_image_frame_on_screen *frame) {
     }
 }
 
+/*
+ * gq_image_advance_row() -- row-level advance for gq_draw_image()'s
+ * row-level uncompressed fast path (issue #308, finishing what #303's row
+ * blit started): produces exactly the frame state that calling
+ * gq_image_advance_byte() `nbytes` times in a row would produce, in one
+ * bookkeeping update instead of a per-byte loop.
+ *
+ * Only valid under the same preconditions as the row fast path's own guard
+ * (gq_draw_image()): frame->x_bit_offset == 0 and frame->x_pixel_offset ==
+ * 0 on entry, frame->rle_type == 1, `nbytes` == frame->width / 8 (i.e. the
+ * call covers one *entire* row), and the row's bytes don't straddle an
+ * image_buffer reload boundary (frame->byte_index + nbytes <=
+ * IMAGE_BUFFER_SIZE, checked by the caller). Given those, only the very
+ * LAST of the nbytes individual gq_image_advance_byte() calls can ever (a)
+ * push x_pixel_offset to width (every earlier call adds 8 short of that,
+ * since nbytes * 8 == width) or (b) push byte_index to a multiple of
+ * IMAGE_BUFFER_SIZE and trigger gq_image_load_buffer() (every earlier
+ * call's byte_index is strictly between the row's starting byte_index and
+ * that boundary, per the caller's guard) -- so row-end and any chunk
+ * reload happen at exactly the same point in the stream as the per-byte
+ * loop, just computed directly instead of discovered one byte at a time.
+ * The intermediate calls' only other effect -- re-reading (and discarding)
+ * frame->render_byte from image_buffer -- is unobservable here, since
+ * nothing reads render_byte until the next decode step after this row
+ * finishes, so those calls are skipped entirely.
+ */
+static void gq_image_advance_row(gq_image_frame_on_screen *frame, uint16_t nbytes) {
+    frame->byte_index     = (uint16_t) (frame->byte_index + nbytes);
+    frame->x_pixel_offset = 0;
+    frame->y_curr++;
+
+    // Same as gq_image_advance_byte()'s final iteration: load the next
+    // source byte (possibly triggering a chunk reload) unless the frame is
+    // now fully drawn.
+    if (!gq_image_done(frame)) {
+        gq_image_load_byte(frame);
+    }
+}
+
 void gq_load_image(
     t_gq_pointer image_bytes,
     int16_t bPP,
@@ -267,19 +306,19 @@ void gq_draw_image(
         // drawn past the image's right edge) and the *entire* row lies
         // within the clip region, forward the whole row in one
         // HAL_oled_blit_row() call instead of nbytes individual
-        // HAL_oled_blit_byte() calls (the fast path just below this one).
-        // Falls through to that byte-level fast path (and ultimately the
-        // generic per-run path) for any row that doesn't qualify --
-        // narrower images, a row straddling the clip region's left/right
-        // edge, or (defensively) a row whose bytes straddle an
-        // image_buffer reload boundary. The frame.width > 0 check matters
-        // even though gqc can't emit a zero-width image today: without it,
-        // width == 0 satisfies width % 8 == 0 trivially, nbytes would be 0,
-        // the gq_image_advance_byte() loop below would run zero times (so
-        // frame.x_pixel_offset/y_curr never advance), and the outer while
-        // loop would spin on this same branch forever -- HAL_oled_blit_row()
-        // itself is documented to require nbytes >= 1, and this is the only
-        // caller, so the guard belongs here.
+        // HAL_oled_blit_byte() calls (the fast path just below this one),
+        // and decode-advance the whole row in one gq_image_advance_row()
+        // call (issue #308) instead of nbytes individual
+        // gq_image_advance_byte() calls. Falls through to that byte-level
+        // fast path (and ultimately the generic per-run path) for any row
+        // that doesn't qualify -- narrower images, a row straddling the
+        // clip region's left/right edge, or (defensively) a row whose bytes
+        // straddle an image_buffer reload boundary. The frame.width > 0
+        // check matters even though gqc can't emit a zero-width image
+        // today: without it, width == 0 satisfies width % 8 == 0 trivially
+        // and nbytes would be 0 -- HAL_oled_blit_row() itself is documented
+        // to require nbytes >= 1, and this is the only caller, so the guard
+        // belongs here.
         if (frame.rle_type == 1 && frame.x_bit_offset == 0 && frame.x_pixel_offset == 0 && frame.width > 0 &&
             ((uint16_t) frame.width % 8) == 0 && draw_y >= context->clipRegion.yMin &&
             draw_y <= context->clipRegion.yMax && draw_x >= context->clipRegion.xMin &&
@@ -296,19 +335,16 @@ void gq_draw_image(
             // path's guard comment above.
             if ((uint32_t) row_index + nbytes <= IMAGE_BUFFER_SIZE) {
                 // Read the row's bytes out of image_buffer (via the HAL
-                // call) BEFORE decode-advancing: the last
-                // gq_image_advance_byte() call below may trigger
-                // gq_image_load_buffer(), which overwrites image_buffer in
-                // place with the next cart chunk -- so the source bytes
-                // must be consumed first.
+                // call) BEFORE decode-advancing: gq_image_advance_row()
+                // below may trigger gq_image_load_buffer(), which
+                // overwrites image_buffer in place with the next cart
+                // chunk -- so the source bytes must be consumed first.
                 GQ_PERF_ENTER_RUNS(DRAW_WRITE);
                 HAL_oled_blit_row(draw_x, draw_y, &frame.image_buffer[row_index], nbytes);
                 GQ_PERF_EXIT_RUNS(DRAW_WRITE);
 
                 GQ_PERF_ENTER_RUNS(DRAW_DECODE);
-                for (uint16_t i = 0; i < nbytes; i++) {
-                    gq_image_advance_byte(&frame);
-                }
+                gq_image_advance_row(&frame, nbytes);
                 GQ_PERF_EXIT_RUNS(DRAW_DECODE);
                 continue;
             }

--- a/gamequeer/tests/CMakeLists.txt
+++ b/gamequeer/tests/CMakeLists.txt
@@ -389,5 +389,35 @@ if(GQ_PERF_INSTRUMENT)
                 -DEXPECTED=128
                 -P "${CMAKE_CURRENT_SOURCE_DIR}/run_perf_section_count_test.cmake"
         )
+
+        # ---- perf_row_blit_draw_decode_count: same idea, DRAW_DECODE ------
+        # gamequeer#308 replaced the row fast path's per-byte
+        # gq_image_advance_byte() loop with a single gq_image_advance_row()
+        # call, but GQ_PERF_ENTER_RUNS(DRAW_DECODE)/EXIT_RUNS(DRAW_DECODE)
+        # already wrapped that whole loop (once per row, not once per byte)
+        # even before #308 -- so DRAW_DECODE's *count* doesn't drop from
+        # this change (only its accumulated total_us does, since there's
+        # much less to do inside each row's single ENTER/EXIT interval).
+        # What EXPECTED=128 (matching DRAW_WRITE, not 2048) still proves is
+        # engagement of the row path at all: if the row path's guard ever
+        # regresses and every row silently falls back to the byte-aligned
+        # fast path just below it (gamequeer#295), THAT path wraps
+        # GQ_PERF_ENTER_RUNS(DRAW_DECODE)/EXIT_RUNS(DRAW_DECODE) once per
+        # BYTE, so full_frame_row_blit.gqgame's 128x128 image (16 bytes/row)
+        # would drive the count to 2048 instead of 128 -- the same
+        # row-vs-byte-granularity signal DRAW_WRITE already gives, just
+        # from the decode side instead of the write side.
+        add_test(
+            NAME perf_row_blit_draw_decode_count
+            COMMAND
+                ${CMAKE_COMMAND}
+                -DEXE=$<TARGET_FILE:gamequeer>
+                -DFIXTURE=${GOLDEN_DIR}/full_frame_row_blit.gqgame
+                -DPERF_DUMP=${CMAKE_CURRENT_BINARY_DIR}/perf_row_blit_draw_decode_count_perfdump.txt
+                -DTICKS=${GOLDEN_TICKS}
+                -DSECTION=draw_decode
+                -DEXPECTED=128
+                -P "${CMAKE_CURRENT_SOURCE_DIR}/run_perf_section_count_test.cmake"
+        )
     endif()
 endif()


### PR DESCRIPTION
## Summary

Finishes what https://github.com/duplico/gamequeer/pull/306 started. That PR's
row-level uncompressed blit fast path (`gq_draw_image`, `oled.c`) forwards a whole
row to `HAL_oled_blit_row()` in one call, but still advanced the decode state one
source byte at a time via a `gq_image_advance_byte()` loop. Hardware A/B on
`perf_dither` (MSP430FR2476, 120 s windows, clean `GQ_PERF_INSTRUMENT`) showed only
~5 ms of the remaining 29.34 ms/frame draw time was real cart SPI (2 x 1024 B chunk
reads); the other ~24 ms was per-byte advance arithmetic and loop guards (~12 us x
2048 iterations).

This PR replaces the loop with `gq_image_advance_row()`: a single bookkeeping
update that advances `byte_index` by `nbytes` and `x_pixel_offset`/`y_curr` by one
row, in one call instead of `nbytes` individual `gq_image_advance_byte()` calls.
It reproduces exactly the frame state the per-byte loop would have left, including
triggering an `image_buffer` chunk reload at the same point in the stream -- a
qualifying row never straddles a reload boundary (the existing call-site guard,
`row_index + nbytes <= IMAGE_BUFFER_SIZE`, already checks this rather than assuming
it), so only the *last* of the `nbytes` per-byte calls could ever trigger row-end
or a reload -- the intermediate calls only re-read (and discard) an unused
`render_byte`. See the new function's doc comment in `oled.c` for the full
argument.

Only the row fast path (`gq_draw_image`) is touched. The masked path
(`gq_draw_image_with_mask`) is out of scope -- a masked row blit is a separate,
unmeasured follow-up (https://github.com/duplico/gamequeer/issues/309).

## Perf instrumentation

Added `perf_row_blit_draw_decode_count` alongside the existing
`perf_row_blit_draw_write_count` (from #306) under `GQ_PERF_INSTRUMENT_RUNS`.

**Important nuance, verified empirically (not assumed):** `DRAW_DECODE`'s section
*count* does **not** change from this PR -- it's asserted at `EXPECTED=128` both
before and after, because `GQ_PERF_ENTER_RUNS(DRAW_DECODE)`/`EXIT_RUNS(DRAW_DECODE)`
already wrapped the *entire* per-byte loop as one interval (once per row, not once
per byte) even in #306's original code. I confirmed this by dumping
`--perf-dump` for `full_frame_row_blit.gqgame` against the pre-this-PR code:
`draw_decode count=128 total_us=16` (baseline) vs. `draw_decode count=128
total_us=8` (this PR) -- same count, roughly half the accumulated time on a noisy
x86 host clock. So this test isn't a before/after discriminator for *this specific*
refactor; what `EXPECTED=128` (instead of 2048) still proves is that the row path
is engaging at all -- if its guard condition ever regresses and every row silently
falls back to the byte-aligned fast path (#295) instead, that path wraps
`GQ_PERF_ENTER_RUNS(DRAW_DECODE)` once per *byte*, driving the count to 2048 for
this fixture's 128x128/16-bytes-per-row image. Same signal `DRAW_WRITE`'s count
already gives, just from the decode side.

## Verification

- **Negative control** (required by the task, to prove the fixtures actually catch
  this class of bug): temporarily removed the `gq_image_load_byte()` reload call
  from `gq_image_advance_row()` (uncommitted, uses this PR's actual new function --
  not a revert to the old per-byte loop) and reran both ctest flavors from a clean
  build. Failures:
  - Plain flavor (24 tests): 4 failed -- `golden_framebuffer_full_frame_row_blit`,
    `golden_framebuffer_anim_advance_frame0`, `_frame1`, `_frame2`.
  - Instrumented flavor (27 tests): the same 4, plus `perf_row_blit_draw_write_count`
    and `perf_row_blit_draw_decode_count` (both fail with `actual: 1088`, showing the
    corrupted state also drove a partial fallback to the byte-level path on later
    rows).
  - This confirms the task brief's expectation: the existing `full_frame_row_blit`
    (row-64 phase flip) and `anim_advance` fixtures already cover the reload-ordering
    hazard, so no new fixture was needed.
- Restored the real fix, clean-rebuilt both flavors from scratch (an earlier
  incremental rebuild without `rm -rf` gave stale false-failures -- worth noting for
  anyone else validating this locally): **plain flavor 24/24 passed, instrumented
  flavor (`GQ_HEADLESS=ON GQ_PERF_INSTRUMENT=ON GQ_PERF_INSTRUMENT_RUNS=ON`) 27/27
  passed**, including both `perf_row_blit_*` engagement-count tests.
- `clang-format --dry-run -Werror src/oled.c` clean (repo's `.clang-format`).

## Follow-up (not in this PR)

- Hardware A/B on the rig (perf_dither + perf_flat carts) is the real validation for
  the perf claim: expected dither draw 29.3 -> ~6-7 ms, frame -> ~28 ms. No hardware
  numbers are claimed here.
- Masked row blit (gamequeer#309), pending its own measurement.
- Issue #308 stays open until the hardware A/B lands.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>