### PR TITLE
fix(gqc): encode negative menu option values as two's complement

### DIFF
--- a/gqc/src/gqc/datamodel.py
+++ b/gqc/src/gqc/datamodel.py
@@ -740,8 +740,18 @@ class Menu:
 
         for label, value in self.options.items():
             bytes_out += label.encode('ascii').ljust(structs.GQ_STR_SIZE, b'\x00')
-            bytes_out += value.to_bytes(structs.GQ_INT_SIZE, 'little')
-        
+            # t_gq_int (GQI_MENU_VALUE) is a signed 32-bit int on-cart (see
+            # gamequeer.h), so a negative option value must be encoded as
+            # signed two's complement -- plain int.to_bytes(..., 'little')
+            # defaults to unsigned and raises OverflowError on a negative
+            # value (gamequeer#362). Non-negative values keep the unsigned
+            # encoding they already had; unlike the persistent-variable
+            # section (gamequeer#359 / linker.py's 0xFFFFFFFF padding
+            # sentinel), the menu section has no analogous non-negative
+            # sentinel that would need to stay unsigned, but the conditional
+            # form is kept anyway to match that fix's pattern.
+            bytes_out += value.to_bytes(structs.GQ_INT_SIZE, 'little', signed=value < 0)
+
         return bytes_out
     
     def set_addr(self, addr : int, namespace : int = structs.GQ_PTR_NS_CART):

--- a/gqc/tests/support.py
+++ b/gqc/tests/support.py
@@ -8,11 +8,11 @@ package doesn't need any of that: it drives `python -m gqc compile` as a
 subprocess per test (see `compile_gq` in conftest.py), which gets fresh
 state for free.
 
