### PR TITLE
gq-game-language: completion, hover, write-validation for reserved builtins

### DIFF
--- a/gq-game-language/src/language/game-queer-game-language-completion-provider.ts
+++ b/gq-game-language/src/language/game-queer-game-language-completion-provider.ts
@@ -1,0 +1,62 @@
+import { AstUtils, GrammarAST, type MaybePromise } from 'langium';
+import { DefaultCompletionProvider, type CompletionAcceptor, type CompletionContext, type NextFeature } from 'langium/lsp';
+import { CompletionItemKind } from 'vscode-languageserver';
+import { GQ_RESERVED_INTS, GQ_RESERVED_STRS, gqBuiltinCompletionDetail, type GqBuiltin } from './gq-builtins.js';
+
+// Parser rules whose `var=ID`/`dst=ID` assignment accepts a reserved
+// GQI_*/GQS_* builtin name as well as a user-defined variable: int
+// operands/assignment targets, and str operands/assignment targets. The
+// grammar captures these as plain strings (not cross-references -- see
+// issue #326), so the default CompletionProvider has no completions for
+// them at all; this override adds the builtin table alongside whatever else
+// ends up being offered for that position.
+const INT_IDENTIFIER_RULES = new Set(['IntOperand', 'CmdAssignmentInt']);
+const STR_IDENTIFIER_RULES = new Set(['StrOperand', 'CmdAssignmentStr']);
+
+/**
+ * Contributes the reserved `GQI_*`/`GQS_*` builtins to completion in
+ * identifier positions of int/str expressions and assignment left-hand
+ * sides (gamequeer#326).
+ */
+export class GameQueerGameLanguageCompletionProvider extends DefaultCompletionProvider {
+
+    protected override completionFor(context: CompletionContext, next: NextFeature, acceptor: CompletionAcceptor): MaybePromise<void> {
+        const builtins = this.builtinsFor(next);
+        if (builtins) {
+            for (const builtin of builtins) {
+                acceptor(context, {
+                    label: builtin.name,
+                    kind: CompletionItemKind.Variable,
+                    detail: gqBuiltinCompletionDetail(builtin),
+                    sortText: '0'
+                });
+            }
+        }
+        return super.completionFor(context, next, acceptor);
+    }
+
+    private builtinsFor(next: NextFeature): readonly GqBuiltin[] | undefined {
+        // The completion feature stack surfaces the *terminal* being
+        // completed (here, a RuleCall to the `ID` terminal), not the
+        // wrapping Assignment -- so we look at `$container` to find out
+        // which property (`var`/`dst`) it's assigned to.
+        const assignment = next.feature.$container;
+        if (!GrammarAST.isAssignment(assignment)) {
+            return undefined;
+        }
+        if (assignment.feature !== 'var' && assignment.feature !== 'dst') {
+            return undefined;
+        }
+        const rule = AstUtils.getContainerOfType(assignment, GrammarAST.isParserRule);
+        if (!rule) {
+            return undefined;
+        }
+        if (INT_IDENTIFIER_RULES.has(rule.name)) {
+            return GQ_RESERVED_INTS;
+        }
+        if (STR_IDENTIFIER_RULES.has(rule.name)) {
+            return GQ_RESERVED_STRS;
+        }
+        return undefined;
+    }
+}

--- a/gq-game-language/src/language/game-queer-game-language-hover-provider.ts
+++ b/gq-game-language/src/language/game-queer-game-language-hover-provider.ts
@@ -1,0 +1,56 @@
+import type { LangiumDocument, MaybePromise } from 'langium';
+import { CstUtils } from 'langium';
+import { MultilineCommentHoverProvider } from 'langium/lsp';
+import type { Hover, HoverParams } from 'vscode-languageserver';
+import { isCmdAssignmentInt, isCmdAssignmentStr, isIntOperand, isStrOperand } from './generated/ast.js';
+import { findGqBuiltin, gqBuiltinHoverMarkdown } from './gq-builtins.js';
+
+/**
+ * Surfaces the description (and read-only/writable status) of a reserved
+ * `GQI_*`/`GQS_*` builtin on hover (gamequeer#326). Falls back to the
+ * default declaration-based hover for everything else.
+ */
+export class GameQueerGameLanguageHoverProvider extends MultilineCommentHoverProvider {
+
+    override getHoverContent(document: LangiumDocument, params: HoverParams): MaybePromise<Hover | undefined> {
+        const builtinHover = this.getBuiltinHoverContent(document, params);
+        if (builtinHover) {
+            return builtinHover;
+        }
+        return super.getHoverContent(document, params);
+    }
+
+    private getBuiltinHoverContent(document: LangiumDocument, params: HoverParams): Hover | undefined {
+        const rootNode = document.parseResult?.value?.$cstNode;
+        if (!rootNode) {
+            return undefined;
+        }
+        const offset = document.textDocument.offsetAt(params.position);
+        const cstNode = CstUtils.findDeclarationNodeAtOffset(rootNode, offset, this.grammarConfig.nameRegexp);
+        if (!cstNode || cstNode.offset + cstNode.length <= offset) {
+            return undefined;
+        }
+
+        const astNode = cstNode.astNode;
+        const text = cstNode.text;
+        const isBuiltinIdentifierSlot =
+            (isIntOperand(astNode) && astNode.var === text) ||
+            (isStrOperand(astNode) && astNode.var === text) ||
+            (isCmdAssignmentInt(astNode) && astNode.dst === text) ||
+            (isCmdAssignmentStr(astNode) && astNode.dst === text);
+        if (!isBuiltinIdentifierSlot) {
+            return undefined;
+        }
+
+        const builtin = findGqBuiltin(text);
+        if (!builtin) {
+            return undefined;
+        }
+        return {
+            contents: {
+                kind: 'markdown',
+                value: gqBuiltinHoverMarkdown(builtin)
+            }
+        };
+    }
+}

