### PR TITLE
ci: add instrumented (GQ_PERF_INSTRUMENT_RUNS) ctest leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,53 @@ jobs:
       - name: Run golden framebuffer regression suite
         run: ctest --output-on-failure
         working-directory: gamequeer/build-headless
+
+  gamequeer-vm-build-instrumented:
+    name: gamequeer C VM instrumented (GQ_PERF_INSTRUMENT_RUNS) golden suite
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          # No libx11-dev needed here: this job only ever configures
+          # GQ_HEADLESS=ON (see below), which swaps in the no-op X11 stub
+          # (src/gfx/gfx_headless.c) -- same as gamequeer-vm-build's headless
+          # step above.
+          sudo apt-get update -q
+          sudo apt-get install -y cmake
+
+      - name: Configure (CMake, headless + GQ_PERF_INSTRUMENT + GQ_PERF_INSTRUMENT_RUNS)
+        # This is the leg gamequeer#307 was filed for: gamequeer-vm-build
+        # above only ever configures plain GQ_HEADLESS=ON, so the
+        # GQ_PERF_INSTRUMENT_RUNS-gated ctests (perf_draw_count_cross_check,
+        # perf_row_blit_draw_{write,decode}_count, perf_mask_row_blit_draw_
+        # {write,decode}_count, and any future GQ_PERF_INSTRUMENT_RUNS-gated
+        # test) never ran in CI at all -- the plain golden suite proves
+        # pixel identity either way, but only these instrumented tests catch
+        # a regression that silently defeats a fast path's engagement gate
+        # (verified empirically during #306/#310/#311's review: forcing a
+        # fast-path gate off still passes every pixel golden; only the
+        # instrumented count tests fail). GQ_PERF_INSTRUMENT_RUNS requires
+        # GQ_PERF_INSTRUMENT (see gq_perf.h's own doc comment) -- both are
+        # set here, deliberately not relying on GQ_PERF_INSTRUMENT_RUNS's
+        # implicit default.
+        run: cmake -B build-headless -DGQ_HEADLESS=ON -DGQ_PERF_INSTRUMENT=ON -DGQ_PERF_INSTRUMENT_RUNS=ON
+        working-directory: gamequeer/
+
+      - name: Build (instrumented)
+        run: cmake --build build-headless --parallel
+        working-directory: gamequeer/
+
+      - name: Run full ctest suite (instrumented)
+        # Deliberately does NOT hardcode an expected test count -- the
+        # instrumented suite has grown from 26 (gamequeer#307 was filed
+        # against) to 30 as of gamequeer#311, and will keep growing as more
+        # GQ_PERF_INSTRUMENT_RUNS-gated tests are added. `ctest` itself
+        # already fails the job on any individual test failure; asserting a
+        # specific total count here would just be one more place to
+        # remember to update per PR; the leg's job is to run every
+        # registered test, not to know in advance how many there are.
+        run: ctest --output-on-failure
+        working-directory: gamequeer/build-headless

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,9 +111,11 @@ jobs:
         # test) never ran in CI at all -- the plain golden suite proves
         # pixel identity either way, but only these instrumented tests catch
         # a regression that silently defeats a fast path's engagement gate
-        # (verified empirically during #306/#310/#311's review: forcing a
-        # fast-path gate off still passes every pixel golden; only the
-        # instrumented count tests fail). GQ_PERF_INSTRUMENT_RUNS requires
+        # (verified empirically during the #306/#310/#313 review rounds --
+        # the PRs that introduced the row blit, row decode advance, and
+        # masked row blit fast paths -- forcing a fast-path gate off still
+        # passes every pixel golden; only the instrumented count tests
+        # fail). GQ_PERF_INSTRUMENT_RUNS requires
         # GQ_PERF_INSTRUMENT (see gq_perf.h's own doc comment) -- both are
         # set here, deliberately not relying on GQ_PERF_INSTRUMENT_RUNS's
         # implicit default.
@@ -126,12 +128,14 @@ jobs:
 
       - name: Run full ctest suite (instrumented)
         # Deliberately does NOT hardcode an expected test count -- the
-        # instrumented suite has grown from 26 (gamequeer#307 was filed
-        # against) to 30 as of gamequeer#311, and will keep growing as more
-        # GQ_PERF_INSTRUMENT_RUNS-gated tests are added. `ctest` itself
-        # already fails the job on any individual test failure; asserting a
-        # specific total count here would just be one more place to
-        # remember to update per PR; the leg's job is to run every
-        # registered test, not to know in advance how many there are.
+        # instrumented suite has already grown once (26 when gamequeer#307
+        # was filed, 27 on `default` as of this PR) and will keep growing
+        # as more GQ_PERF_INSTRUMENT_RUNS-gated tests are added (e.g.
+        # gamequeer#313's masked row-blit engagement tests, still in
+        # review as of this writing). `ctest` itself already fails the job
+        # on any individual test failure; asserting a specific total count
+        # here would just be one more place to remember to update per PR --
+        # the leg's job is to run every registered test, not to know in
+        # advance how many there are.
         run: ctest --output-on-failure
         working-directory: gamequeer/build-headless


### PR DESCRIPTION
## Summary

Closes #307.

`gamequeer-vm-build` (`.github/workflows/ci.yml`) only ever configures plain `-DGQ_HEADLESS=ON`, so the `GQ_PERF_INSTRUMENT_RUNS`-gated engagement-count tests (`perf_draw_count_cross_check`, `perf_row_blit_draw_{write,decode}_count`, and -- as of #313 -- `perf_mask_row_blit_draw_{write,decode}_count`) never execute in CI. These are the only gate-defeat detectors this repo has: a regression that silently defeats a fast path's engagement gate (row blit, row decode advance, masked row blit) still passes every pixel golden -- only the instrumented count tests catch it (verified empirically, independently, across #306's, #310's, and #313's review rounds: forcing a fast-path gate off leaves the plain golden suite 100% green while the instrumented count tests fail). This gap was first flagged during #306's review-convergence pass and has now been carried across three consecutive PRs without being closed.

## Change

Adds a new `gamequeer-vm-build-instrumented` job configuring `-DGQ_HEADLESS=ON -DGQ_PERF_INSTRUMENT=ON -DGQ_PERF_INSTRUMENT_RUNS=ON` and running the full `ctest` suite. Deliberately does **not** hardcode an expected test count in the workflow -- the instrumented suite has grown from 26 (when #307 was filed) to 27 (current `default`) to 30 (on #313's still-open branch) and will keep growing; `ctest` itself already fails the job on any individual test failure, so the leg's job is to run every registered test, not to also track a count that would need bumping on every PR that adds one.

## Test plan

- [x] YAML validated locally (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`) -- parses cleanly, three jobs present (`gqc-tests`, `gamequeer-vm-build`, `gamequeer-vm-build-instrumented`).
- [x] Ran the exact configure/build/ctest commands the new job uses, in the Docker builder container against this branch's `default`-based checkout: `cmake -B build-headless -DGQ_HEADLESS=ON -DGQ_PERF_INSTRUMENT=ON -DGQ_PERF_INSTRUMENT_RUNS=ON && cmake --build build-headless --parallel && ctest --output-on-failure` -- **27/27 passing**.
- [ ] `act`/syntax-check tool not used (not required per task); the real test is CI running on this PR itself -- see below.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