-`reset_compiler_state()` exists for *future* tests that want to compile
-in-process (e.g. to inspect intermediate objects instead of just exit code
-and stderr) more than once per pytest session. It is additive only: nothing
-in this file changes any production behavior, and nothing in the current
-suite calls it.
+`reset_compiler_state()` lets tests that want to compile in-process (e.g. to
+inspect intermediate objects instead of just exit code and stderr) do so
+more than once per pytest session -- see `test_support.py` and other
+in-process test modules in this package for callers. It is additive only:
+nothing in this file changes any production behavior.
 """
 
 from gqc import structs

--- a/gqc/tests/test_negative_menu_values.py
+++ b/gqc/tests/test_negative_menu_values.py
@@ -1,0 +1,101 @@
+"""Regression coverage for gamequeer#362: a negative menu option value used
+to crash `gqc compile` with an `OverflowError`, the `Menu.to_bytes()`
+sibling of the `Variable.to_bytes()` bug fixed for gamequeer#359 (PR #361).
+
+The end-to-end (CLI) case below uses the `compile_gq` fixture from
+conftest.py, matching the accept/reject style of test_grammar.py. The
+byte-level cases drive gqc in-process (see tests/support.py) so they can
+inspect the actual on-cart encoding of each menu option's value instead of
+just the exit code, without needing to reverse-engineer file offsets out of
+the compiled `.gqgame` binary.
+"""
+
+import io
+import struct
+
+import pytest
+
+from gqc import linker, parser, structs
+from gqc.datamodel import Menu
+
+from .support import reset_compiler_state
+
+GAME_HEADER = 'game { id = 1; title := "T"; author := "A"; starting_stage = start; }\n'
+
+
+def _compile_in_process(decls: str):
+    """Compile a minimal game with the given top-level `decls` (e.g. a
+    `menus { ... }` block) in-process, and return the resulting symbol
+    table for inspection."""
+    reset_compiler_state()
+    linker.create_reserved_variables()
+    source = f"{GAME_HEADER}{decls}\nstage start {{ event enter {{ }} }}\n"
+    parser.parse(io.StringIO(source))
+    return linker.create_symbol_table(table_dest=io.StringIO(), cmd_dest=io.StringIO())
+
+
+# --- CLI (black-box) cases --------------------------------------------------
+
+
+def test_negative_menu_value_compiles(compile_gq):
+    source = (
+        f"{GAME_HEADER}"
+        'menus { m1 { -1 : "neg"; 2 : "pos"; } }\n'
+        "stage start { event enter { } }\n"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+# --- in-process (white-box) cases -------------------------------------------
+
+
+def test_menu_negative_value_encodes_twos_complement():
+    _compile_in_process('menus { m1 { -1 : "neg"; 2 : "pos"; } }')
+
+    menu = Menu.menu_table["m1"]
+    assert menu.options["neg"] == -1
+    assert menu.options["pos"] == 2
+
+    encoded = menu.to_bytes()
+
+    # Layout: option_count (GQ_INT_SIZE), then per option: label
+    # (GQ_STR_SIZE) + value (GQ_INT_SIZE), in declaration order.
+    option_size = structs.GQ_STR_SIZE + structs.GQ_INT_SIZE
+    count = int.from_bytes(encoded[: structs.GQ_INT_SIZE], "little")
+    assert count == 2
+
+    neg_value_bytes = encoded[
+        structs.GQ_INT_SIZE + structs.GQ_STR_SIZE : structs.GQ_INT_SIZE + option_size
+    ]
+    assert neg_value_bytes == (-1 & 0xFFFFFFFF).to_bytes(structs.GQ_INT_SIZE, "little")
+    assert struct.unpack(structs.GQ_INT_FORMAT, neg_value_bytes)[0] == -1
+
+    pos_value_bytes = encoded[
+        structs.GQ_INT_SIZE + option_size + structs.GQ_STR_SIZE :
+        structs.GQ_INT_SIZE + option_size * 2
+    ]
+    assert struct.unpack(structs.GQ_INT_FORMAT, pos_value_bytes)[0] == 2
+
+
+def test_menu_negative_value_distinguishes_from_unsigned_bit_pattern():
+    # -100 (unlike -1) doesn't happen to share its two's-complement bit
+    # pattern with any other plausible unsigned encoding, so this pins down
+    # that the encoding is genuinely signed two's complement.
+    _compile_in_process('menus { m1 { -100 : "neg"; } }')
+
+    menu = Menu.menu_table["m1"]
+    encoded = menu.to_bytes()
+    value_bytes = encoded[structs.GQ_INT_SIZE + structs.GQ_STR_SIZE:]
+    assert struct.unpack(structs.GQ_INT_FORMAT, value_bytes)[0] == -100
+
+
+def test_menu_positive_value_still_encodes_unsigned():
+    # Regression guard: non-negative menu option values must keep encoding
+    # exactly as they did before this fix.
+    _compile_in_process('menus { m1 { 4000 : "pos"; } }')
+
+    menu = Menu.menu_table["m1"]
+    encoded = menu.to_bytes()
+    value_bytes = encoded[structs.GQ_INT_SIZE + structs.GQ_STR_SIZE:]
+    assert value_bytes == (4000).to_bytes(structs.GQ_INT_SIZE, "little")


### PR DESCRIPTION
## Summary

- `Menu.to_bytes()` (`gqc/src/gqc/datamodel.py`) encoded each menu option's on-cart value with the unsigned default of `int.to_bytes()`, so a menu option with a negative value (e.g. `menus { m1 { -1 : "neg"; 2 : "pos"; } }`) crashed `gqc compile` with an `OverflowError` in `linker.generate_code`. This is the same bug class as #359, in the menu path -- flagged as a follow-up during adversarial review of #361 and filed as #362 so it would survive #359 auto-closing on that PR's merge.
- Fix: only switch to signed encoding when the value is actually negative, mirroring #361's `signed=value < 0` conditional pattern.

**Lockstep check:** confirmed compiler-only. `gq_menu_option.value` (`gamequeer/include/gamequeer.h`) is a `t_gq_int` (`typedef int32_t t_gq_int;`), and `handle_event_menu_choice()` (`gamequeer/src/menu.c`) does a straight `*menu_value = menu_current->options[menu_option_selected].value;` -- a signed int32 read of the same bytes gqc writes, so no VM-side change is needed.

**Conditional vs. unconditional:** kept the same `signed=value < 0` conditional form #361 established, rather than switching unconditionally to `struct.pack(structs.GQ_INT_FORMAT, value)`. I checked whether the menu section has any non-negative sentinel analogous to the persistent-variable section's `0xFFFFFFFF` linker padding (the reason #361 needed the conditional instead of an unconditional signed pack) -- it does not; `linker.py` places menus back-to-back via each `Menu.size()` with no padding/sentinel entries. So an unconditional signed pack would also have worked here. Used the conditional anyway for consistency with #361 and because it's strictly safer against any future non-negative-but-out-of-int32-range value in this path.

Also fixes `gqc/tests/support.py`'s module docstring, which claimed nothing in the suite calls `reset_compiler_state()` -- stale even before this PR, since `test_support.py` already calls it.

## Test plan

- [x] Reproduced the crash pre-fix with the issue's minimal repro cart (`menus { m1 { -1 : "neg"; 2 : "pos"; } }`), confirmed `OverflowError: can't convert negative int to unsigned` at `Menu.to_bytes()`, and confirmed the fix resolves it (exit code 0).
- [x] New `gqc/tests/test_negative_menu_values.py`: CLI-level accept coverage for a negative menu option value, plus in-process byte-level checks that a negative option value (`-1`, `-100`) round-trips as signed two's complement and a positive option value still encodes unsigned.
- [x] No existing pytest-level pattern in this package drives the headless C VM/emulator to assert `GQI_MENU_VALUE` after a menu confirm (that tooling lives in `gamequeer/tests`'s cmake/C golden-test harness, not gqc's Python suite), so this PR relies on the in-process byte-level assertions instead.
- [x] `cd gqc && make test` -- 57 passed (53 pre-existing + 4 new), no regressions.

Fixes https://github.com/duplico/gamequeer/issues/362

🤖 Generated with [Claude Code](https://claude.com/claude-code)