### PR TITLE
ci: add gq-game-language vitest leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,42 @@ jobs:
         run: pytest tests
         working-directory: gqc/
 
+  gq-game-language-tests:
+    name: gq-game-language vitest suite
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js 20
+        # Matches gq-game-language/install-langium-deps.sh's `nvm install 20`
+        # (the version its Docker-based dev setup uses); package.json places
+        # no floor on engines.node.
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: gq-game-language/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: gq-game-language/
+
+      - name: Generate Langium artifacts
+        # test/*.test.ts import from src/language/generated/, which is
+        # gitignored and produced by this step (see langium-quickstart.md).
+        run: npm run langium:generate
+        working-directory: gq-game-language/
+
+      - name: Run vitest suite
+        # No Docker/submodules needed: vitest only needs Node, and
+        # test/golden.test.ts's fixture sweep reads .gq files straight from
+        # this checkout (gamequeer/tests/golden/, examples/games/,
+        # gqc/examples/skel/games/working_samples/ -- all plain paths
+        # relative to the repo root, no submodule required).
+        run: npm test
+        working-directory: gq-game-language/
+
   gamequeer-vm-build:
     name: gamequeer C VM native build + headless golden suite
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a `gq-game-language-tests` job to `.github/workflows/ci.yml`: `actions/setup-node@v4` (Node 20, matching `gq-game-language/install-langium-deps.sh`'s `nvm install 20`), `npm ci` against the committed `package-lock.json`, `npm run langium:generate`, then `npm test` (vitest).
- No Docker or submodule init required: `gamequeer` has no submodules, and `test/golden.test.ts`'s fixture sweep reads `.gq` files as plain paths relative to the checkout root (`gamequeer/tests/golden/`, `examples/games/`, `gqc/examples/skel/games/working_samples/`).
- Other CI legs (`gqc-tests`, `gamequeer-vm-build`, `gamequeer-vm-build-instrumented`) are untouched -- diff is additive only.

Closes #332. Part of epic #329.

## Test plan
- [x] Local-equivalent verification: fresh `node:20-slim` container against a pristine `git clone` of this branch, running the exact workflow commands (`npm ci`, `npm run langium:generate`, `npm test`). Result: 7 test files, 58 tests, all passing.
- [x] `.github/workflows/ci.yml` parses as valid YAML (`yaml.safe_load`).
- [x] Diffed `ci.yml` to confirm the other three jobs are byte-identical to `default`.
- [ ] New `gq-game-language-tests` leg goes green on this PR itself (real CI run) -- to be confirmed once Actions runs.

AI-authorship: this PR (code, commit, and description) was drafted by an AI agent (Claude Code, Fable 5) per repository convention.

https://claude.ai/code/session_01S6CTNoncMd7oGjJja2fLBy