### PR TITLE
fix(anim): deliver frame duration at authored tick count, not N+1

### DIFF
--- a/gamequeer/src/gamequeer.c
+++ b/gamequeer/src/gamequeer.c
@@ -466,8 +466,22 @@ void system_tick() {
             continue;
         }
 
+        // Decrement first, then check: a freshly (re)loaded frame's `ticks`
+        // holds its full authored duration (e.g. 20), and this is the same
+        // system_tick() call that keeps it on screen for that Nth tick, so
+        // the decrement-and-test must happen together here rather than on
+        // the following call. Checking `ticks > 0` *before* decrementing
+        // (the old code) let a frame survive one extra, undecremented call
+        // once `ticks` reached 0 before the advance below finally fired --
+        // every animation frame was shown for N+1 ticks instead of the
+        // authored N (duplico/gamequeer#315). The `ticks > 0` guard around
+        // the decrement itself is preserved so a `ticks` value of 0 (only
+        // reachable if GQ_MIN_FRAME_DURATION is ever overridden down to 0)
+        // still advances immediately instead of underflowing the u16.
         if (current_animations[i].ticks > 0) {
             current_animations[i].ticks--;
+        }
+        if (current_animations[i].ticks > 0) {
             continue;
         }
 

--- a/gamequeer/tests/CMakeLists.txt
+++ b/gamequeer/tests/CMakeLists.txt
@@ -271,9 +271,9 @@ add_test(NAME led_fade_delta COMMAND test_led_fade_delta)
 add_golden_test(golden_framebuffer_anim_advance_frame0 anim_advance
     TICKS 1  GOLDEN_SUFFIX anim_advance_frame0)
 add_golden_test(golden_framebuffer_anim_advance_frame1 anim_advance
-    TICKS 22 GOLDEN_SUFFIX anim_advance_frame1)
+    TICKS 21 GOLDEN_SUFFIX anim_advance_frame1)
 add_golden_test(golden_framebuffer_anim_advance_frame2 anim_advance
-    TICKS 43 GOLDEN_SUFFIX anim_advance_frame2)
+    TICKS 41 GOLDEN_SUFFIX anim_advance_frame2)
 
 # ---- golden_framebuffer_edge_coverage: true-display-edge oracle coverage
 # gamequeer#297 fixed the emulator canvas (OLED_HORIZONTAL_MAX/

--- a/gamequeer/tests/golden/anim_advance.gq
+++ b/gamequeer/tests/golden/anim_advance.gq
@@ -25,41 +25,41 @@
  * = 100/10 = 10, but gamequeer.c clamps every frame's `ticks` up to
  * `GQ_MIN_FRAME_DURATION` (20, include/gamequeer.h) since 10 < 20 -- see
  * gq_clamp_frame_duration(), shared by both load_animation() and
