### PR TITLE
fix(leds): make RTC-ISR-reachable LED flushes non-blocking

### DIFF
--- a/gamequeer/include/HAL.h
+++ b/gamequeer/include/HAL.h
@@ -17,6 +17,24 @@ void HAL_init(int argc, char *argv[]);
 
 void HAL_update_leds();
 
+/*
+ * Same redraw as HAL_update_leds(), except it must never block waiting on
+ * driver hardware: on a target where the LED redraw path can be in flight
+ * when this is called (e.g. a busy TLC5948A SPI transfer whose completion
+ * interrupt is masked in the caller's context), an implementation may drop
+ * this redraw instead of waiting. leds.c calls this instead of
+ * HAL_update_leds() from led_tick() and the code paths reachable only
+ * through it (led_anim_done()'s bg-restore and non-bg-cue-stop branches):
+ * those are the sole call paths that run from the badge's RTC ISR, where a
+ * blocking wait for an in-flight transfer could deadlock (the transfer's
+ * own completion interrupt can't run until the RTC ISR returns). Every
+ * other LED flush (led_stop() called directly, load_game()'s boot colors)
+ * runs from ordinary main-loop context and keeps using HAL_update_leds().
+ * On hosts with no such hazard (e.g. the emulator), this may simply be an
+ * alias for HAL_update_leds().
+ */
+void HAL_update_leds_nonblocking();
+
 void HAL_event_poll();
 void HAL_sleep();
 t_gq_int HAL_get_player_id();

--- a/gamequeer/src/HAL.c
+++ b/gamequeer/src/HAL.c
@@ -196,6 +196,12 @@ void HAL_update_leds() {
     }
 }
 
+void HAL_update_leds_nonblocking() {
+    // The emulator has no in-flight-transfer hazard to avoid (gfx_flush()
+    // is synchronous), so the non-blocking variant is just an alias.
+    HAL_update_leds();
+}
+
 void HAL_new_game() {
     // Nothing to do, on the emulator.
 }

--- a/gamequeer/src/leds.c
+++ b/gamequeer/src/leds.c
@@ -213,7 +213,11 @@ static void led_render_frame() {
     }
 }
 