--- a/gq-game-language/src/language/game-queer-game-language-module.ts
+++ b/gq-game-language/src/language/game-queer-game-language-module.ts
@@ -1,6 +1,8 @@
 import { type Module, inject } from 'langium';
 import { createDefaultModule, createDefaultSharedModule, type DefaultSharedModuleContext, type LangiumServices, type LangiumSharedServices, type PartialLangiumServices } from 'langium/lsp';
 import { GameQueerGameLanguageGeneratedModule, GameQueerGameLanguageGeneratedSharedModule } from './generated/module.js';
+import { GameQueerGameLanguageCompletionProvider } from './game-queer-game-language-completion-provider.js';
+import { GameQueerGameLanguageHoverProvider } from './game-queer-game-language-hover-provider.js';
 import { GameQueerGameLanguageValidator, registerValidationChecks } from './game-queer-game-language-validator.js';
 
 /**
@@ -26,6 +28,10 @@ export type GameQueerGameLanguageServices = LangiumServices & GameQueerGameLangu
 export const GameQueerGameLanguageModule: Module<GameQueerGameLanguageServices, PartialLangiumServices & GameQueerGameLanguageAddedServices> = {
     validation: {
         GameQueerGameLanguageValidator: () => new GameQueerGameLanguageValidator()
+    },
+    lsp: {
+        CompletionProvider: (services) => new GameQueerGameLanguageCompletionProvider(services),
+        HoverProvider: (services) => new GameQueerGameLanguageHoverProvider(services)
     }
 };
 

--- a/gq-game-language/src/language/game-queer-game-language-validator.ts
+++ b/gq-game-language/src/language/game-queer-game-language-validator.ts
@@ -1,6 +1,7 @@
 import type { ValidationAcceptor, ValidationChecks } from 'langium';
-import type { GameAssignment, GameDefinitionSection, GameQueerGameLanguageAstType } from './generated/ast.js';
+import type { CmdAssignmentInt, CmdAssignmentStr, GameAssignment, GameDefinitionSection, GameQueerGameLanguageAstType } from './generated/ast.js';
 import type { GameQueerGameLanguageServices } from './game-queer-game-language-module.js';
+import { findGqBuiltin } from './gq-builtins.js';
 
 /**
  * Register custom validation checks.
@@ -9,7 +10,9 @@ export function registerValidationChecks(services: GameQueerGameLanguageServices
     const registry = services.validation.ValidationRegistry;
     const validator = services.validation.GameQueerGameLanguageValidator;
     const checks: ValidationChecks<GameQueerGameLanguageAstType> = {
-        GameDefinitionSection: validator.checkGameAssignmentCardinality
+        GameDefinitionSection: validator.checkGameAssignmentCardinality,
+        CmdAssignmentInt: validator.checkIntAssignmentBuiltin,
+        CmdAssignmentStr: validator.checkStrAssignmentBuiltin
     };
     registry.register(checks, validator);
 }
@@ -51,6 +54,46 @@ export class GameQueerGameLanguageValidator {
                     accept('error', `Duplicate '${key}' assignment in game block; exactly one is allowed.`, { node: duplicate });
                 }
             }
+        }
+    }
+
+    /**
+     * `dst = ...;` assigns with the int operator. If `dst` names a reserved
+     * builtin, it must be an int builtin (a str builtin here is a kind
+     * mismatch -- it needs `:=`), and if it's a read-only (VM/firmware-
+     * managed) builtin, writing it is reported as a warning rather than an
+     * error: the VM does not itself reject the write (see gamequeer#326),
+     * so this is a lint, not a hard failure.
+     */
+    checkIntAssignmentBuiltin(node: CmdAssignmentInt, accept: ValidationAcceptor): void {
+        const builtin = findGqBuiltin(node.dst);
+        if (!builtin) {
+            return;
+        }
+        if (builtin.kind !== 'int') {
+            accept('error', `'${builtin.name}' is a str builtin; assign to it with ':=', not '='.`, { node, property: 'dst' });
+            return;
+        }
+        if (!builtin.writable) {
+            accept('warning', `'${builtin.name}' is a read-only builtin (${builtin.description}); the VM/firmware manages it and a game assignment will be overwritten.`, { node, property: 'dst' });
+        }
+    }
+
+    /**
+     * `dst := ...;` assigns with the str operator; see
+     * {@link checkIntAssignmentBuiltin} for the mirrored int-side checks.
+     */
+    checkStrAssignmentBuiltin(node: CmdAssignmentStr, accept: ValidationAcceptor): void {
+        const builtin = findGqBuiltin(node.dst);
+        if (!builtin) {
+            return;
+        }
+        if (builtin.kind !== 'str') {
+            accept('error', `'${builtin.name}' is an int builtin; assign to it with '=', not ':='.`, { node, property: 'dst' });
+            return;
+        }
+        if (!builtin.writable) {
+            accept('warning', `'${builtin.name}' is a read-only builtin (${builtin.description}); the VM/firmware manages it and a game assignment will be overwritten.`, { node, property: 'dst' });
         }
     }
 }

