### PR TITLE
fix(gqc): nested/parenthesized int-expression crashes (#345)

### DIFF
--- a/gqc/src/gqc/parser.py
+++ b/gqc/src/gqc/parser.py
@@ -230,6 +230,17 @@ def parse_int_expression(instring, loc, toks):
     toks = toks[0]
     if isinstance(toks, GqcIntOperand):
         return toks
+    if isinstance(toks, IntExpression):
+        # A fully-parenthesized (sub)expression used as a bare operand with
+        # no sibling operator at its own nesting level, e.g. the entire RHS
+        # of "x = (1 + 2);" or any of the parenthesized groups nested inside
+        # it, is already reduced to an IntExpression by the recursive parse
+        # of its own parens. pyparsing's infix_notation still re-invokes
+        # this parse action once more for the enclosing bare-atom match, so
+        # pass the already-built expression through unchanged instead of
+        # re-folding/re-constructing it (which would double-alloc its
+        # registers -- see gamequeer#345).
+        return toks
 
     # pyparsing's infix_notation hands us a flat token list [a, op1, b, op2,
     # c, ...] for a chain of same-precedence (opAssoc.LEFT) operators. Fold
@@ -255,6 +266,10 @@ def parse_str_literal(instring, loc, toks):
 def parse_str_expression(instring, loc, toks):
     toks = toks[0]
     if isinstance(toks, str):
+        return toks
+    if isinstance(toks, StrExpression):
+        # Same already-reduced-atom re-invocation as parse_int_expression;
+        # pass a fully-parenthesized (sub)expression through unchanged.
         return toks
 
     # Same left-fold as parse_int_expression. String `+` is associative
@@ -363,6 +378,18 @@ def parse(text):
         exit(1)
     except GqcParseError as ge:
         print(ge, file=sys.stderr)
+        exit(1)
+    except RecursionError:
+        # Deeply nested parenthesized expressions can exceed pyparsing's
+        # packrat-memoized recursive descent before codegen is ever reached
+        # (gamequeer#345). There's no source location to point at (the
+        # RecursionError can strike mid-raise, before pyparsing attaches
+        # one), so just fail cleanly instead of dumping a Python traceback.
+        print(
+            "Error: expression nesting is too deep for gqc to parse. "
+            "Split it into intermediate variables.",
+            file=sys.stderr,
+        )
         exit(1)
 
     return parsed

--- a/gqc/tests/test_expressions.py
+++ b/gqc/tests/test_expressions.py
@@ -33,8 +33,6 @@ result -> one lightcue, wrong result -> another) at nesting depths 1-3,
 including a negative control confirming the gate discriminates correctly.
 """
 
-import pathlib
-
 import pytest
 
 GAME_HEADER = 'game { id = 1; title := "T"; author := "A"; starting_stage = start; }\n'
@@ -86,7 +84,11 @@ def test_fully_parenthesized_chain_compiles_with_correct_value(compile_gq):
     assert "0x00000002" in addby_lines[0]
     assert "0x00000003" in addby_lines[1]
     assert "0x00000004" in addby_lines[2]
-    dest_regs = {line.split()[3] for line in addby_lines}
+    # Column layout is "Address Command Op Flags arg1 arg2" (see
+    # linker.create_symbol_table's gqasm header) -- arg1 (index 4) is the
+    # destination register; index 3 is Flags, which is constant across
+    # these lines and wouldn't catch a register-reuse regression.
+    dest_regs = {line.split()[4] for line in addby_lines}
     assert len(dest_regs) == 1
 
 
@@ -181,5 +183,7 @@ def test_flat_6_term_chain_stays_single_register(compile_gq):
     cmds = (out_dir / "cmds.gqasm").read_text()
     addby_lines = [line for line in cmds.splitlines() if "ADDBY" in line]
     assert len(addby_lines) == 5
-    dest_regs = {line.split()[3] for line in addby_lines}
+    # arg1 (index 4) is the destination register; see the column-layout
+    # note in test_fully_parenthesized_chain_compiles_with_correct_value.
+    dest_regs = {line.split()[4] for line in addby_lines}
     assert len(dest_regs) == 1

--- a/gqc/tests/test_expressions.py
+++ b/gqc/tests/test_expressions.py
@@ -1,0 +1,185 @@
+"""Nested parenthesized int-expression regression suite (gamequeer#345, epic
+gamequeer#329). To be absorbed into gamequeer#334's dedicated codegen test
+suite when that lands.
+
+Before this fix, `parse_int_expression`'s left-fold (added by gamequeer#341,
+`gqc/src/gqc/parser.py`) only handled a flat token list. pyparsing's
+`infix_notation` re-invokes the *same* parse action once more on the bare
+atom whenever an entire (sub)expression collapses to a single already-built
+`IntExpression` -- which happens for any fully-parenthesized expression, not
+just deeply "nested" ones (`x = (1 + 2);` reproduced the crash on its own).
+That second invocation handed `parse_int_expression` an `IntExpression`
+instance directly (instead of a flat token list), and `if len(toks) > 3`
+raised `TypeError: object of type 'IntExpression' has no len()`.
+
+Separately, pyparsing's packrat recursive descent hits Python's own
+recursion limit on sufficiently deep nesting (5+ levels for the shapes
+below), raising a bare `RecursionError` before codegen is ever reached --
+unrelated to the fold logic, so it's handled as its own clean diagnostic in
+`parser.parse()` rather than "fixed" by restructuring the grammar.
+
+Per gamequeer#331/#341 precedent, correctness is asserted cheaply from the
+emitted `cmds.gqasm` listing rather than a full bytecode/VM run. The exact
+nested-shift shapes from gamequeer#345's repro (which use `1<<50`, a
+shift-by-a-not-representable-amount on the VM's 32-bit `t_gq_int`) are only
+asserted to compile without crashing -- not to evaluate to a specific value,
+since that value is platform/compiler-dependent (UB in C) and not something
+gqc's compiler is responsible for. Correct-value assertions instead use
+plain, portable arithmetic on the same "fully-parenthesized" shape that
+actually triggers the bug. The nested-shift shapes were additionally
+verified end to end against the headless emulator during development (see
+the gamequeer#345 PR description) with a pass/fail gate cart (correct
+result -> one lightcue, wrong result -> another) at nesting depths 1-3,
+including a negative control confirming the gate discriminates correctly.
+"""
+
+import pathlib
+
+import pytest
+
+GAME_HEADER = 'game { id = 1; title := "T"; author := "A"; starting_stage = start; }\n'
+
+
+def game_with_stage(body: str, decls: str = "") -> str:
+    """A minimal valid game with a single stage `start` whose `enter` event
+    runs `body`, optionally preceded by top-level declarations (e.g. a
+    `volatile { ... }` block)."""
+    return f"{GAME_HEADER}{decls}\nstage start {{ event enter {{ {body} }} }}\n"
+
+
+def assert_no_traceback(stderr: str):
+    assert "Traceback" not in stderr, f"raw Python traceback leaked to stderr:\n{stderr}"
+
+
+# --- the minimal previously-crashing shape: any fully-parenthesized RHS -----
+# Nesting isn't actually required to hit the bug -- a single pair of parens
+# around the *entire* right-hand side already reproduces it, because
+# infix_notation re-invokes parse_int_expression on the bare, already-built
+# IntExpression atom.
+
+
+def test_fully_parenthesized_pair_compiles_with_correct_value(compile_gq):
+    source = game_with_stage("x = (1 + 2);", "volatile { int x = 0; }")
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+    assert_no_traceback(stderr)
+    cmds = (out_dir / "cmds.gqasm").read_text()
+    addby_lines = [line for line in cmds.splitlines() if "ADDBY" in line]
+    assert len(addby_lines) == 1
+    assert "0x00000002" in addby_lines[0]
+
+
+def test_fully_parenthesized_chain_compiles_with_correct_value(compile_gq):
+    # The parenthesized RHS is itself a >3-token left-fold chain, so this
+    # exercises both bugs at once: the fold first reduces "1+2+3+4" to a
+    # single IntExpression, and then the outer bare-atom re-invocation used
+    # to crash trying to len() that already-built IntExpression.
+    source = game_with_stage("x = (1 + 2 + 3 + 4);", "volatile { int x = 0; }")
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+    assert_no_traceback(stderr)
+    cmds = (out_dir / "cmds.gqasm").read_text()
+    addby_lines = [line for line in cmds.splitlines() if "ADDBY" in line]
+    # Single accumulator register throughout -- same left-fold guarantee as
+    # the unparenthesized chain (gamequeer#341).
+    assert len(addby_lines) == 3
+    assert "0x00000002" in addby_lines[0]
+    assert "0x00000003" in addby_lines[1]
+    assert "0x00000004" in addby_lines[2]
+    dest_regs = {line.split()[3] for line in addby_lines}
+    assert len(dest_regs) == 1
+
+
+# --- exact gamequeer#345 repro shapes: nested (1<<a | 1<<b) | (...) chains --
+# These use the issue's own `1<<50` sentinel, so only exit code / absence of
+# a raw traceback is asserted -- not a specific numeric result (see module
+# docstring).
+
+
+def nested_shift_or_chain(pair_count: int) -> str:
+    """Build the gamequeer#345 repro shape: `pair_count` nested
+    `((1<<a)|(1<<b)) | (...)` groups, terminating in a bare `1<<50`. Matches
+    the issue's own depth-2/4/5 examples verbatim at pair_count=2/4/5."""
+    expr = "1<<50"
+    for i in reversed(range(pair_count)):
+        expr = f"(((1<<{2 * i})|(1<<{2 * i + 1})) | {expr})"
+    return expr
+
+
+@pytest.mark.parametrize("pair_count", [2, 3])
+def test_nested_shift_or_chain_previously_typeerror_now_compiles(compile_gq, pair_count):
+    source = game_with_stage(
+        f"mask = {nested_shift_or_chain(pair_count)};", "volatile { int mask = 0; }"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+    assert_no_traceback(stderr)
+
+
+def test_nested_shift_or_chain_4_pairs_register_exhaustion_boundary(compile_gq):
+    # Pin the current (post-fix) 4-register-exhaustion boundary: gqc has
+    # exactly 4 int registers (GQ_REGISTERS_INT), and this shape's 4 nested
+    # `(1<<a)|(1<<b)` groups each need a register alive concurrently with
+    # its enclosing OR, exhausting the pool. This is a clean, documented
+    # GqcParseError-style diagnostic, not a crash.
+    source = game_with_stage(
+        f"mask = {nested_shift_or_chain(4)};", "volatile { int mask = 0; }"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+    assert_no_traceback(stderr)
+    assert "No free registers available" in stderr
+
+
+def test_nested_shift_or_chain_5_pairs_previously_recursionerror_now_clean(compile_gq):
+    # One level deeper than the register-exhaustion boundary: pyparsing's
+    # packrat recursive descent exceeds Python's own recursion limit before
+    # codegen is ever reached. Pin the clean one-line diagnostic instead of
+    # a raw RecursionError traceback.
+    source = game_with_stage(
+        f"mask = {nested_shift_or_chain(5)};", "volatile { int mask = 0; }"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+    assert_no_traceback(stderr)
+    assert "too deep" in stderr
+
+
+# --- #341 review case: nested non-associative subtraction -------------------
+
+
+def test_nested_subtraction_evaluates_nonassociatively(compile_gq):
+    # 10 - (5 - (2 - 1)) = 10 - (5 - 1) = 10 - 4 = 6, not the flat left-fold
+    # result. Was already correct pre-#345-fix (the outer expression isn't a
+    # bare parenthesized atom, so the buggy re-invocation path wasn't hit)
+    # -- pinned here as a regression guard now that parse_int_expression's
+    # atom-passthrough logic has changed.
+    source = game_with_stage("x = 10 - (5 - (2 - 1));", "volatile { int x = 0; }")
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+    cmds = (out_dir / "cmds.gqasm").read_text()
+    lines = cmds.splitlines()
+    subby_lines = [line for line in lines if "SUBBY" in line]
+    setvar_lines = [line for line in lines if "SETVAR" in line]
+    assert len(subby_lines) == 3
+    # Innermost "2 - 1" is the only SUBBY against an immediate; the outer two
+    # subtract a previously-computed register result (5 and 10 arrive as
+    # SETVAR-loaded literals, then SUBBY operates register-to-register).
+    assert "0x00000001" in subby_lines[0]  # 2 - 1
+    assert any("0x00000002" in line for line in setvar_lines)  # literal 2
+    assert any("0x00000005" in line for line in setvar_lines)  # literal 5
+    assert any("0x0000000a" in line for line in setvar_lines)  # literal 10 (0x0a)
+
+
+# --- flat chain stays single-register ---------------------------------------
+
+
+def test_flat_6_term_chain_stays_single_register(compile_gq):
+    source = game_with_stage("x = 1+2+3+4+5+6;", "volatile { int x = 0; }")
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+    cmds = (out_dir / "cmds.gqasm").read_text()
+    addby_lines = [line for line in cmds.splitlines() if "ADDBY" in line]
+    assert len(addby_lines) == 5
+    dest_regs = {line.split()[3] for line in addby_lines}
+    assert len(dest_regs) == 1


### PR DESCRIPTION
## Summary

Fixes duplico/gamequeer#345 (part of epic duplico/gamequeer#329). Three failure bands were reported for parenthesized `int_expression`s at increasing nesting:

- **2-3 nesting levels**: `TypeError: object of type 'IntExpression' has no len()`
- **4 nesting levels**: clean, documented `No free registers available` (expected/unchanged)
- **5+ nesting levels**: raw `RecursionError` traceback

## Root cause

pyparsing's `infix_notation` re-invokes the attached parse action (`parse_int_expression`/`parse_str_expression`) a *second time* on the bare atom whenever a fully-parenthesized (sub)expression collapses to a single already-built `IntExpression`/`StrExpression`. This isn't specific to "nesting" -- a single `x = (1 + 2);` reproduces it on its own, since the entire RHS is one bare parenthesized atom. The #341 left-fold's `if len(toks) > 3:` then crashes trying `len()` on that already-reduced `IntExpression` instance, because it assumed a flat token list.

The 5+ level `RecursionError` is a separate, unrelated issue: pyparsing's packrat recursive descent exceeds Python's own recursion limit before codegen is ever reached for sufficiently deep nesting of this shape.

## Fix

- `gqc/src/gqc/parser.py`: added an `isinstance(toks, IntExpression)` / `isinstance(toks, StrExpression)` atom-passthrough check in `parse_int_expression`/`parse_str_expression`, mirroring the existing `GqcIntOperand`/`str` short-circuit -- pass an already-reduced expression through unchanged instead of re-folding/re-constructing it (which would double-allocate its registers).
- `parser.parse()`: catch `RecursionError` and emit a clean one-line diagnostic instead of leaking a raw Python traceback for the 5+ level band.
- `gqc/tests/test_expressions.py` (new file -- **not** `test_grammar.py**, to avoid a merge conflict with a concurrent PR adding cases there): 8 tests covering the fully-parenthesized-pair/chain shape, the exact issue repro shapes at 2/3/4/5 nesting levels, the #341 `10 - (5 - (2 - 1)) == 6` regression, and a flat 6-term single-register chain. **duplico/gamequeer#334** (the dedicated codegen test suite) should absorb these when it lands.

## Per-band before/after

| Shape | Before | After |
|---|---|---|
| `x = (1 + 2);` (single paren pair) | `TypeError: object of type 'IntExpression' has no len()` | compiles, `x = 3` |
| Issue's 2-3 nesting levels | same `TypeError` | compiles cleanly |
| Issue's 4 nesting levels | `Error: No free registers available` | unchanged -- same clean error, same boundary |
| Issue's 5+ nesting levels | raw `RecursionError` traceback | `Error: expression nesting is too deep for gqc to parse. Split it into intermediate variables.` |

## Bytecode-correctness verification

Built the headless emulator locally (`cmake -B build-headless -DGQ_HEADLESS=ON`) and ran a pass/fail gate cart at nesting depths 1-3 of the issue's shape family (shift amounts capped at `1<<20` instead of the issue's `1<<50`, since shifting a 32-bit `t_gq_int` by 50 is C UB and not portable). Each cart computes the nested expression, compares it against the Python-precomputed expected value via `if (mask == EXPECTED)`, and selects a lime vs. red lightcue accordingly, observed via `--dump-leds`:

- All three depths (1, 2, 3) showed **lime** (`0,255,0`) -- correct value.
- A **negative control** (deliberately wrong expected value at depth 2) showed **red** (`255,0,0`) -- confirming the gate discriminates correctly rather than trivially passing.

## Golden fixture regression check

Recompiled all 15 `.gq` fixtures in `gamequeer/tests/golden/` with the patched compiler:

- **14 are byte-identical** to their checked-in `.gqgame`.
- `anim_advance.gqgame` differs, but this is **pre-existing and unrelated**: the identical byte-diff reproduces against unmodified `origin/default` (confirmed by recompiling on a clean stash), pointing at some other nondeterminism in animation encoding, not this change.

## Verification

`pytest tests` (from `gqc/`): 48 passed (40 pre-existing + 8 new), 0 failed.

## Lockstep

Parser-side only (pyparsing grammar/codegen logic in `gqc`). No bytecode format, opcode, or shared-struct change -- nothing needed on the C VM side.

---

Do not merge -- pending review/convergence.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

https://claude.ai/code/session_01S6CTNoncMd7oGjJja2fLBy