### PR TITLE
perf(oled): hoist row-fast-path invariant gate out of the row loop

### DIFF
--- a/gamequeer/src/oled.c
+++ b/gamequeer/src/oled.c
@@ -301,6 +301,20 @@ void gq_draw_image(
 
     gq_load_image(image_bytes, bPP, width, height, img_frame_data_size, x, y, &frame);
 
+    // Row-level uncompressed fast path (issue #303) invariant gate (issue
+    // #312): rle_type, width, x, and context are all fixed for the whole
+    // call (gq_load_image() sets frame.rle_type once and nothing below ever
+    // changes it or frame.width; x/context are plain parameters), so every
+    // term that doesn't depend on the current row is evaluated once here
+    // instead of on every iteration of the loop below. The frame.width > 0
+    // check matters even though gqc can't emit a zero-width image today:
+    // without it, width == 0 satisfies width % 8 == 0 trivially and nbytes
+    // would be 0 -- HAL_oled_blit_row() itself is documented to require
+    // nbytes >= 1, and this is the only caller, so the guard belongs here.
+    uint8_t row_fastpath_x_ok = frame.rle_type == 1 && frame.width > 0 && ((uint16_t) frame.width % 8) == 0 &&
+        x >= context->clipRegion.xMin && (x + frame.width - 1) <= context->clipRegion.xMax;
+    uint16_t row_fastpath_nbytes = (uint16_t) (frame.width / 8);
+
     while (!(gq_image_done(&frame))) {
         // Decode the next run (same procedure regardless of clipping --
         // see gq_image_peek_run()'s doc comment: the RLE stream must be
@@ -311,12 +325,8 @@ void gq_draw_image(
 
         // Row-level uncompressed fast path (issue #303): at the very start
         // of an uncompressed image row (x_bit_offset == 0, x_pixel_offset
-        // == 0), if the row's byte count divides its width evenly (width %
-        // 8 == 0 -- gqc's uncompressed encoder pads every row to a whole
-        // number of bytes, so a non-multiple-of-8 width would otherwise
-        // have don't-care padding bits in the last byte that must NOT be
-        // drawn past the image's right edge) and the *entire* row lies
-        // within the clip region, forward the whole row in one
+        // == 0), if the invariant part above held and the row's y coordinate
+        // lies within the clip region, forward the whole row in one
         // HAL_oled_blit_row() call instead of nbytes individual
         // HAL_oled_blit_byte() calls (the fast path just below this one),
         // and decode-advance the whole row in one gq_image_advance_row()
@@ -325,17 +335,16 @@ void gq_draw_image(
         // fast path (and ultimately the generic per-run path) for any row
         // that doesn't qualify -- narrower images, a row straddling the
         // clip region's left/right edge, or (defensively) a row whose bytes
-        // straddle an image_buffer reload boundary. The frame.width > 0
-        // check matters even though gqc can't emit a zero-width image
-        // today: without it, width == 0 satisfies width % 8 == 0 trivially
-        // and nbytes would be 0 -- HAL_oled_blit_row() itself is documented
-        // to require nbytes >= 1, and this is the only caller, so the guard
-        // belongs here.
-        if (frame.rle_type == 1 && frame.x_bit_offset == 0 && frame.x_pixel_offset == 0 && frame.width > 0 &&
-            ((uint16_t) frame.width % 8) == 0 && draw_y >= context->clipRegion.yMin &&
-            draw_y <= context->clipRegion.yMax && draw_x >= context->clipRegion.xMin &&
-            (draw_x + frame.width - 1) <= context->clipRegion.xMax) {
-            uint16_t nbytes    = (uint16_t) (frame.width / 8);
+        // straddle an image_buffer reload boundary. x_bit_offset/
+        // x_pixel_offset are structurally always 0 here whenever this path
+        // was also taken for the previous row (gq_image_advance_row() resets
+        // x_pixel_offset and never touches x_bit_offset), but are still
+        // checked explicitly rather than relied on, so the gate stays
+        // self-contained if a future change to the fallback paths below ever
+        // lets them drift.
+        if (row_fastpath_x_ok && frame.x_bit_offset == 0 && frame.x_pixel_offset == 0 &&
+            draw_y >= context->clipRegion.yMin && draw_y <= context->clipRegion.yMax) {
+            uint16_t nbytes    = row_fastpath_nbytes;
             uint16_t row_index = frame.byte_index;
 
             // Buffer-straddle guard: HAL_oled_blit_row() needs the whole
@@ -449,6 +458,18 @@ void gq_draw_image_with_mask(
     gq_load_image(image_bytes, image_bPP, width, height, img_frame_data_size, x, y, &image_frame);
     gq_load_image(mask_bytes, mask_bPP, width, height, mask_frame_data_size, x, y, &mask_frame);
 
+    // Row-level masked uncompressed fast path (issue #311) invariant gate
+    // (issue #312, extending gq_draw_image()'s matching hoist to the masked
+    // path): image_frame.rle_type/mask_frame.rle_type, width, x, and context
+    // are all fixed for the whole call (gq_load_image() sets each frame's
+    // rle_type once and nothing below ever changes it or width; x/context
+    // are plain parameters), so every term that doesn't depend on the
+    // current row is evaluated once here instead of on every iteration of
+    // the loop below.
+    uint8_t row_fastpath_x_ok = image_frame.rle_type == 1 && mask_frame.rle_type == 1 && width > 0 &&
+        ((uint16_t) width % 8) == 0 && x >= context->clipRegion.xMin && (x + width - 1) <= context->clipRegion.xMax;
+    uint16_t row_fastpath_nbytes = (uint16_t) (width / 8);
+
     while (!gq_image_done(&image_frame) && !gq_image_done(&mask_frame)) {
         int16_t draw_x = x + image_frame.x_pixel_offset;
         int16_t draw_y = y + image_frame.y_curr;
@@ -462,13 +483,11 @@ void gq_draw_image_with_mask(
         // fast path below relies on, but this gate checks both explicitly
         // rather than leaning on that invariant, so the precondition stays
         // self-contained even if a future change to either stream's
-        // advance logic ever let them drift), if BOTH streams are
-        // uncompressed and byte-aligned in their own decode stream
-        // (x_bit_offset == 0, checked independently per stream -- the
-        // image and mask are
-        // independently RLE/byte-position-tracked even though they share
-        // width/height), the row's byte count divides its width evenly,
-        // and the *entire* row lies within the clip region, forward the
+        // advance logic ever let them drift), if the invariant part above
+        // held for both streams (x_bit_offset == 0, checked independently
+        // per stream -- the image and mask are independently RLE/byte-
+        // position-tracked even though they share width/height) and the
+        // row's y coordinate lies within the clip region, forward the
         // whole row's image+mask bytes in one HAL_oled_blit_row_masked()
         // call instead of nbytes individual HAL_oled_blit_byte_masked()
         // calls, and decode-advance BOTH streams a whole row at a time via
@@ -487,12 +506,10 @@ void gq_draw_image_with_mask(
         // stream, a row straddling the clip region's edge, or
         // (defensively) either stream's row bytes straddling ITS OWN
         // image_buffer reload boundary.
-        if (image_frame.rle_type == 1 && mask_frame.rle_type == 1 && image_frame.x_bit_offset == 0 &&
-            mask_frame.x_bit_offset == 0 && image_frame.x_pixel_offset == 0 && mask_frame.x_pixel_offset == 0 &&
-            width > 0 && ((uint16_t) width % 8) == 0 && draw_y >= context->clipRegion.yMin &&
-            draw_y <= context->clipRegion.yMax && draw_x >= context->clipRegion.xMin &&
-            (draw_x + width - 1) <= context->clipRegion.xMax) {
-            uint16_t nbytes          = (uint16_t) (width / 8);
+        if (row_fastpath_x_ok && image_frame.x_bit_offset == 0 && mask_frame.x_bit_offset == 0 &&
+            image_frame.x_pixel_offset == 0 && mask_frame.x_pixel_offset == 0 && draw_y >= context->clipRegion.yMin &&
+            draw_y <= context->clipRegion.yMax) {
+            uint16_t nbytes          = row_fastpath_nbytes;
             uint16_t image_row_index = image_frame.byte_index;
             uint16_t mask_row_index  = mask_frame.byte_index;
 


### PR DESCRIPTION
## Summary

Part of https://github.com/duplico/gamequeer/issues/312 — addresses that issue's
"row-gate condition re-evaluation every row" candidate, extended (per this round's
task) to **both** `gq_draw_image()`'s unmasked row fast path (#303/#308) and
`gq_draw_image_with_mask()`'s masked row fast path (#311).

The row-level uncompressed fast path's guard condition re-evaluated 9 (unmasked) /
12 (masked) ANDed comparisons on *every row*, even though most of them — `rle_type`,
`width`, and the row's x-axis clip bounds — depend only on the draw call's own
arguments (`x`, `width`, the loaded `rle_type`, and `context`) and are provably
invariant across the whole call. This PR precomputes that invariant subset once per
`gq_draw_image()` / `gq_draw_image_with_mask()` call, leaving only the genuinely
per-row-varying terms (`x_bit_offset`/`x_pixel_offset` — kept as defensive checks per
this file's existing convention even though they're structurally always 0 once the
path is engaged — and the y clip bounds, which do vary with `frame.y_curr`) inside
the loop:

- Unmasked: 9 terms/row → 1 hoisted flag + 4 terms/row (5 terms moved out of the loop).
- Masked: 12 terms/row → 1 hoisted flag + 6 terms/row (6 terms moved out of the loop).

This is a pure loop-invariant-code-motion refactor with **no behavior change** — the
compiler can't do this hoist itself across the `HAL_oled_blit_row()` /
`HAL_oled_blit_row_masked()` call boundary (an opaque external call it must
conservatively assume could mutate `frame` state), so it costs nothing to do by hand.

## Attribution (issue #312's "attribute first" step)

**The emulator's host-CPU wall-clock cannot resolve this change's real-world
magnitude, and I want to be upfront about that rather than paper over it with a
misleadingly precise number.** MSP430 has no branch predictor/pipeline speculation —
a chain of ANDed comparisons costs roughly the same per term regardless of outcome —
while host x86 branch prediction makes a short, highly-predictable AND-chain nearly
free. Measuring the before/after `perf_dither`/`perf_mask_dither` carts
(`examples/games/perf/`) confirms this: over 200 draws (`--ticks 4000`, 3 trials each,
`GQ_PERF_INSTRUMENT`+`GQ_PERF_INSTRUMENT_RUNS`), `draw_animation_stack`'s `min_us`
(least-scheduling-noise sample) is statistically indistinguishable before/after —
unmasked ~62–63 µs both before and after, masked ~80–82 µs both before and after —
because the real removed cost (single-digit nanoseconds on x86) is far below both the
timer's ~1 µs resolution and the Docker-container scheduling jitter visible in the
same runs' `max_us` column (which swings 2–3× between identical repeated
invocations). What *is* clean on the emulator: `draw_decode`/`draw_write` section
counts are unchanged (384 for the 3-draw/60-tick window, 25600 for the 200-draw/4000-
tick window, both fixtures) — the row fast path engages exactly as before, no
fallback regression — and all pixel-golden and engagement-count tests pass unchanged
(below).

**Static attribution instead**: MCLK is confirmed 16 MHz
(`ccs_workspace/qc2024/badge.h`'s `MCLK_FREQ_16_MHZ`). Each removed comparison is a
16-bit register/memory compare + conditional branch (~2–3 cycles on MSP430); the
`width % 8` term was already compiler-strength-reduced to an AND (1024 and 8 are both
compile-time powers of two), so it's roughly the same cost class as the others. Call
it ~2.5 cycles/removed term (an estimate — no MSP430 disassembly access in this
environment, flagged explicitly as such): **unmasked ≈ 5 × 2.5 ≈ 12.5 cycles/row ≈
0.78 µs/row ≈ 0.1 ms/frame over 128 rows; masked ≈ 6 × 2.5 ≈ 15 cycles/row ≈ 0.94
µs/row ≈ 0.12 ms/frame.** This is a real, correct, zero-risk win, but it is **not**
close to the ≥3 ms/frame the "earn 4 ticks" campaign is after — I want to say that
plainly rather than imply otherwise.

### A finding worth flagging for the next round: possible instrumentation
### observer-effect in the 70 µs/row figure itself

Issue #312's 70 µs/row residual comes from a `GQ_PERF_INSTRUMENT_RUNS`-instrumented
hardware measurement (that's how `DRAW_DECODE`/`DRAW_WRITE` get reported at all).
`GQ_PERF_INSTRUMENT_RUNS`'s own doc comment (`include/gq_perf.h`) says its purpose is
*exactly* to let someone "quantify \[...\] contamination of the enclosing per-draw
timings" — but `docs/perf-investigation.md` doesn't appear to contain a RUNS-on-vs-
RUNS-off A/B for this content class yet. On the emulator (post-this-change code,
`GQ_PERF_INSTRUMENT` alone vs. `+GQ_PERF_INSTRUMENT_RUNS`, same 200-draw runs):
`draw_animation_stack`'s `min_us` drops from ~62–63 → ~55–59 (unmasked) and ~80–82 →
~73–74 (masked) when `GQ_PERF_INSTRUMENT_RUNS` is off — roughly 8–13% of the total on
host. Whether that proportion holds on hardware is genuinely unknown from here (a
`clock_gettime()` vDSO call and a raw MSP430 TA1 read-with-retry are not comparable in
absolute terms), but it's a cheap, high-value next diagnostic: re-run the same
`perf_dither`/`perf_mask_dither` carts on the bench with `GQ_PERF_INSTRUMENT` alone
(no `_RUNS`) and compare `DRAW_ANIMATION_STACK` against the existing RUNS-on figures
before spending more effort chasing the row loop itself. If the residual survives
RUNS-off, `gq_perf.h`'s own documented (not-yet-implemented) GPIO-toggle extension
point would be the next tool to actually localize it — I don't have enough here to
pinpoint the dominant term beyond "it's very unlikely to be the row-gate branches
this PR removes."

## Verification

- `docker run ... clang-format --dry-run --Werror gamequeer/src/oled.c` clean (after
  one `clang-format -i` pass to re-wrap the two new multi-line boolean expressions).
- Clean rebuild (`rm -rf build-headless build-perf-*`, fresh `cmake -B ... && cmake
  --build ...`) + full `ctest`, twice (once right after the change, once again from a
  final from-HEAD checkout before opening this PR):
  - `-DGQ_HEADLESS=ON`: **25/25** pixel-golden tests pass, byte-identical output,
    including `golden_framebuffer_full_frame_row_blit` and
    `golden_framebuffer_full_frame_mask_row_blit` (the two fixtures purpose-built for
    the row fast paths this PR touches).
  - `-DGQ_HEADLESS=ON -DGQ_PERF_INSTRUMENT=ON -DGQ_PERF_INSTRUMENT_RUNS=ON`: **30/30**
    pass, including `perf_row_blit_draw_{write,decode}_count` and
    `perf_mask_row_blit_draw_{write,decode}_count` — these assert the row fast path's
    `DRAW_WRITE`/`DRAW_DECODE` section count is exactly 128 (one per row), not 2048
    (the byte-aligned fallback's per-byte count) — unchanged, confirming the fast path
    still engages on every qualifying row after the hoist.

### Negative control

Per the lineage standard, I broke the hoisted invariant on purpose (dropped the two
x-clip-bound terms from `row_fastpath_x_ok` in both functions, keeping
`rle_type`/`width % 8`) and re-ran the full suite from a clean build. **Result: 0/55
failures (25/25 golden + 30/30 instrumented, all still pass).** This is expected, not
a coverage gap: `HAL_oled_blit_row()`'s documented contract
(`include/gamequeer.h`) says the primitive itself "does NOT clip or split a
partially-visible span" — callers must guarantee the whole row is in-clip — but
*both* current concrete implementations happen to be defensively safe anyway even
when that precondition is violated: the emulator's implementation
(`grlib_gfx_driver.c`) delegates to `HAL_oled_blit_byte()` per source byte (which
self-clips per pixel), and the firmware's implementation (`sh1107.c`) has its own
explicit out-of-bounds fallback to the same per-byte primitive. So an x-clip-bound
regression in the caller-side gate is structurally invisible to a pixel golden on
*either* current implementation — the caller-side check still matters (it's what the
documented contract requires, and a future/different display implementation might not
carry the same defensive fallback), but I can't manufacture a golden fixture on this
codebase that would catch its removal, so I'm reporting the actual (surprising) result
instead of a fixture that would give false confidence. I restored the correct code
before committing; `git diff HEAD -- gamequeer/src/oled.c` is empty against the
committed state.

## Pre-registered hardware predictions

Given the ~0.1 ms (unmasked) / ~0.12 ms (masked) estimated savings above:

- Unmasked dither anim draw: 14.83 ms → **≈ 14.7 ms** (estimate, not measurement).
- Masked dither anim draw: 28.78 ms → **≈ 28.66 ms**.
- Masked-dither p100 vs. the 40 ms/4-tick budget: 40.67 ms → **≈ 40.55 ms** — still
  over budget. **This PR alone does not close the gap to a 4-tick/25 FPS clamp for
  the masked+uncompressed content class**, and I don't want the PR description to
  imply otherwise. The GQ_PERF_INSTRUMENT_RUNS observer-effect check above is, in my
  assessment, a higher-expected-value next step than further row-loop micro-
  optimization here.

## Scope notes

- VM-internal only — no HAL contract change, no cart-format change, no bytecode/struct
  change (no `gqc` lockstep impact).
- `oled.c` is shared verbatim with the firmware build
  (`ccs_workspace/qc2024/.project` references `gamequeer/src/oled.c` directly), so
  this change is live on both targets once the submodule pointer bump lands. The two
  new locals per function (`row_fastpath_x_ok`, `row_fastpath_nbytes`) are the same
  shape of data the old code already computed transiently inside the loop body every
  iteration (`nbytes` was already a same-sized local declared inside the `if` block),
  so I don't expect a stack-frame-size regression, but I don't have CCS/`--asm_listing`
  access from this environment to prove it — per this repo's established pattern, that
  measurement belongs to the qc2024-side bump PR.
- I did **not** implement the issue's "rows-until-reload counter" idea: `IMAGE_BUFFER_SIZE`
  (1024) is a compile-time power of two, so `byte_index % IMAGE_BUFFER_SIZE` is already
  compiler-strength-reduced to a single AND — a counter-based rewrite would trade one
  cheap op for another with no net win, at the cost of new persistent state. Also left
  `gq_image_load_byte()`'s render_byte/RLE-branch decode alone: its row-path-irrelevant
  cost is small relative to the gate (~1.5–1.8 µs/row estimated), and safely eliminating
  it would require a lazy-redecode mechanism (tracking staleness across the fast-path/
  fallback boundary) whose correctness risk isn't justified by that small an estimated
  gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>