--- a/gq-game-language/src/language/gq-builtins.ts
+++ b/gq-game-language/src/language/gq-builtins.ts
@@ -9,7 +9,7 @@
  * the VM (`gamequeer/src/gamequeer.c`, `gamequeer/src/menu.c`,
  * `gamequeer/src/bytecode.c`) and the firmware HAL (`ccs_workspace/qc2024/HAL_badge.c`)
  * to see who writes each variable, plus real usage in
- * `gamequeer/tests/golden/*.gq` and `examples/games/**\/*.gq`. See the PR
+ * `gamequeer/tests/golden/` and `examples/games/` (recursively). See the PR
  * description for the per-variable rationale.
  */
 

--- a/gq-game-language/src/language/gq-builtins.ts
+++ b/gq-game-language/src/language/gq-builtins.ts
@@ -1,0 +1,89 @@
+/**
+ * Reserved `GQI_*`/`GQS_*` builtin variables recognized by the gamequeer VM.
+ *
+ * Hand-synced from `gqc/src/gqc/structs.py` (`GQ_RESERVED_INTS` /
+ * `GQ_RESERVED_STRS`) -- name/kind/description come from there. When those
+ * tables change, update this file to match.
+ *
+ * `writable` is *not* present in `structs.py`; it was determined by reading
+ * the VM (`gamequeer/src/gamequeer.c`, `gamequeer/src/menu.c`,
+ * `gamequeer/src/bytecode.c`) and the firmware HAL (`ccs_workspace/qc2024/HAL_badge.c`)
+ * to see who writes each variable, plus real usage in
+ * `gamequeer/tests/golden/*.gq` and `examples/games/**\/*.gq`. See the PR
+ * description for the per-variable rationale.
+ */
+
+export type GqBuiltinKind = 'int' | 'str';
+
+export interface GqBuiltin {
+    /** e.g. `GQI_PLAYER_ID` */
+    readonly name: string;
+    readonly kind: GqBuiltinKind;
+    /** From `structs.py`'s `GqReservedVariable.description`. */
+    readonly description: string;
+    /**
+     * Whether game code may assign to this variable. `false` for VM/firmware
+     * outputs (identity, menu results, cartridge metadata) that games only
+     * ever read.
+     */
+    readonly writable: boolean;
+}
+
+export const GQ_RESERVED_INTS: readonly GqBuiltin[] = [
+    { name: 'GQI_GAME_ID', kind: 'int', description: 'ID of the game', writable: false },
+    { name: 'GQI_MENU_ACTIVE', kind: 'int', description: 'Menu active', writable: false },
+    { name: 'GQI_MENU_VALUE', kind: 'int', description: 'Menu selection', writable: false },
+    { name: 'GQI_GAME_COLOR', kind: 'int', description: 'Color of the game cartridge', writable: false },
+    { name: 'GQI_BGANIM_X', kind: 'int', description: 'Background animation X', writable: true },
+    { name: 'GQI_BGANIM_Y', kind: 'int', description: 'Background animation Y', writable: true },
+    { name: 'GQI_FGANIM1_X', kind: 'int', description: 'Foreground animation 0 X', writable: true },
+    { name: 'GQI_FGANIM1_Y', kind: 'int', description: 'Foreground animation 0 Y', writable: true },
+    { name: 'GQI_FGMASK1_X', kind: 'int', description: 'Foreground mask 0 X', writable: true },
+    { name: 'GQI_FGMASK1_Y', kind: 'int', description: 'Foreground mask 0 Y', writable: true },
+    { name: 'GQI_FGANIM2_X', kind: 'int', description: 'Foreground animation 1 X', writable: true },
+    { name: 'GQI_FGANIM2_Y', kind: 'int', description: 'Foreground animation 1 Y', writable: true },
+    { name: 'GQI_FGMASK2_X', kind: 'int', description: 'Foreground mask 1 X', writable: true },
+    { name: 'GQI_FGMASK2_Y', kind: 'int', description: 'Foreground mask 1 Y', writable: true },
+    { name: 'GQI_LABEL1_X', kind: 'int', description: 'Label 1 X', writable: true },
+    { name: 'GQI_LABEL1_Y', kind: 'int', description: 'Label 1 Y', writable: true },
+    { name: 'GQI_LABEL2_X', kind: 'int', description: 'Label 2 X', writable: true },
+    { name: 'GQI_LABEL2_Y', kind: 'int', description: 'Label 2 Y', writable: true },
+    { name: 'GQI_LABEL3_X', kind: 'int', description: 'Label 3 X', writable: true },
+    { name: 'GQI_LABEL3_Y', kind: 'int', description: 'Label 3 Y', writable: true },
+    { name: 'GQI_LABEL4_X', kind: 'int', description: 'Label 4 X', writable: true },
+    { name: 'GQI_LABEL4_Y', kind: 'int', description: 'Label 4 Y', writable: true },
+    { name: 'GQI_LABEL_FLAGS', kind: 'int', description: 'Label flags', writable: true },
+    { name: 'GQI_PLAYER_ID', kind: 'int', description: 'Player ID', writable: false }
+];
+
+export const GQ_RESERVED_STRS: readonly GqBuiltin[] = [
+    { name: 'GQS_GAME_NAME', kind: 'str', description: 'Name of the game', writable: false },
+    { name: 'GQS_PLAYER_HANDLE', kind: 'str', description: 'Player handle', writable: false },
+    { name: 'GQS_LABEL1', kind: 'str', description: 'Label 1', writable: true },
+    { name: 'GQS_LABEL2', kind: 'str', description: 'Label 2', writable: true },
+    { name: 'GQS_LABEL3', kind: 'str', description: 'Label 3', writable: true },
+    { name: 'GQS_LABEL4', kind: 'str', description: 'Label 4', writable: true },
+    { name: 'GQS_TEXTMENU_RESULT', kind: 'str', description: 'Text menu result', writable: true }
+];
+
+export const GQ_RESERVED_BUILTINS: readonly GqBuiltin[] = [...GQ_RESERVED_INTS, ...GQ_RESERVED_STRS];
+
+export const GQ_RESERVED_BUILTINS_BY_NAME: ReadonlyMap<string, GqBuiltin> = new Map(
+    GQ_RESERVED_BUILTINS.map(builtin => [builtin.name, builtin])
+);
+
+export function findGqBuiltin(name: string): GqBuiltin | undefined {
+    return GQ_RESERVED_BUILTINS_BY_NAME.get(name);
+}
+
+/** Markdown hover text for a builtin: description plus read-only/writable status. */
+export function gqBuiltinHoverMarkdown(builtin: GqBuiltin): string {
+    const status = builtin.writable ? 'game-writable' : 'read-only (VM/firmware-managed)';
+    return `**${builtin.name}** _(${builtin.kind} builtin, ${status})_\n\n${builtin.description}`;
+}
+
+/** One-line completion-item detail: description plus read-only/writable status. */
+export function gqBuiltinCompletionDetail(builtin: GqBuiltin): string {
+    const status = builtin.writable ? 'writable' : 'read-only';
+    return `${builtin.kind} builtin (${status}) -- ${builtin.description}`;
+}

