### PR TITLE
docs(gqc): reword stale register-exhaustion gotcha post-#341

### DIFF
--- a/gqc/docs/authoring-and-perf-carts.md
+++ b/gqc/docs/authoring-and-perf-carts.md
@@ -162,7 +162,7 @@ also setting the opaque bit).
 compiler's register pool** — each level of `(term | (term | …))` nesting
 holds one more register live while codegen recurses into the next, and
 `IntExpression`'s allocator has only 4 int registers (`GQ_REGISTERS_INT` in
-`structs.py`), so a handful of nested levels fails with `No free registers
+`structs.py`), so a handful of nested levels fail with `No free registers
 available`. A flat chain like `(1<<0)|(1<<1)|(1<<9)|(1<<16)|(1<<17)`
 left-folds into a single accumulator (~2 registers) and is fine at any
 length. Restructure into a flat chain, or precompute a literal.

--- a/gqc/docs/authoring-and-perf-carts.md
+++ b/gqc/docs/authoring-and-perf-carts.md
@@ -158,12 +158,15 @@ opaque unset nothing paints the background, so black-on-black renders
 nothing (found while authoring `perf_text.gq`'s edge-case label — fixed by
 also setting the opaque bit).
 
-**A long chain of `<<`/`|` literal-shift terms in one expression can exhaust
-the compiler's register pool.** `IntExpression`'s allocator has only 4 int
-registers (`GQ_REGISTERS_INT` in `structs.py`); a 5-term chain like
-`(1<<0)|(1<<1)|(1<<9)|(1<<16)|(1<<17)` fails to compile with `No free
-registers available`, while a 2-3 term chain is fine. Precompute a literal
-for wide bitmasks instead.
+**A flat chain of same-precedence `<<`/`|` literal-shift terms compiles fine
+at any length** — codegen left-folds it into a single accumulator, so
+`(1<<0)|(1<<1)|(1<<9)|(1<<16)|(1<<17)` only ever needs ~2 of the 4 int
+registers (`GQ_REGISTERS_INT` in `structs.py`). **Deeply *nested*
+parenthesized subexpressions can still exhaust the pool** — each additional
+level of `(term | (term | (term | …)))` nesting holds one more register live
+while it recurses into the next level, so a handful of nested levels reaches
+`No free registers available`. Restructure into a flat chain, or precompute
+a literal, instead of nesting.
 
 The font is `g_sFontFixed6x8` (`grlib/fonts/fontfixed6x8.c`): fixed 6×8px
 glyphs, covering printable ASCII **0x20 (space) .. 0x7E (`~`)**, 95 glyphs.
@@ -458,9 +461,10 @@ flashrom invocation is tracked as
 - **Strings are 21 usable chars**; overlong values raise at compile time.
 - **`str(x)` casts can't be composed inline in a `+` chain** — cast into an
   intermediate str var first (see "Event-body statements" above).
-- **A wide `<<`/`|` literal expression can exhaust the 4-register compiler
-  pool** (`No free registers available`) — precompute a literal instead (see
-  "Labels" above).
+- **A deeply *nested* parenthesized `<<`/`|` expression can exhaust the
+  4-register compiler pool** (`No free registers available`) — a flat
+  same-precedence chain is fine at any length; restructure or precompute a
+  literal instead (see "Labels" above).
 - **Integer division/modulo by a zero divisor is unguarded.**
   `run_arithmetic()`'s `GQ_OP_DIVBY`/`GQ_OP_MODBY` cases (`bytecode.c`) are
   bare C `/` and `%` with no zero check — a zero divisor is undefined

--- a/gqc/docs/authoring-and-perf-carts.md
+++ b/gqc/docs/authoring-and-perf-carts.md
@@ -158,15 +158,14 @@ opaque unset nothing paints the background, so black-on-black renders
 nothing (found while authoring `perf_text.gq`'s edge-case label — fixed by
 also setting the opaque bit).
 
-**A flat `|` chain of literal-shift (`1<<n`) terms compiles fine at any
-length** — codegen left-folds it into a single accumulator, so
-`(1<<0)|(1<<1)|(1<<9)|(1<<16)|(1<<17)` only ever needs ~2 of the 4 int
-registers (`GQ_REGISTERS_INT` in `structs.py`). **Deeply *nested*
-parenthesized subexpressions can still exhaust the pool** — each additional
-level of `(term | (term | (term | …)))` nesting holds one more register live
-while it recurses into the next level, so a handful of nested levels reaches
-`No free registers available`. Restructure into a flat chain, or precompute
-a literal, instead of nesting.
+**Deeply nested parenthesized `|`-of-shifts subexpressions can exhaust the
+compiler's register pool** — each level of `(term | (term | …))` nesting
+holds one more register live while codegen recurses into the next, and
+`IntExpression`'s allocator has only 4 int registers (`GQ_REGISTERS_INT` in
+`structs.py`), so a handful of nested levels fails with `No free registers
+available`. A flat chain like `(1<<0)|(1<<1)|(1<<9)|(1<<16)|(1<<17)`
+left-folds into a single accumulator (~2 registers) and is fine at any
+length. Restructure into a flat chain, or precompute a literal.
 
 The font is `g_sFontFixed6x8` (`grlib/fonts/fontfixed6x8.c`): fixed 6×8px
 glyphs, covering printable ASCII **0x20 (space) .. 0x7E (`~`)**, 95 glyphs.

--- a/gqc/docs/authoring-and-perf-carts.md
+++ b/gqc/docs/authoring-and-perf-carts.md
@@ -158,8 +158,8 @@ opaque unset nothing paints the background, so black-on-black renders
 nothing (found while authoring `perf_text.gq`'s edge-case label — fixed by
 also setting the opaque bit).
 
-**A flat chain of same-precedence `<<`/`|` literal-shift terms compiles fine
-at any length** — codegen left-folds it into a single accumulator, so
+**A flat `|` chain of literal-shift (`1<<n`) terms compiles fine at any
+length** — codegen left-folds it into a single accumulator, so
 `(1<<0)|(1<<1)|(1<<9)|(1<<16)|(1<<17)` only ever needs ~2 of the 4 int
 registers (`GQ_REGISTERS_INT` in `structs.py`). **Deeply *nested*
 parenthesized subexpressions can still exhaust the pool** — each additional
@@ -461,10 +461,10 @@ flashrom invocation is tracked as
 - **Strings are 21 usable chars**; overlong values raise at compile time.
 - **`str(x)` casts can't be composed inline in a `+` chain** — cast into an
   intermediate str var first (see "Event-body statements" above).
-- **A deeply *nested* parenthesized `<<`/`|` expression can exhaust the
-  4-register compiler pool** (`No free registers available`) — a flat
-  same-precedence chain is fine at any length; restructure or precompute a
-  literal instead (see "Labels" above).
+- **A deeply *nested* parenthesized `|`-of-shifts expression can exhaust the
+  4-register compiler pool** (`No free registers available`) — a flat `|`
+  chain is fine at any length; restructure or precompute a literal instead
+  (see "Labels" above).
 - **Integer division/modulo by a zero divisor is unguarded.**
   `run_arithmetic()`'s `GQ_OP_DIVBY`/`GQ_OP_MODBY` cases (`bytecode.c`) are
   bare C `/` and `%` with no zero check — a zero divisor is undefined


### PR DESCRIPTION
## Summary

- The `authoring-and-perf-carts.md` gotcha about wide `<<`/`|` literal-shift
  chains exhausting the 4-register compiler pool was stale after PR
  duplico/gamequeer#341 (left-fold codegen). Rewords both the Labels-section
  note and the "Gotchas found" entry to reflect current behavior: a flat
  same-precedence chain of any length compiles fine (accumulator codegen,
  ~2 registers), while deeply nested parenthesized subexpressions can still
  exhaust the pool.

## Verification

Compiled two probe carts in the `gamequeer-builder` Docker container
(per the doc's §7 compile command):

- A flat 5-term chain, `(1<<0)|(1<<1)|(1<<9)|(1<<16)|(1<<17)` (the doc's
  previously-failing example) — **compiles successfully.**
- A nested construction, `(((1<<0)|(1<<1)) | (((1<<2)|(1<<3)) |
  (((1<<4)|(1<<5)) | (((1<<6)|(1<<7)) | 1<<50))))` — **fails** with
  `No free registers available`, confirming register exhaustion is still
  reachable via nesting.

## Test plan

- [x] Verified flat 5-term chain compiles clean in the builder container
- [x] Verified nested-parens construction fails with the register error
- [x] Doc reworded per repo's current-state writing convention (no
      before/after narration)

Fixes duplico/gamequeer#342.

---
AI-authorship disclosure: this PR (docs + verification) was produced with
AI assistance (Claude Fable 5), per the repo's AI-authorship convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6CTNoncMd7oGjJja2fLBy