### PR TITLE
fix(gqc): anchor keyword-prefix grammar literals to word boundaries

### DIFF
--- a/gqc/src/gqc/grammar.py
+++ b/gqc/src/gqc/grammar.py
@@ -147,7 +147,7 @@ def build_game_parser():
     animation_assignment.set_parse_action(parse_animation_definition)
 
     # Light cue sections
-    lightcue_definition_section = pp.Suppress("lightcues") - file_assignments
+    lightcue_definition_section = pp.Suppress(pp.Keyword("lightcues")) - file_assignments
     lightcue_definition_section.set_parse_action(parse_lightcue_definition_section)
 
     # Menu sections
@@ -166,7 +166,7 @@ def build_game_parser():
     int_operand = identifier | integer
     int_operand.set_parse_action(parse_int_operand)
     int_expression = pp.infix_notation(int_operand, [
-        (pp.oneOf('! - ~ badge_get'), 1, pp.opAssoc.RIGHT),
+        (pp.Keyword('badge_get') | pp.one_of('! - ~'), 1, pp.opAssoc.RIGHT),
         (pp.one_of('* / %'), 2, pp.opAssoc.LEFT),
         (pp.one_of('+ -'), 2, pp.opAssoc.LEFT),
         (pp.one_of('<< >>'), 2, pp.opAssoc.LEFT),
@@ -182,7 +182,7 @@ def build_game_parser():
 
     string_literal = pp.QuotedString('"').setName("string_literal")
     string_literal.set_parse_action(parse_str_literal)
-    string_cast = pp.Group(pp.Suppress("str") - pp.Suppress("(") - int_expression - pp.Suppress(")"))
+    string_cast = pp.Group(pp.Suppress(pp.Keyword("str")) - pp.Suppress("(") - int_expression - pp.Suppress(")"))
     string_operand = identifier | string_literal
     string_expression = pp.infix_notation(string_operand, [
         ('+', 2, pp.opAssoc.LEFT),
@@ -195,7 +195,7 @@ def build_game_parser():
     assignment_statement.add_parse_action(parse_assignment)
 
     # Flow control
-    if_statement = pp.Suppress("if") - pp.Suppress("(") - int_expression - pp.Suppress(")") - event_statements - pp.Optional(pp.Suppress("else") - event_statements)
+    if_statement = pp.Suppress(pp.Keyword("if")) - pp.Suppress("(") - int_expression - pp.Suppress(")") - event_statements - pp.Optional(pp.Suppress(pp.Keyword("else")) - event_statements)
     if_statement.set_parse_action(parse_if)
 
     loop_statement = pp.Group(pp.Keyword("loop") - event_statements)
@@ -227,12 +227,12 @@ def build_game_parser():
     # General stage definition and options
     stage_bganim = pp.Group(pp.Keyword("bganim") - identifier - pp.Suppress(";"))
     stage_bgcue = pp.Group(pp.Keyword("bgcue") - identifier - pp.Suppress(";"))
-    stage_menu = pp.Suppress("menu") - identifier - pp.Optional(pp.Suppress("prompt") - string_operand) - pp.Suppress(";")
+    stage_menu = pp.Suppress(pp.Keyword("menu")) - identifier - pp.Optional(pp.Suppress(pp.Keyword("prompt")) - string_operand) - pp.Suppress(";")
     stage_textmenu = pp.Group(pp.Keyword("textmenu") - pp.Optional(pp.Keyword("prompt") - string_operand) - pp.Suppress(";"))
     stage_event = pp.Group(pp.Keyword("event") - event_type - event_statements)
     stage_option = stage_bganim | stage_bgcue | stage_menu | stage_event | stage_textmenu
     stage_options = pp.Group(stage_option | pp.Suppress("{") - pp.ZeroOrMore(stage_option) - pp.Suppress("}"))
-    stage_definition_section = pp.Group(pp.Suppress("stage") - identifier - stage_options)
+    stage_definition_section = pp.Group(pp.Suppress(pp.Keyword("stage")) - identifier - stage_options)
 
     stage_menu.set_parse_action(parse_bound_menu)
     stage_event.set_parse_action(parse_event_definition)

--- a/gqc/tests/test_grammar.py
+++ b/gqc/tests/test_grammar.py
@@ -390,3 +390,124 @@ def test_7_option_menu_rejects(compile_gq):
     exit_code, stderr, _ = compile_gq(source)
     assert exit_code != 0
     assert "too many options" in stderr
+
+
+# --- keyword-prefixed identifiers (gamequeer#354) ----------------------------
+# Several bare-string grammar literals (`pp.Suppress("str")`,
+# `pp.Suppress("if")`, `pp.Suppress("else")`, and the `badge_get` unary
+# operator, all matched via a plain `Literal` rather than a word-boundary-
+# anchored `Keyword`) used to greedily consume a matching prefix of a longer
+# identifier -- e.g. `str_scratch` lost its leading "str" to the `str(...)`
+# cast literal. Because these all sit ahead of `-` (And, "no backtrack")
+# operators, the mismatch after the truncated match surfaced as a hard
+# ParseSyntaxException rather than falling through to try the identifier as
+# a whole. `badge_get`/`else` are worse: since nothing *requires* the
+# character after the literal to be non-identifier, a colliding identifier
+# can still fully parse, just as the *wrong* tokens (see
+# test_else_prefixed_identifier_accepts and
+# test_badge_get_prefixed_identifier_in_expression_accepts below, which pin
+# the corrupted-but-non-crashing failure mode against fresh regressions).
+
+
+def test_str_prefixed_str_var_accepts(compile_gq):
+    # The original gamequeer#354 report: a `str`-prefixed str variable name
+    # used as the RHS operand of another string assignment used to trip the
+    # `str(...)` cast literal.
+    source = game_with_stage(
+        's := str_scratch;',
+        'volatile { str str_scratch := "x"; str s := ""; }',
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    ["int", "timer", "cue", "play", "loop"],
+)
+def test_int_keyword_prefixed_var_accepts(compile_gq, prefix):
+    # Keyword-prefixed int variable names, both as an assignment target and
+    # as an operand inside an int_expression.
+    varname = f"{prefix}_v"
+    source = game_with_stage(
+        f"{varname} = {varname} + 1;",
+        f"volatile {{ int {varname} = 0; }}",
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_badge_get_prefixed_identifier_in_expression_accepts(compile_gq):
+    # `badge_get` is matched as one alternative of a bare-string oneOf(...)
+    # inside int_expression's infixNotation; `badge_getter` used to lose its
+    # leading `badge_get` to that operator, leaving a bogus `ter` operand.
+    source = game_with_stage(
+        "y = badge_getter + 1;",
+        "volatile { int badge_getter = 0; int y = 0; }",
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_if_prefixed_identifier_as_assignment_target_accepts(compile_gq):
+    # `ifconfig = 5;` used to lose its leading `if` to if_statement's
+    # `Suppress("if")`, then hard-fail expecting `(`.
+    source = game_with_stage(
+        "ifconfig = 5;", "volatile { int ifconfig = 0; }"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_else_prefixed_identifier_accepts(compile_gq):
+    # `elsewhere = 5;` immediately after a real if-block's true branch used
+    # to have its leading `else` silently consumed by if_statement's
+    # optional `Suppress("else")` (no word-boundary check), leaving `where =
+    # 5;` to parse as its own (bogus) assignment -- a silent corruption
+    # rather than a parse error. The if-condition here is a variable
+    # comparison (not a bare literal) to route around an unrelated,
+    # pre-existing CommandIf bug (see gamequeer#354's PR) that only
+    # misfires for literal-only if-conditions.
+    source = game_with_stage(
+        "if (x == 1) { badge_set 1; } elsewhere = 5;",
+        "volatile { int x = 0; int elsewhere = 0; }",
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_stage_prefixed_stage_name_accepts(compile_gq):
+    source = (
+        'game { id = 1; title := "T"; author := "A"; starting_stage = stage_one; }\n'
+        "stage stage_one { event enter { gostage stage_two; } }\n"
+        "stage stage_two { event enter { badge_set 1; } }\n"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+# --- real keywords still parse as keywords (not swallowed by the fix) -------
+
+
+def test_str_cast_still_works_alongside_str_prefixed_var(compile_gq):
+    source = game_with_stage(
+        's := str(x);',
+        "volatile { int x = 0; str s := \"\"; str str_scratch := \"y\"; }",
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_bare_timer_statement_still_works(compile_gq):
+    source = game_with_stage("timer 5;")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_if_else_statement_still_works(compile_gq):
+    source = game_with_stage(
+        "if (x == 1) { badge_set 1; } else { badge_clear 1; }",
+        "volatile { int x = 0; }",
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr


### PR DESCRIPTION
## Summary

Fixes #354: identifiers that begin with a grammar keyword (e.g.
`str_scratch`, `ifconfig`, `elsewhere`, `badge_getter`) broke gqc parsing,
because several grammar productions used a bare pyparsing string literal
(auto-converted to `Literal`, which prefix-matches with no word-boundary
check) instead of `pp.Keyword` (which requires a non-identifier char on
both sides of the match).

## Root cause

`Literal("str")` (etc.) happily matches just the first three characters of
`str_scratch`, leaving `_scratch` dangling. Most of these sit ahead of a
`-` (`And`, "no backtrack") operator, so the follow-on mismatch raised a
hard `ParseSyntaxException` instead of falling through to try the
identifier as a whole (this is the exact `str_scratch` failure from the
issue). `badge_get` and `else` are worse: nothing requires the following
character to be a non-identifier char, so a colliding identifier can
*fully parse* as the wrong tokens with no error at all (e.g. `badge_getter`
silently became `badge_get` applied to the bogus operand `ter`; `elsewhere
= 5;` right after an `if` block's true branch silently became `where = 5;`
with `else` eaten).

## Affected keyword prefixes (full audit)

Audited every bare-literal keyword usage in `grammar.py` against the
requested prefix list. Confirmed **empirically exploitable** (reproduced
before the fix, fixed after -- see the new tests):

- `str` -- `string_cast`'s `Suppress("str")` (the reported bug)
- `if` / `else` -- `if_statement`'s `Suppress("if")` / `Suppress("else")`
- `badge_get` -- the unary-operator `pp.oneOf('! - ~ badge_get')` inside
  `int_expression`'s `infix_notation` (found during the audit, not in the
  original report)

Also hardened for consistency/defense-in-depth, but **not reachable**
given the current grammar's structure (no legal construct places a bare
identifier immediately adjacent, with no separating whitespace, at the
position where these literals are tried -- confirmed with `stage_one`/
`menufoo`-named stage tests that already passed *before* this fix):

- `menu` / `prompt` -- `stage_menu`
- `lightcues` -- `lightcue_definition_section`
- `stage` -- `stage_definition_section`

All fixed by wrapping the literal in `pp.Keyword(...)` (or, for
`badge_get`, by pulling it out of the shared `oneOf` string into an
explicit `pp.Keyword('badge_get') | pp.one_of('! - ~')` -- `one_of(...,
as_keyword=True)` was tried first but incorrectly broke the bare `!`/`-`/`~`
unary operators, since it applies `Keyword`-style boundary checks
uniformly across the whole alternation).

## Tests

Added 13 grammar accept/reject cases to `gqc/tests/test_grammar.py`
(40 -> 53 total):
- `str_scratch`-style str var used as an RHS operand
- `int`/`timer`/`cue`/`play`/`loop`-prefixed int vars, both as assignment
  targets and as expression operands
- `badge_getter` in an expression
- `ifconfig` and `elsewhere` as assignment targets (the latter right after
  a real `if` block)
- a stage named `stage_one`
- regression coverage that real keyword usage (`str(x)` cast, bare
  `timer 5;`, `if`/`else`) still parses correctly

## Verification

- `pytest tests`: 53 passed (was 40; no regressions, no ffmpeg-skips
  affected).
- Recompiled `gqc/examples/skel/games/working_samples/*.gq` and the
  `nonworking_samples/*.gq` rejects before/after: byte-identical output,
  identical exit codes (this is parse-acceptance only, no codegen change).
- Spot-checked 2 real carts from `gq-games` (read-only,
  `games/queersafe.gq` and the in-review `bricks.gq`): both compile, both
  byte-identical before/after.

## Lockstep check

Grammar/parse-acceptance only -- no bytecode, opcode, or shared-struct
change. The C VM runtime is unaffected.

## Out of scope: a separate bug found along the way

While probing `if`/`else` collisions I hit an unrelated, pre-existing
`CommandIf` bug: any `if` statement whose condition is a *bare integer
literal* (e.g. `if (1) { ... }`, as opposed to a variable/expression
condition) crashes with `AttributeError: 'CommandIf' object has no
attribute 'true_cmds'`, because `CommandIf.__init__` calls
`super().__init__()` (which unconditionally calls the overridden
`self.resolve()`) before setting `self.true_cmds`. Confirmed via `git
stash` that this reproduces identically with or without this PR's changes.
Filed as #356 rather than folding into this PR's scope; this PR's
`if`/`else`-collision tests route around it by using a variable-comparison
condition (`if (x == 1)`), same as every real `.gq` example in the repo.

---

(AI-generated via Claude Code w/ Fable 5)

https://claude.ai/code/session_01S6CTNoncMd7oGjJja2fLBy