--- a/gq-game-language/test/builtin-completion.test.ts
+++ b/gq-game-language/test/builtin-completion.test.ts
@@ -1,0 +1,87 @@
+import { beforeAll, describe, expect, test } from 'vitest';
+import { textDocumentPositionParams } from 'langium/test';
+import { GQ_RESERVED_INTS, GQ_RESERVED_STRS } from '../src/language/gq-builtins.js';
+import { createParse, createTestServices, VALID_GAME_BLOCK } from './test-utils.js';
+
+// Completion for reserved GQI_*/GQS_* builtins in identifier positions
+// (gamequeer#326). The default CompletionProvider has nothing to offer for
+// these positions at all (see game-queer-game-language-completion-provider.ts),
+// so we only assert that our builtins are *among* the offered completions --
+// other candidates (keywords like `badge_get`) may legitimately also appear
+// at the same cursor position.
+describe('reserved builtin completion (issue #326)', () => {
+    const services = createTestServices();
+    let parse: ReturnType<typeof createParse>;
+
+    beforeAll(() => {
+        parse = createParse();
+    });
+
+    async function completionLabelsAt(text: string, offset: number): Promise<string[]> {
+        const document = await parse(text);
+        const completions = await services.lsp.CompletionProvider?.getCompletion(
+            document,
+            textDocumentPositionParams(document, offset)
+        );
+        return (completions?.items ?? []).map(item => item.label);
+    }
+
+    test('offers all reserved int builtins inside an int expression', async () => {
+        const stage = `
+stage start {
+    event enter {
+        if () {
+        }
+    }
+}
+`;
+        const text = `${VALID_GAME_BLOCK}${stage}`;
+        const offset = text.indexOf('if (') + 'if ('.length;
+        const labels = await completionLabelsAt(text, offset);
+
+        for (const builtin of GQ_RESERVED_INTS) {
+            expect(labels).toContain(builtin.name);
+        }
+        // Str builtins are not valid in an int expression position.
+        expect(labels).not.toContain('GQS_LABEL1');
+    });
+
+    test('offers all reserved str builtins on the RHS of a str assignment', async () => {
+        const stage = `
+stage start {
+    str greeting := "";
+    event enter {
+        greeting := ;
+    }
+}
+`;
+        const text = `${VALID_GAME_BLOCK}${stage}`;
+        const offset = text.indexOf('greeting := ;') + 'greeting := '.length;
+        const labels = await completionLabelsAt(text, offset);
+
+        for (const builtin of GQ_RESERVED_STRS) {
+            expect(labels).toContain(builtin.name);
+        }
+        // Int builtins are not valid in a str expression position.
+        expect(labels).not.toContain('GQI_PLAYER_ID');
+    });
+
+    test('offers both int and str builtins as an assignment target', async () => {
+        const stage = `
+stage start {
+    event enter {
+
+    }
+}
+`;
+        const text = `${VALID_GAME_BLOCK}${stage}`;
+        // Cursor right after "enter {\n        " -- the start of a fresh
+        // StageCommand, where both CmdAssignmentInt.dst and
+        // CmdAssignmentStr.dst are viable next features.
+        const offset = text.indexOf('event enter {') + 'event enter {\n'.length;
+        const labels = await completionLabelsAt(text, offset);
+
+        expect(labels).toContain('GQI_PLAYER_ID');
+        expect(labels).toContain('GQS_LABEL1');
+    });
+});

