### PR TITLE
fix(emulator): raise HAL_INPUT_MAX_EVENTS to 4096

### DIFF
--- a/gamequeer/src/HAL.c
+++ b/gamequeer/src/HAL.c
@@ -159,7 +159,9 @@ void HAL_init(int argc, char *argv[]) {
  * This is minimal — enough to exercise button-driven game logic in tests.
  */
 
-#define HAL_INPUT_MAX_EVENTS 256
+#ifndef HAL_INPUT_MAX_EVENTS
+#define HAL_INPUT_MAX_EVENTS 4096
+#endif
 
 static uint16_t hal_input_events[HAL_INPUT_MAX_EVENTS];
 static int hal_input_count  = 0;


### PR DESCRIPTION
## Summary

- `HAL_input_load()`'s scripted `--input` mechanism (`gamequeer/src/HAL.c`) caps replayed button events at `HAL_INPUT_MAX_EVENTS = 256` (one event consumed per tick, unconditionally, whether or not that tick needs real input). That's well below what a full card-game playthrough needs to script end-to-end: e.g. the in-progress Donsol port's R13 resolve pause is 50 ticks, so a natural 54-card victory transcript needs on the order of 2800+ ticks of real button presses -- about 11x the old cap. Past 256 lines, `HAL_input_load()` silently stops loading further events and falls through to live (no-op in headless) key polling, which desyncs any longer script from the intended game state without any error being raised.
- This is headless **test-harness capacity**, not a VM/cart-format change. Confirmed `HAL_INPUT_MAX_EVENTS`/`HAL_input_load`/`hal_input_events` are emulator-only: the hardware HAL (`HAL_badge.c`, in the `qc2024` repo) never references any of them.
- Raises the constant to 4096 and wraps it in `#ifndef` so a build can still override it (e.g. a future test wanting an even longer script, or a build wanting to keep the tighter old default).

## Test plan

- [x] Rebuilt headless (`-DGQ_HEADLESS=ON`); full existing golden suite still passes (25/25, `ctest`).
- [x] Smoke-tested a 1000-line `--input` script (previously would have silently truncated at 256) against `tests/golden/hello.gqgame`; runs cleanly to completion.

## Notes

This unblocks scripting a full natural-playthrough victory transcript for the Donsol port (currently in progress in a separate repo, `duplico/gq-games`, per the game/cart-vs-VM split); that golden fixture is intentionally *not* included here and will land in a follow-up once this merges.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>