- * system_tick()'s per-advance reset as of gamequeer#288, which fixed a
- * prior asymmetry where only frame 0's duration was clamped and every
- * later frame ran at the unclamped 10-tick rate. With the clamp applied
- * uniformly, every frame of this animation is shown for 20 ticks):
+ * system_tick()'s per-advance reset as of gamequeer#288. With the clamp
+ * applied uniformly, every frame of this animation is authored to be shown
+ * for 20 ticks, and system_tick()'s decrement-then-check ordering
+ * (gamequeer#315) delivers exactly that -- no extra tick per frame):
  *
  *   tick 1:  `enter` fires (first handle_events() pass), runs `play bganim
  *            pop`, which calls load_animation() (frame=0, ticks clamped to
  *            20, unconditional REFRESH) -- frame 0 is drawn.
- *   ticks 2..21: system_tick() decrements the per-frame counter to 0; no
+ *   ticks 2..20: system_tick() decrements the per-frame counter to 0; no
  *            REFRESH fires in this window, so the framebuffer is untouched
  *            (still frame 0's pixels) -- confirmed identical for every
- *            tick count in [1, 21].
- *   tick 22: the counter hits 0 -> frame advances to 1, the cache is
+ *            tick count in [1, 20].
+ *   tick 21: the counter hits 0 -> frame advances to 1, the cache is
  *            invalidated (frame_meta.data_pointer zeroed), a fresh cart
  *            read repopulates it, and REFRESH fires -- frame 1 is drawn.
- *   ticks 23..42: same idle window (clamped ticks_per_frame=20 again);
+ *   ticks 22..40: same idle window (clamped ticks_per_frame=20 again);
  *            still frame 1's pixels -- confirmed identical for every
- *            tick count in [22, 42].
- *   tick 43: frame advances to 2 and is drawn, by the same mechanism.
+ *            tick count in [21, 40].
+ *   tick 41: frame advances to 2 and is drawn, by the same mechanism.
  *
  * Three ctest cases share this one compiled cart (see tests/CMakeLists.txt):
  *   golden_framebuffer_anim_advance_frame0 (TICKS=1)  -- frame 0.
- *   golden_framebuffer_anim_advance_frame1 (TICKS=22) -- frame 1: proves the
+ *   golden_framebuffer_anim_advance_frame1 (TICKS=21) -- frame 1: proves the
  *     cache invalidates and the *new* frame's metadata is actually read
- *     (a stale/frozen cache would still show frame 0's pixels here). This
- *     boundary happens to be unchanged by the uniform-clamp fix, since
- *     frame 0's duration was already clamped to 20 ticks before it too.
- *   golden_framebuffer_anim_advance_frame2 (TICKS=43) -- frame 2: proves
+ *     (a stale/frozen cache would still show frame 0's pixels here).
+ *   golden_framebuffer_anim_advance_frame2 (TICKS=41) -- frame 2: proves
  *     invalidation isn't a one-shot fluke and keeps working on the *second*
  *     advance too (guards against a fix that only clears the cache once).
- *     This boundary moved from 33 to 43 once frame 1's duration was also
- *     clamped to 20 ticks (was 10, unclamped) by the uniform-clamp fix.
  * Each of the three goldens differs pixel-for-pixel from the other two
  * (confirmed via md5sum of the dumped PGMs when this fixture was authored:
- * three distinct hashes across the [1,21]/[22,42]/43+ tick ranges).
+ * three distinct hashes across the [1,20]/[21,40]/41+ tick ranges). The
+ * committed golden PGMs' *pixel content* is unaffected by #315's retiming
+ * (each frame's drawn bytes are identical to before, only the tick offset
+ * at which that content first appears moved), confirmed by byte-for-byte
+ * `cmp` against dumps taken at the new TICKS values before/after the fix.
  *
  * Negative-control validation performed when authoring this fixture (per
  * the PR body): with the `frame_meta.data_pointer = 0` invalidation lines


### PR DESCRIPTION
## Summary

`system_tick()` was delivering every animation frame for **authored duration + 1 tick**
(a content-independent, cadence-only bug), matching the hardware evidence in
duplico/gamequeer#315: perf_flat and perf_mask_dither both measured 561 frames/120s
(20.98 ticks/frame) against a 20-tick authored duration.

## Root cause

`gamequeer/src/gamequeer.c`, `system_tick()`'s per-animation tick loop (pre-fix):

```c
if (current_animations[i].ticks > 0) {
    current_animations[i].ticks--;
    continue;
}
// If we're here, it's time for this animation to go to the next frame.
current_animations[i].frame++;
...
current_animations[i].ticks = gq_clamp_frame_duration(current_animations[i].anim.ticks_per_frame);
```

`ticks` is set to the clamped duration `N` (`gq_clamp_frame_duration()`, `GQ_MIN_FRAME_DURATION`
= 20, `include/gamequeer.h`) whenever a frame becomes current (`load_animation()` or the advance
branch below). The bug is the *order* of check vs. decrement: on the call where `ticks` would
reach exactly `1 -> 0`, the old code decrements to 0 and just `continue`s (frame unchanged) --
consuming a tick without advancing. Only on the *next* call does the code see `ticks == 0` and
finally advance. That extra "detect zero" call is a free tick neither frame's duration accounts
for, so the true interval between two frame-advance events is `N + 1`, not `N`.

Traced empirically (not just from the arithmetic) with the headless emulator against the
existing `tests/golden/anim_advance.gqgame` fixture (`bwcircles.gif`, `frame_rate = 10` ->
`ticks_per_frame = 10`, clamped to `N = 20` by `gq_clamp_frame_duration()`, shared by
`load_animation()` and `system_tick()`'s per-advance reset since #288/#289): dumping every tick
1..45 and diffing the PGMs, the pre-fix binary's frame-advance boundaries land at ticks
**1, 22, 43** -- an interval of 21, exactly `N + 1` -- matching the existing fixture's own header
comment (which already documented this cadence, just hadn't been recognized as a bug) and the
hardware's 20.98 ticks/frame.

## Fix

Decrement first, then check for zero, so the advance happens on the *same* call that consumes
the last tick of the old frame's duration, rather than waiting for a following call:

```c
if (current_animations[i].ticks > 0) {
    current_animations[i].ticks--;
}
if (current_animations[i].ticks > 0) {
    continue;
}
// If we're here, it's time for this animation to go to the next frame.
```

The `ticks > 0` guard around the decrement is kept (rather than an unconditional `ticks--`) so a
`ticks` value of 0 at entry -- only reachable if `GQ_MIN_FRAME_DURATION` is ever overridden down
to 0 at build-config level -- still advances immediately instead of underflowing the `uint16_t`
counter. In the shipped configuration (`GQ_MIN_FRAME_DURATION` defaults to 20, always defined),
`ticks` is always >= 1 whenever an animation slot is `in_use`, so this path is unreachable today
but kept as a safety net matching the old code's own zero-handling.

## Emulator cadence proof

Built headless (`GQ_HEADLESS=ON`, `GQ_PERF_INSTRUMENT=OFF`) and re-ran the same tick sweep
against the unmodified `anim_advance.gqgame` fixture:

- **Pre-fix** (`git show fcc759c:gamequeer/src/gamequeer.c`, built standalone as a negative
  control -- not via `git stash`, per this repo's shared-refs/stash constraint): boundaries at
  ticks 1, 22, 43 (interval 21).
- **Post-fix** (this branch): boundaries at ticks 1, 21, 41 (interval 20, exactly the authored
  duration).

Each frame's *pixel content* is unaffected -- `cmp` confirms the post-fix dump at tick 21 is
byte-identical to the pre-fix dump at tick 22 (same for tick 41 vs. tick 43), and both match the
already-committed `anim_advance_frame{1,2}_golden.pgm` files unchanged. Only the tick offset at
which that content first appears moved.

As a further negative control, I copied only the retimed `tests/CMakeLists.txt` (TICKS=21/41)
onto the *pre-fix* source and rebuilt: `golden_framebuffer_anim_advance_frame1` and `_frame2`
both genuinely FAIL against the unmodified golden PGMs (pre-fix code is still showing the
previous frame's content at ticks 21/41, since its own boundaries are at 22/43) -- confirming
the retimed goldens actually discriminate old vs. new code rather than coincidentally passing at
the boundary.

Predicted post-fix hardware result: perf_flat and perf_mask_dither should measure ~600
frames/120s (20.00 ticks/frame) against the same 20-tick authored duration -- hardware
confirmation is still needed, so duplico/gamequeer#315 stays open pending that.

## Golden fallout

Only `tests/golden/anim_advance.gq`'s two frame-advance boundaries needed retiming, both in
`tests/CMakeLists.txt`:

- `golden_framebuffer_anim_advance_frame1`: `TICKS=22` -> `TICKS=21`
- `golden_framebuffer_anim_advance_frame2`: `TICKS=43` -> `TICKS=41`

`golden_framebuffer_anim_advance_frame0` (`TICKS=1`) is unchanged -- frame 0's on-screen start
is set by `load_animation()` at cart-load time, not by a `system_tick()` advance, so it isn't
affected by this fix. No golden `.pgm` files needed regeneration (pixel content unchanged, as
shown above). `anim_advance.gq`'s header comment is updated to describe the new (correct)
timing derivation. `tests/run_perf_draw_count_cross_check.cmake`'s `TICKS=43` (used purely to
guarantee at least one RLE-decode pass through `anim_advance.gqgame`, not to assert a specific
frame boundary) needed no change -- by tick 43 the animation is still well into frame 2 either
way (post-fix frame 2 starts at tick 41).

No other committed fixture ever advances an animation frame (`hello.gq` has none;
`mask_encoding_*.gq`/`full_frame_row_blit.gq`/`full_frame_mask_row_blit.gq` load a single
static frame and never tick past it; `redundant_write.gq` has no animations at all), so this is
the only fallout.

## Suite / CI status

Full `ctest` suite run twice (clean rebuild between flavors), both green:

- `GQ_HEADLESS=ON, GQ_PERF_INSTRUMENT=OFF`: **25/25 passed**
- `GQ_HEADLESS=ON, GQ_PERF_INSTRUMENT=ON, GQ_PERF_INSTRUMENT_RUNS=ON`: **30/30 passed**

## Lockstep check (gqc)

`gqc` (`gqc/src/gqc/datamodel.py`'s `Animation.__init__`) only computes and bakes the
*authored* `ticks_per_frame = 100 // frame_rate` (or an explicit `duration`) into the compiled
`GqAnim` struct -- it makes no assumption about delivered-vs-authored tick counts anywhere in
the compiler or grammar (`grammar.py`, `structs.py`, the Langium grammar). This fix is entirely
VM-side; no `gqc` changes are needed or made.

## Disclosure

This change was written with AI assistance (Claude Sonnet 5, via Claude Code).