--- a/gq-game-language/test/builtin-hover.test.ts
+++ b/gq-game-language/test/builtin-hover.test.ts
@@ -1,0 +1,71 @@
+import { beforeAll, describe, expect, test } from 'vitest';
+import { MarkupContent } from 'vscode-languageserver';
+import { textDocumentPositionParams } from 'langium/test';
+import { createParse, createTestServices, VALID_GAME_BLOCK } from './test-utils.js';
+
+// Hover surfaces a builtin's description and writable/read-only status
+// (gamequeer#326).
+describe('reserved builtin hover (issue #326)', () => {
+    const services = createTestServices();
+    let parse: ReturnType<typeof createParse>;
+
+    beforeAll(() => {
+        parse = createParse();
+    });
+
+    async function hoverAt(text: string, offset: number): Promise<string | undefined> {
+        const document = await parse(text);
+        const hover = await services.lsp.HoverProvider?.getHoverContent(document, textDocumentPositionParams(document, offset));
+        return hover && MarkupContent.is(hover.contents) ? hover.contents.value : undefined;
+    }
+
+    test('hovering a read-only int builtin shows its description and read-only status', async () => {
+        const stage = `
+stage start {
+    event enter {
+        if (GQI_PLAYER_ID == 1) {
+        }
+    }
+}
+`;
+        const text = `${VALID_GAME_BLOCK}${stage}`;
+        const offset = text.indexOf('GQI_PLAYER_ID') + 3;
+        const content = await hoverAt(text, offset);
+
+        expect(content).toContain('GQI_PLAYER_ID');
+        expect(content).toContain('Player ID');
+        expect(content).toContain('read-only');
+    });
+
+    test('hovering a writable str builtin shows its description and writable status', async () => {
+        const stage = `
+stage start {
+    event enter {
+        GQS_LABEL1 := "hi";
+    }
+}
+`;
+        const text = `${VALID_GAME_BLOCK}${stage}`;
+        const offset = text.indexOf('GQS_LABEL1') + 3;
+        const content = await hoverAt(text, offset);
+
+        expect(content).toContain('GQS_LABEL1');
+        expect(content).toContain('Label 1');
+        expect(content).toContain('game-writable');
+    });
+
+    test('does not treat an unrelated identifier as a builtin', async () => {
+        const stage = `
+stage start {
+    event enter {
+        gostage start;
+    }
+}
+`;
+        const text = `${VALID_GAME_BLOCK}${stage}`;
+        const offset = text.lastIndexOf('start;') + 2;
+        const content = await hoverAt(text, offset);
+
+        expect(content).toBeUndefined();
+    });
+});

--- a/gq-game-language/test/builtin-textmenu-result.test.ts
+++ b/gq-game-language/test/builtin-textmenu-result.test.ts
@@ -1,0 +1,49 @@
+import { beforeAll, describe, expect, test } from 'vitest';
+import { createParse, lexerAndParserErrors, VALID_GAME_BLOCK } from './test-utils.js';
+
+// Targeted repro of GQS_TEXTMENU_RESULT's pre-seed-before-textmenu write
+// pattern from gqc/examples/skel/games/working_samples/sample_working_simple.gq
+// (lines 191-196 as of gamequeer#328):
+//
+//   event enter {
+//       GQS_TEXTMENU_RESULT := my_name;
+//   }
+//   event menu {
+//       my_name := GQS_TEXTMENU_RESULT;
+//   }
+//
+// This is the evidence that GQS_TEXTMENU_RESULT is writable (not read-only,
+// as the issue speculated): the game assigns it to pre-seed the text-entry
+// buffer, and menu.c's menu_text_load() explicitly documents honoring that
+// pre-set value. That source file itself isn't swept by golden.test.ts --
+// two of its sibling fixtures hit an unrelated grammar issue
+// (gamequeer#340) that would otherwise mask this assertion -- so this test
+// parses the relevant snippet directly instead.
+describe('GQS_TEXTMENU_RESULT pre-seed pattern (issue #326)', () => {
+    let parse: ReturnType<typeof createParse>;
+
+    beforeAll(() => {
+        parse = createParse();
+    });
+
+    test('pre-seeding and reading back GQS_TEXTMENU_RESULT produces no diagnostics', async () => {
+        const declAndStage = `
+volatile {
+    str my_name := "Name";
+}
+stage start {
+    event enter {
+        GQS_TEXTMENU_RESULT := my_name;
+    }
+
+    event menu {
+        my_name := GQS_TEXTMENU_RESULT;
+    }
+}
+`;
+        const document = await parse(`${VALID_GAME_BLOCK}${declAndStage}`, { validation: true });
+
+        expect(lexerAndParserErrors(document)).toEqual([]);
+        expect(document.diagnostics ?? []).toEqual([]);
+    });
+});

