### PR TITLE
docs(authoring): note the in-system cart-burning variant

### DIFF
--- a/gqc/docs/authoring-and-perf-carts.md
+++ b/gqc/docs/authoring-and-perf-carts.md
@@ -433,6 +433,15 @@ A user-friendly wrapper that automates padding, layout generation, and the
 flashrom invocation is tracked as
 [duplico/qc2024#62](https://github.com/duplico/qc2024/issues/62).
 
+The recipe above assumes the cart is pulled and seated directly in the
+CH341A. An **in-system** variant also exists: the cart stays seated in the
+badge's cart slot, with the CH341A driving it through a pass-through
+fixture while the badge itself is held in a debug-controlled reset (GPIOs
+high-impedance) via qc2024's `cart-bus-hold.sh` tooling, so the burn
+happens without unseating the cart between burn and play. See qc2024's
+[`docs/bench-workflow.md`](https://github.com/duplico/qc2024/blob/default/docs/bench-workflow.md)
+for the full in-system procedure.
+
 ## 8. Gotchas found
 
 - **Asset paths are CWD-relative** (`assets/animations/<file>`). Compile from


### PR DESCRIPTION
## Summary

- The cart-flashing section of `gqc/docs/authoring-and-perf-carts.md`
  only documented pulling the cart and seating it directly in the CH341A.
  Adds one short paragraph noting the in-system variant (burn without
  unseating, badge held in reset via qc2024's `cart-bus-hold.sh` tooling),
  pointing at qc2024's `docs/bench-workflow.md` for the full procedure
  rather than duplicating qc2024-side tooling details in this repo.

Companion PR (qc2024-side doc this points to):
https://github.com/duplico/qc2024/pull/88

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>