-void led_stop() {
+// Shared bookkeeping for led_stop() and led_anim_done()'s non-bg-cue stop
+// branch: clears animation/color state but doesn't flush -- callers decide
+// which HAL flush variant is safe for their context (see led_stop() vs.
+// led_anim_done() below).
+static void led_stop_state() {
     // Stop the animation flag.
     leds_animating = 0;
     // Unsave any background cue.
@@ -223,11 +227,23 @@ void led_stop() {
     for (uint8_t i = 0; i < 5; i++) {
         gq_leds[i] = (rgbcolor16_t) {.r = 0, .g = 0, .b = 0};
     }
+}
 
-    // Flush the LEDs.
+void led_stop() {
+    led_stop_state();
+    // Flush the LEDs. This flush's only callers (gamequeer.c's load_stage()
+    // and unload_game()) run from ordinary main-loop context, never from
+    // the RTC ISR, so it's safe -- and needs to actually take effect rather
+    // than possibly get dropped -- to block until any in-flight transfer
+    // completes.
     HAL_update_leds();
 }
 
+// Only ever called from led_tick(), i.e. from the RTC ISR: every flush in
+// this function must therefore use HAL_update_leds_nonblocking(), not
+// HAL_update_leds() -- a blocking wait here for an in-flight transfer could
+// deadlock, since the transfer's own completion interrupt can't run until
+// the RTC ISR returns (see HAL_update_leds_nonblocking()'s declaration).
 void led_anim_done() {
     // If we just completed a non-background cue, and we have a background cue saved, restore it.
     if (leds_cue_bg_saved && !leds_cue.bgcue) {
@@ -253,7 +269,7 @@ void led_anim_done() {
         // gap-free: the fg cue's final frame row is followed directly by
         // the bg cue's correct, fully resumed (possibly mid-fade) color.
         led_render_frame();
-        HAL_update_leds();
+        HAL_update_leds_nonblocking();
         // Credit this display the same way led_tick()'s own per-subtick
         // advance does (render, then bump leds_cue_frame_ticks_elapsed by
         // LEDS_SUBTICKS): this render just showed the resumed elapsed value,
@@ -264,8 +280,12 @@ void led_anim_done() {
         // ordinary frame-advance case.
         leds_cue_frame_ticks_elapsed += LEDS_SUBTICKS;
     } else {
-        // Otherwise, just stop the animation.
-        led_stop();
+        // Otherwise, just stop the animation. Inlined rather than calling
+        // led_stop(): this function only ever runs from the RTC ISR (see
+        // the function comment above), so it needs led_stop()'s bookkeeping
+        // with a non-blocking flush, not led_stop()'s own blocking one.
+        led_stop_state();
+        HAL_update_leds_nonblocking();
     }
 }
 
@@ -382,6 +402,13 @@ void led_play_cue(t_gq_pointer cue_ptr, uint8_t background) {
     led_setup_frame();
 }
 
+// Runs from the RTC ISR in every build that defines GQ_SUPPRESS_LED_TICK
+// (all builds as of this writing); when that's absent it instead runs from
+// system_tick() in ordinary main-loop context (see gamequeer.c). Either
+// way, its own flush and every flush reachable only through it (see
+// led_anim_done()'s comment) must be non-blocking: a bail-if-busy flush is
+// harmless main-loop-context too (it just drops a redraw), so this doesn't
+// need to detect which context it's actually running in.
 void led_tick() {
     uint8_t need_to_redraw = 0;
     static uint8_t subtick = LEDS_SUBTICKS - 1;
@@ -453,6 +480,6 @@ void led_tick() {
     }
 
     if (need_to_redraw) {
-        HAL_update_leds();
+        HAL_update_leds_nonblocking();
     }
 }


### PR DESCRIPTION
## Summary

Part of the fix for [duplico/qc2024#59](https://github.com/duplico/qc2024/issues/59) (TLC5948A LED-driver busy-wait deadlock). That issue's disassembly-confirmed root cause is that the badge firmware's `tlc_send_type` flag wasn't `volatile`, causing `--opt_level=3` to miscompile the driver's busy-wait as a permanent jump-to-self. The `volatile` fix alone is not sufficient: it restores correct busy-wait behavior, but a busy-wait reached from the badge's RTC ISR (GIE disabled) would then deadlock legitimately, because the completing SPI-transfer interrupt can't run until the RTC ISR returns. See the firmware-side PR (duplico/qc2024) for the `volatile` fix and disassembly proof.

This PR is the VM-side half: it gives the firmware a non-blocking LED-flush entry point (`HAL_update_leds_nonblocking()`) and routes every `leds.c` call path reachable only from the RTC ISR through it instead of the blocking `HAL_update_leds()`.

## Caller/context enumeration

`led_tick()` runs directly from the badge's RTC ISR in every build that defines `GQ_SUPPRESS_LED_TICK` (all builds today); if that define is ever absent (see qc2024#71), it instead runs from `system_tick()` in main-loop context. Either way, `led_tick()` and everything reachable **only** through it must use the non-blocking flush -- a dropped 25 Hz LED frame is invisible, but a blocking wait for an in-flight transfer under GIE=0 is a real deadlock.

| Call site | Context | Flush used |
|---|---|---|
| `led_tick()`'s own end-of-function flush | RTC ISR (or main-loop system_tick if `GQ_SUPPRESS_LED_TICK` absent) | `HAL_update_leds_nonblocking()` (was `HAL_update_leds()`) |
| `led_anim_done()`'s bg-restore branch | Only ever called from `led_tick()` | `HAL_update_leds_nonblocking()` (was `HAL_update_leds()`) |
| `led_anim_done()`'s non-bg stop branch | Only ever called from `led_tick()` | inlined `led_stop_state()` + `HAL_update_leds_nonblocking()` (was `led_stop()`, which flushes blocking) |
| `led_stop()` called directly (`gamequeer.c`'s `load_stage()`/`unload_game()`) | Main-loop only | `HAL_update_leds()` (unchanged, blocking) |
| `load_game()`'s boot-color flush (`gamequeer.c`) | Main-loop only | `HAL_update_leds()` (unchanged, blocking) |

The tricky part: `led_stop()` itself is called from **both** a main-loop-only path (`gamequeer.c`) and an RTC-ISR-only path (`led_anim_done()`), so it can't uniformly be blocking or non-blocking. Its bookkeeping is factored into `led_stop_state()`, and `led_anim_done()` calls that directly with a non-blocking flush instead of calling `led_stop()` (which stays blocking, for its main-loop-only direct callers).

## HAL contract change

Added `void HAL_update_leds_nonblocking();` to `HAL.h`. The emulator (`HAL.c`) implements it as a plain alias for `HAL_update_leds()` -- the emulator's `gfx_flush()` is synchronous, so there's no in-flight-transfer hazard to avoid on that side. The badge firmware side (a separate PR against `duplico/qc2024`) implements it with a real bail-if-busy primitive.

## Verification

- `make builder-build && make` (Docker/cmake) builds clean.
- `clang-format --dry-run --Werror` clean on all three touched files.
- All 27 existing tests pass under `-DGQ_HEADLESS=ON`, including the LED-specific ones (`golden_leds_dump_test`, `golden_led_handback`, `led_fade_delta`) -- byte-identical golden output, since the emulator's non-blocking variant is a pure alias.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>