--- a/gq-game-language/test/golden.test.ts
+++ b/gq-game-language/test/golden.test.ts
@@ -6,18 +6,46 @@ import { createParse, lexerAndParserErrors } from './test-utils.js';
 
 // Real-world regression sweep (issue #321): every committed .gq fixture must
 // parse cleanly under the fixed grammar, and a well-formed `game {}` block
-// must not trip the new cardinality validator (fix 3).
+// must not trip the new cardinality validator (fix 3). Recursive, so
+// sub-directories like examples/games/perf/ and examples/games/showcase/
+// are covered too (gamequeer#326/#328 review).
+//
+// gqc/examples/skel/games/working_samples/ is included deliberately:
+// sample_working_simple.gq is the fixture that demonstrates
+// GQS_TEXTMENU_RESULT's pre-seed-before-textmenu write pattern (see the
+// writable-classification rationale for that builtin, and
+// builtin-textmenu-result.test.ts's targeted repro of that same snippet).
+// Its sibling gqc/examples/skel/games/nonworking_samples/ is excluded on
+// purpose -- those fixtures exist to exercise gqc's *error* paths (e.g.
+// missing `starting_stage`, a duplicate variable name) and are expected to
+// fail validation; sweeping them in here would defeat the "zero error
+// diagnostics" assertion by design, not by regression.
 const TEST_DIR = fileURLToPath(new URL('.', import.meta.url));
 const REPO_ROOT = join(TEST_DIR, '..', '..');
 const FIXTURE_DIRS = [
     join(REPO_ROOT, 'gamequeer', 'tests', 'golden'),
-    join(REPO_ROOT, 'examples', 'games')
+    join(REPO_ROOT, 'examples', 'games'),
+    join(REPO_ROOT, 'gqc', 'examples', 'skel', 'games', 'working_samples')
 ];
 
