### PR TITLE
docs(gqc): randomness recipe + div/mod-by-zero gotcha

### DIFF
--- a/gqc/docs/authoring-and-perf-carts.md
+++ b/gqc/docs/authoring-and-perf-carts.md
@@ -100,18 +100,35 @@ event timer {
 
 The VM timer is a single global one-shot (see `timer_active` in
 `gamequeer.c`), so this pattern monopolizes it for as long as it runs — don't
-also rely on `timer` for anything else (e.g. an animation cadence) while this
-is armed.
+also rely on `timer` for anything else (e.g. a periodic scripted behavior
+you built with `timer`) while this is armed.
 
 **Generation**: seed a Park-Miller LCG from the sampled counter (fold in
 `GQI_PLAYER_ID`, or another badge word, first if per-cart variation across
-badges is wanted, then clamp into `[1, 2147483646]`, e.g.
-`seed % 2147483646 + 1`), and step it with the **Schrage-form** update below.
-This is the only form to use: the VM's arithmetic is plain signed `int32` C
-arithmetic, and a naive LCG like `state = state * 1103515245 + 12345` relies
-on signed-overflow wraparound, which is undefined behavior in C and not
-guaranteed to produce identical results between the emulator (gcc/clang) and
-the badge (`cl430 --opt_level=3`).
+badges is wanted), clamp into `[1, 2147483646]`, and step it with the
+**Schrage-form** update below. This is the only LCG form to use: the VM's
+arithmetic is plain signed `int32` C arithmetic, and a naive LCG like
+`state = state * 1103515245 + 12345` relies on signed-overflow wraparound,
+which is undefined behavior in C and not guaranteed to produce identical
+results between the emulator (gcc/clang) and the badge (`cl430
+--opt_level=3`).
+
+**Clamp the seed as two separate statements, mask before modulo**: C's `%`
+takes the sign of the dividend, so if the folded-in badge word can be
+negative (bit 31 set), `seed % 2147483646 + 1` can land on `state = 0` —
+which is an absorbing fixed point of the Schrage step below (`0 →
+2147483647 → 2147483647 …`, a permanently stuck generator). Mask to
+non-negative *before* the modulo clamp:
+
+```
+seed = seed & 2147483647;
+state = seed % 2147483646 + 1;
+```
+
+After masking, `seed` ∈ `[0, 2^31-1]`; `% 2147483646` gives `[0,
+2147483645]`; `+1` gives `[1, 2147483646]` — `state` can never be `0` or
+`2147483647`. Keep the mask and the modulo/`+1` clamp as separate
+statements as shown, not combined into one mixed `%`/`&`/`+` expression.
 
 ```
 // state must be a volatile int, seeded to 1..2147483646 before first use

--- a/gqc/docs/authoring-and-perf-carts.md
+++ b/gqc/docs/authoring-and-perf-carts.md
@@ -83,6 +83,47 @@ score_str := str(score);
 GQS_LABEL2 := "score=" + score_str;
 ```
 