+// sample_working.gq, sample_working_simple.gq, and persistent_test.gq each
+// declare an int variable literally named `A` and/or `B` (e.g.
+// `int A = 1;`), which collide with the grammar's `input(A)`/`input(B)`
+// button-literal keywords -- a pre-existing, unrelated grammar ambiguity
+// (gamequeer#340), not a regression from this PR. Excluded here rather
+// than silently dropping the whole directory; builtin-textmenu-result.test.ts
+// covers sample_working_simple.gq's GQS_TEXTMENU_RESULT pattern directly
+// instead.
+const KNOWN_BROKEN_FIXTURES = new Set(['sample_working.gq', 'sample_working_simple.gq', 'persistent_test.gq']);
+
 function findGqFiles(dir: string): string[] {
-    return readdirSync(dir)
-        .filter(f => f.endsWith('.gq'))
-        .map(f => join(dir, f));
+    return readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+        const fullPath = join(dir, entry.name);
+        if (entry.isDirectory()) {
+            return findGqFiles(fullPath);
+        }
+        return entry.name.endsWith('.gq') && !KNOWN_BROKEN_FIXTURES.has(entry.name) ? [fullPath] : [];
+    });
 }
 
 const fixtures = FIXTURE_DIRS.flatMap(findGqFiles).map(path => ({

--- a/gq-game-language/test/validation.test.ts
+++ b/gq-game-language/test/validation.test.ts
@@ -146,6 +146,30 @@ stage start {
         expect(document.diagnostics ?? []).toEqual([]);
     });
 
+    test('reading a read-only builtin (not assigning to it) produces no diagnostics', async () => {
+        // GQI_PLAYER_ID is read-only, but only the *assignment target*
+        // checks (checkIntAssignmentBuiltin/checkStrAssignmentBuiltin) look
+        // at builtins -- a read (an IntOperand use, e.g. in a condition)
+        // should never be flagged.
+        const document = await parse(`
+game {
+    id = 0;
+    title := "Test Game";
+    author := "duplico";
+    starting_stage = start;
+}
+stage start {
+    event enter {
+        if (GQI_PLAYER_ID == 1) {
+        }
+    }
+}
+`, { validation: true });
+
+        expect(lexerAndParserErrors(document)).toEqual([]);
+        expect(document.diagnostics ?? []).toEqual([]);
+    });
+
     test('errors when an int builtin is assigned with := (kind mismatch)', async () => {
         const document = await parse(`
 game {

--- a/gq-game-language/test/validation.test.ts
+++ b/gq-game-language/test/validation.test.ts
@@ -78,3 +78,116 @@ ${STAGE}
         expect(messages.some(m => m.includes("missing required assignment 'author'"))).toBe(true);
     });
 });
+
+describe('reserved builtin assignment validator (issue #326)', () => {
+    test('warns on assignment to a read-only int builtin', async () => {
+        const document = await parse(`
+game {
+    id = 0;
+    title := "Test Game";
+    author := "duplico";
+    starting_stage = start;
+}
+stage start {
+    event enter {
+        GQI_PLAYER_ID = 5;
+    }
+}
+`, { validation: true });
+
+        expect(lexerAndParserErrors(document)).toEqual([]);
+        const diagnostics = document.diagnostics ?? [];
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0].severity).toBe(2); // DiagnosticSeverity.Warning
+        expect(diagnostics[0].message).toContain('GQI_PLAYER_ID');
+        expect(diagnostics[0].message).toContain('read-only');
+    });
+
+    test('warns on assignment to a read-only str builtin', async () => {
+        const document = await parse(`
+game {
+    id = 0;
+    title := "Test Game";
+    author := "duplico";
+    starting_stage = start;
+}
+stage start {
+    event enter {
+        GQS_GAME_NAME := "hijacked";
+    }
+}
+`, { validation: true });
+
+        expect(lexerAndParserErrors(document)).toEqual([]);
+        const diagnostics = document.diagnostics ?? [];
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0].severity).toBe(2); // DiagnosticSeverity.Warning
+        expect(diagnostics[0].message).toContain('GQS_GAME_NAME');
+        expect(diagnostics[0].message).toContain('read-only');
+    });
+
+    test('does not warn on assignment to a writable builtin', async () => {
+        const document = await parse(`
+game {
+    id = 0;
+    title := "Test Game";
+    author := "duplico";
+    starting_stage = start;
+}
+stage start {
+    event enter {
+        GQI_LABEL1_X = 0;
+        GQS_LABEL1 := "hi";
+    }
+}
+`, { validation: true });
+
+        expect(lexerAndParserErrors(document)).toEqual([]);
+        expect(document.diagnostics ?? []).toEqual([]);
+    });
+
+    test('errors when an int builtin is assigned with := (kind mismatch)', async () => {
+        const document = await parse(`
+game {
+    id = 0;
+    title := "Test Game";
+    author := "duplico";
+    starting_stage = start;
+}
+stage start {
+    event enter {
+        GQI_LABEL1_X := "0";
+    }
+}
+`, { validation: true });
+
+        expect(lexerAndParserErrors(document)).toEqual([]);
+        const diagnostics = document.diagnostics ?? [];
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0].severity).toBe(1); // DiagnosticSeverity.Error
+        expect(diagnostics[0].message).toContain('GQI_LABEL1_X');
+        expect(diagnostics[0].message).toContain(':=');
+    });
+
+    test('errors when a str builtin is assigned with = (kind mismatch)', async () => {
+        const document = await parse(`
+game {
+    id = 0;
+    title := "Test Game";
+    author := "duplico";
+    starting_stage = start;
+}
+stage start {
+    event enter {
+        GQS_LABEL1 = 0;
+    }
+}
+`, { validation: true });
+
+        expect(lexerAndParserErrors(document)).toEqual([]);
+        const diagnostics = document.diagnostics ?? [];
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0].severity).toBe(1); // DiagnosticSeverity.Error
+        expect(diagnostics[0].message).toContain('GQS_LABEL1');
+    });
+});


### PR DESCRIPTION
## Summary

Closes #326. The extension previously had no knowledge of the reserved `GQI_*`/`GQS_*` builtin variables -- they parsed only because they matched `terminal ID`. This adds:

- **`gq-game-language/src/language/gq-builtins.ts`** -- a single data module `{ name, kind, description, writable }`, hand-synced from `gqc/src/gqc/structs.py`'s `GQ_RESERVED_INTS`/`GQ_RESERVED_STRS` (with a comment marking the sync point).
- **Completion** -- builtins are offered in int/str expression and assignment-target identifier positions via a `CompletionProvider` override. (`var=ID`/`dst=ID` in the grammar are plain strings, not cross-references, so the default provider offers nothing there at all.)
- **Hover** -- shows a builtin's description plus writable/read-only status.
- **Validation** -- extends the PR #324 validator pattern: warning-severity diagnostic on assignment to a read-only builtin, error on kind mismatch (int builtin assigned with `:=`, str builtin with `=`).

## Writable classification (investigated, not guessed)

`structs.py` doesn't encode writability, so I determined it by reading the VM (`gamequeer/src/gamequeer.c`, `menu.c`, `bytecode.c`) and firmware HAL (`ccs_workspace/qc2024/HAL_badge.c`) for who actually writes each variable, then cross-checked against every `.gq` fixture under `gamequeer/tests/golden/`, `examples/games/`, and `gqc/examples/skel/games/working_samples/`.

| Builtin | Writable | Rationale |
|---|---|---|
| `GQI_GAME_ID` | read-only | VM sets from the cartridge header in `load_game()` (`*game_id = game.id;`), clears to 0 on unload; no `.gq` fixture ever assigns it. |
| `GQI_MENU_ACTIVE` | read-only | VM-only menu-state flag, set exclusively in `menu.c`'s choice/text-entry transitions; never assigned in any fixture. |
| `GQI_MENU_VALUE` | read-only | VM writes the selected option's value in `menu.c` (`*menu_value = ...`) on the `menu` event; every fixture only ever reads it (`if (GQI_MENU_VALUE == 1) ...`). |
| `GQI_GAME_COLOR` | read-only | VM sets from the cartridge header in `load_game()`, cleared on unload; never assigned by a game. |
| `GQI_BGANIM_X`/`_Y`, `GQI_FGANIM{1,2}_X`/`_Y`, `GQI_FGMASK{1,2}_X`/`_Y`, `GQI_LABEL{1-4}_X`/`_Y`, `GQI_LABEL_FLAGS` | writable | Positioning/flag variables authored throughout the fixtures (e.g. `GQI_LABEL1_X = 0;`). `bytecode.c`'s `SETVAR` handler treats exactly this contiguous range (`GQI_BGANIM_X`..`GQI_LABEL_FLAGS`) as "visual" (game-driven, redraw-triggering) writes -- corroborating evidence, not just usage. |
| `GQI_PLAYER_ID` | read-only | Firmware writes it every game load: `HAL_badge.c`: `*player_id = badge_id;` inside `HAL_new_game()`. No `.gq` fixture assigns it. |
| `GQS_GAME_NAME` | read-only | VM copies the compiled game title into it in `load_game()` (`memcpy(game_title, game.title, ...)`), cleared on unload. The game-block `title := "...";` is a compile-time header field, not a runtime target for this builtin. |
| `GQS_PLAYER_HANDLE` | read-only | No firmware write site for it exists yet (the slot is presently unpopulated), unlike `GQI_PLAYER_ID`'s confirmed `HAL_new_game()` write. Read-only here is the conservative default for an unpopulated identity slot, not evidence of an active writer -- revisit if/when firmware starts populating it. |
| `GQS_LABEL1`-`GQS_LABEL4` | writable | Label text, authored throughout the fixtures (e.g. `GQS_LABEL1 := "HELLO WORLD";`). |
| `GQS_TEXTMENU_RESULT` | writable | **Deviates from the issue's initial guess.** `gqc/examples/skel/games/working_samples/sample_working_simple.gq` pre-seeds it in `enter { GQS_TEXTMENU_RESULT := my_name; }` before opening `textmenu`, and `menu.c`'s `menu_text_load()` explicitly documents honoring a pre-set value ("If there's already text in the buffer, it's because the enter event set it. We need to honor it."). It's also VM-written as the final result on menu close -- a deliberate two-way channel, not a plain output. |

24 int + 7 str = 31 builtins total, matching `structs.py`.

## Test plan

- [x] `npm run langium:generate`
- [x] `npm run build` (tsc + esbuild)
- [x] `npm run lint` (clean)
- [x] `npm run test` -- **57/57 passing** (34 pre-existing + 23 new: 3 completion, 3 hover, 6 builtin-validator (incl. an explicit builtin-*read* case: `if (GQI_PLAYER_ID == 1) {...}` produces zero diagnostics), 1 targeted `GQS_TEXTMENU_RESULT` repro, 24 golden-sweep cases). `test/golden.test.ts`'s fixture discovery is now **recursive** (previously missed `examples/games/perf/*.gq`, `examples/games/showcase/*.gq`) and now also walks `gqc/examples/skel/games/working_samples/`, where `sample_working_simple.gq` -- the `GQS_TEXTMENU_RESULT` pre-seed evidence -- lives. Three files there (`sample_working.gq`, `sample_working_simple.gq`, `persistent_test.gq`) are excluded by name: each declares an `int` variable literally named `A`/`B`, colliding with the grammar's `input(A)`/`input(B)` button-literal keywords -- a pre-existing, unrelated grammar ambiguity, filed as [gamequeer#340](https://github.com/duplico/gamequeer/issues/340), not a regression from this PR. `builtin-textmenu-result.test.ts` covers `sample_working_simple.gq`'s actual snippet directly instead. The golden sweep stays green with zero *error*-severity diagnostics across all included fixtures.
- [x] `make gq-game-language` (full Docker `gamequeer-builder:latest` harness: `npm install`, `langium:generate`, `build`, `vsce package`) -- vsix packages successfully.

## AI disclosure

This PR was written by Claude Code (Claude Sonnet 5) per the qc2024 repo's AI-authorship convention. All commits carry a `Co-Authored-By: Claude Fable 5` trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6CTNoncMd7oGjJja2fLBy