+### Randomness
+
+There is no RNG builtin. Build one from two pieces: an entropy source sampled
+at a human input event, and a deterministic generator.
+
+**Entropy**: run a self-re-arming counter while waiting for the player, and
+sample it the moment they act:
+
+```
+event timer {
+    c = c + 1;
+    timer 1;
+}
+```
+
+The VM timer is a single global one-shot (see `timer_active` in
+`gamequeer.c`), so this pattern monopolizes it for as long as it runs — don't
+also rely on `timer` for anything else (e.g. an animation cadence) while this
+is armed.
+
+**Generation**: seed a Park-Miller LCG from the sampled counter (fold in
+`GQI_PLAYER_ID`, or another badge word, first if per-cart variation across
+badges is wanted, then clamp into `[1, 2147483646]`, e.g.
+`seed % 2147483646 + 1`), and step it with the **Schrage-form** update below.
+This is the only form to use: the VM's arithmetic is plain signed `int32` C
+arithmetic, and a naive LCG like `state = state * 1103515245 + 12345` relies
+on signed-overflow wraparound, which is undefined behavior in C and not
+guaranteed to produce identical results between the emulator (gcc/clang) and
+the badge (`cl430 --opt_level=3`).
+
+```
+// state must be a volatile int, seeded to 1..2147483646 before first use
+hi = state / 127773;
+lo = state % 127773;
+state = 16807 * lo - 2836 * hi;
+if (state <= 0) {
+    state = state + 2147483647;
+}
+// roll: r = state % N; for a 0..N-1 result
+```
+
 ## 2. Labels (on-screen text)
 
 Four label slots (`GQI_LABEL{1..4}_X/Y` position, `GQS_LABEL{1..4}` text,
@@ -403,6 +444,11 @@ flashrom invocation is tracked as
 - **A wide `<<`/`|` literal expression can exhaust the 4-register compiler
   pool** (`No free registers available`) — precompute a literal instead (see
   "Labels" above).
+- **Integer division/modulo by a zero divisor is unguarded.**
+  `run_arithmetic()`'s `GQ_OP_DIVBY`/`GQ_OP_MODBY` cases (`bytecode.c`) are
+  bare C `/` and `%` with no zero check — a zero divisor is undefined
+  behavior/a trap on both the emulator and the badge. Guard any divisor that
+  can be zero with an `if` before dividing.
 - **RLE4 is unreachable** via the public pipeline (commented out in `Frame`).
 - Encoding is decided **per frame**, not per animation — a mixed-content
   animation can contain both RLE7 and UNCOMPRESSED frames.


### PR DESCRIPTION
## Summary

Follow-up to #322. Adds two pieces of verified authoring guidance to `gqc/docs/authoring-and-perf-carts.md`:

- **Randomness** (new subsection in §1, after the event-body-statements material): the console has no RNG builtin. Documents the two-piece pattern — a self-re-arming counter (`event timer { c = c + 1; timer 1; }`) sampled at the moment of human input as an entropy source, noting this monopolizes the VM's single global one-shot timer while armed; and a Schrage-form Park-Miller LCG as the *only* recommended generator, since the VM's arithmetic is plain signed `int32` C arithmetic and a naive `state = state * A + C` LCG relies on signed-overflow UB that isn't guaranteed to match between the emulator (gcc/clang) and the badge (`cl430 --opt_level=3`).
- **Gotcha**: integer division/modulo by zero is unguarded — `run_arithmetic()`'s `GQ_OP_DIVBY`/`GQ_OP_MODBY` (`bytecode.c`) are bare C `/`/`%` with no zero check, so a zero divisor is UB/a trap on both the emulator and the badge.

**Update (34b2635)**: adversarial review caught a sign bug in the original seed-clamp expression, `seed % 2147483646 + 1` — C `%` takes the sign of the dividend, so a negative folded-in seed (e.g. a badge word with bit 31 set) could clamp to `state = 0`, an absorbing fixed point of the Schrage step that permanently stalls the generator. Fixed by masking to non-negative (`seed = seed & 2147483647;`) *before* the modulo clamp, as a separate statement from the clamp itself. Also reworded the timer-monopolization aside, which incorrectly implied animations are stepped by the scripted `timer` (they're driven by `system_tick()`, not the scripted timer).

Docs-only change; no bytecode/struct changes, so nothing on the C VM side needs updating in lockstep.

**On "verified"**: the randomness recipe is verified in the sense that it *compiles cleanly* — both the original three-statement LCG step and the follow-up mask+clamp lines were pasted into throwaway `.gq` carts and compiled via the builder container (doc's own §7 invocation), confirming no register-pool exhaustion and no grammar issues. The recipe's *runtime sequence behavior* (that the masked clamp actually keeps `state` off `0`/`m`, that the Schrage step decorrelates as expected, etc.) was checked by code review / arithmetic analysis, not by executing the generator and inspecting its output stream — no test harness runs the compiled bytecode's actual arithmetic here.

## Test plan

- [x] Wrote a throwaway `.gq` cart using the original randomness recipe verbatim and compiled it via the Docker builder (`docker run ... gamequeer-builder:latest ... python -m gqc compile ...`) — compiled successfully, no register-allocation errors.
- [x] Wrote a second throwaway `.gq` cart adding the `seed & 2147483647` mask line ahead of the modulo clamp and compiled it the same way — compiled successfully (commit 34b2635).
- [x] `cd gqc && make test` — 0 items collected (pre-existing, unrelated to this change).

## Authorship

This PR was written with AI assistance (Claude Code) per the repo's AI-authorship convention; the doc's authorship note already covers this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S6CTNoncMd7oGjJja2fLBy
