### PR TITLE
fix(leds): quiesce-stage-commit mutual exclusion for LED cue-state layer

### DIFF
--- a/gamequeer/include/HAL.h
+++ b/gamequeer/include/HAL.h
@@ -38,11 +38,24 @@ void HAL_update_leds_nonblocking();
 /*
  * Enter/exit a critical section against this target's single-writer-at-
  * a-time ISR(s): on the badge, HAL_critical_enter() disables interrupts
- * and HAL_critical_exit() restores exactly the interrupt-enable state
- * that was in effect when the matching HAL_critical_enter() ran (not an
- * unconditional re-enable), so a critical section stays correct even if
- * it's entered from inside another one. On a single-threaded host with
- * no interrupts (e.g. the emulator), both are no-ops.
+ * and returns a token capturing the interrupt-enable state that was in
+ * effect just before it disabled them; HAL_critical_exit() takes that
+ * token back and restores exactly that state (not an unconditional
+ * re-enable). On a single-threaded host with no interrupts (e.g. the
+ * emulator), HAL_critical_enter() returns 0 and HAL_critical_exit()
+ * ignores its argument -- both no-ops.
+ *
+ * Token-based by design, not a shared saved-state slot: each call's
+ * token lives on the caller's own stack (a local variable), so nested or
+ * interleaved enter/exit pairs -- including a call from MAIN racing an
+ * RTC-ISR call that preempts it mid-enter -- can never clobber each
+ * other's saved state. This is what actually makes the primitive safe to
+ * enter from inside another one (or from an ISR that preempts a MAIN
+ * call in progress); a single shared static for the saved state would
+ * not be (confirmed via review of an earlier, non-token-based version of
+ * this primitive: the shared slot could be overwritten mid-save by a
+ * preempting nested call, silently corrupting the outer caller's restore
+ * value and leaving interrupts masked forever).
  *
  * Every call must be paired, non-overlapping with any other synchronous
  * control flow (no early return between enter/exit), and as short as
@@ -52,8 +65,8 @@ void HAL_update_leds_nonblocking();
  * quiesce/commit windows around the cue-state layer atomic w.r.t. the
  * RTC ISR.
  */
-void HAL_critical_enter();
-void HAL_critical_exit();
+uint16_t HAL_critical_enter(void);
+void HAL_critical_exit(uint16_t prev_state);
 
 void HAL_event_poll();
 void HAL_sleep();

--- a/gamequeer/include/HAL.h
+++ b/gamequeer/include/HAL.h
@@ -35,6 +35,26 @@ void HAL_update_leds();
  */
 void HAL_update_leds_nonblocking();
 
+/*
+ * Enter/exit a critical section against this target's single-writer-at-
+ * a-time ISR(s): on the badge, HAL_critical_enter() disables interrupts
+ * and HAL_critical_exit() restores exactly the interrupt-enable state
+ * that was in effect when the matching HAL_critical_enter() ran (not an
+ * unconditional re-enable), so a critical section stays correct even if
+ * it's entered from inside another one. On a single-threaded host with
+ * no interrupts (e.g. the emulator), both are no-ops.
+ *
+ * Every call must be paired, non-overlapping with any other synchronous
+ * control flow (no early return between enter/exit), and as short as
+ * possible: never wrap blocking I/O (flash reads, SPI waits) in a
+ * critical section (see docs/led-tlc-concurrency.md's I4/I9 in the
+ * qc2024 firmware repo). leds.c's led_play_cue() uses this to make its
+ * quiesce/commit windows around the cue-state layer atomic w.r.t. the
+ * RTC ISR.
+ */
+void HAL_critical_enter();
+void HAL_critical_exit();
+
 void HAL_event_poll();
 void HAL_sleep();
 t_gq_int HAL_get_player_id();

--- a/gamequeer/include/gamequeer.h
+++ b/gamequeer/include/gamequeer.h
@@ -276,7 +276,7 @@ extern Graphics_Context g_sContext;
 extern uint8_t gq_heap[GQ_HEAP_SIZE];
 extern rgbcolor16_t gq_leds[5];
 extern gq_ledcue_t leds_cue;
-extern uint8_t leds_animating;
+extern volatile uint8_t leds_animating;
 
 extern uint8_t gq_builtin_ints[];
 extern uint8_t gq_builtin_strs[];

--- a/gamequeer/src/HAL.c
+++ b/gamequeer/src/HAL.c
@@ -202,12 +202,14 @@ void HAL_update_leds_nonblocking() {
     HAL_update_leds();
 }
 
-void HAL_critical_enter() {
+uint16_t HAL_critical_enter() {
     // No-op: the emulator is single-threaded with no interrupts to mask.
+    return 0;
 }
 
-void HAL_critical_exit() {
-    // No-op: see HAL_critical_enter().
+void HAL_critical_exit(uint16_t prev_state) {
+    // No-op: see HAL_critical_enter(). prev_state is unused.
+    (void) prev_state;
 }
 
 void HAL_new_game() {

--- a/gamequeer/src/HAL.c
+++ b/gamequeer/src/HAL.c
@@ -202,6 +202,14 @@ void HAL_update_leds_nonblocking() {
     HAL_update_leds();
 }
 
+void HAL_critical_enter() {
+    // No-op: the emulator is single-threaded with no interrupts to mask.
+}
+
+void HAL_critical_exit() {
+    // No-op: see HAL_critical_enter().
+}
+
 void HAL_new_game() {
     // Nothing to do, on the emulator.
 }

--- a/gamequeer/src/leds.c
+++ b/gamequeer/src/leds.c
@@ -228,14 +228,15 @@ static void led_render_frame() {
 // led_anim_done() below).
 //
 // Tiny masked window (I9): from led_anim_done() this is already inside
-// RTC_ISR, so HAL_critical_enter()/HAL_critical_exit() correctly no-op
-// here (see HAL.h); from led_stop() (MAIN, GIE=1) it closes the same
-// ordering gap led_play_cue() does -- leds_animating = 0 must land before
+// RTC_ISR, so the HAL_critical_enter() token here just captures
+// "already disabled" and HAL_critical_exit() correctly restores that (see
+// HAL.h); from led_stop() (MAIN, GIE=1) it closes the same ordering gap
+// led_play_cue() does -- leds_animating = 0 must land before
 // leds_cue_bg_saved/gq_leds are cleared, or a tick landing between those
 // stores could still observe leds_animating == 1 with only some of this
 // state reset.
 static void led_stop_state() {
-    HAL_critical_enter();
+    uint16_t crit_state = HAL_critical_enter();
     // Stop the animation flag.
     leds_animating = 0;
     // Unsave any background cue.
@@ -245,7 +246,7 @@ static void led_stop_state() {
     for (uint8_t i = 0; i < 5; i++) {
         gq_leds[i] = (rgbcolor16_t) {.r = 0, .g = 0, .b = 0};
     }
-    HAL_critical_exit();
+    HAL_critical_exit(crit_state);
 }
 
 void led_stop() {
@@ -433,7 +434,7 @@ void led_play_cue(t_gq_pointer cue_ptr, uint8_t background) {
     uint16_t bg_frame_index         = 0;
     uint16_t bg_frame_ticks_elapsed = 0;
 
-    HAL_critical_enter();
+    uint16_t crit_state = HAL_critical_enter();
     if (leds_animating && !background && leds_cue.bgcue) {
         // Currently playing a background cue and this isn't itself a
         // background cue: save it for later before interrupting it.
@@ -443,7 +444,7 @@ void led_play_cue(t_gq_pointer cue_ptr, uint8_t background) {
         bg_frame_ticks_elapsed = leds_cue_frame_ticks_elapsed;
     }
     leds_animating = 0;
-    HAL_critical_exit();
+    HAL_critical_exit(crit_state);
 
     // --- 2. Stage (GIE on; the flash reads live here) ---
     if (save_bg) {
@@ -481,12 +482,12 @@ void led_play_cue(t_gq_pointer cue_ptr, uint8_t background) {
     }
 
     // --- 3. Commit (tiny masked window; RAM-only work, no I/O) ---
-    HAL_critical_enter();
+    crit_state           = HAL_critical_enter();
     leds_cue             = new_cue;
     leds_cue_frame_index = 0;
-    leds_animating       = 1; // Before led_setup_frame(): it early-returns on !leds_animating.
-    led_setup_frame();        // Consumes leds_cue/leds_cue_frame_index set just above.
-    HAL_critical_exit();      // Only past this point can RTC_ISR observe any of this state.
+    leds_animating       = 1;      // Before led_setup_frame(): it early-returns on !leds_animating.
+    led_setup_frame();             // Consumes leds_cue/leds_cue_frame_index set just above.
+    HAL_critical_exit(crit_state); // Only past this point can RTC_ISR observe any of this state.
 }
 
 // Runs from the RTC ISR in every build that defines GQ_SUPPRESS_LED_TICK

--- a/gamequeer/src/leds.c
+++ b/gamequeer/src/leds.c
@@ -66,13 +66,14 @@ rgbcolor16_t gq_leds[5] = {
 #define LED_DELTA_FRAC_BITS 14
 
 // volatile: layered on top of the HAL_critical_enter()/HAL_critical_exit()
-// masked windows below (matching this codebase's established pattern for
-// other cross-context flags -- rtc_ticks_pending in main.c,
-// tlc_send_type in tlc5948a.c/I5) so the leds_animating = 0 -> ... ->
-// leds_animating = 1 ordering those windows rely on (I11) doesn't depend
-// on HAL_critical_enter()/HAL_critical_exit() staying opaque to the
-// compiler (e.g. under a future whole-program-optimized build that inlines
-// them across translation units).
+// masked windows below (matching this file's own gq_game_unload_flag in
+// gamequeer.c, and the badge firmware's analogous tlc_send_type/
+// rtc_ticks_pending -- see docs/led-tlc-concurrency.md's I5 in the qc2024
+// repo) so the leds_animating = 0 -> ... -> leds_animating = 1 ordering
+// those windows rely on (I11) doesn't depend on HAL_critical_enter()/
+// HAL_critical_exit() staying opaque to the compiler (e.g. under a future
+// whole-program-optimized build that inlines them across translation
+// units).
 volatile uint8_t leds_animating = 0;
 gq_ledcue_frame_t leds_cue_fg_frames[GQ_CUE_MAX_FRAMES];
 gq_ledcue_frame_t leds_cue_bg_frames[GQ_CUE_MAX_FRAMES];
@@ -483,9 +484,9 @@ void led_play_cue(t_gq_pointer cue_ptr, uint8_t background) {
     HAL_critical_enter();
     leds_cue             = new_cue;
     leds_cue_frame_index = 0;
-    leds_animating       = 1; // Last store: turns the RTC-ISR consumer back on.
-    led_setup_frame();
-    HAL_critical_exit();
+    leds_animating       = 1; // Before led_setup_frame(): it early-returns on !leds_animating.
+    led_setup_frame();        // Consumes leds_cue/leds_cue_frame_index set just above.
+    HAL_critical_exit();      // Only past this point can RTC_ISR observe any of this state.
 }
 
 // Runs from the RTC ISR in every build that defines GQ_SUPPRESS_LED_TICK

--- a/gamequeer/src/leds.c
+++ b/gamequeer/src/leds.c
@@ -65,7 +65,15 @@ rgbcolor16_t gq_leds[5] = {
 // frame completion, untouched by this PR) are unaffected.
 #define LED_DELTA_FRAC_BITS 14
 
-uint8_t leds_animating = 0;
+// volatile: layered on top of the HAL_critical_enter()/HAL_critical_exit()
+// masked windows below (matching this codebase's established pattern for
+// other cross-context flags -- rtc_ticks_pending in main.c,
+// tlc_send_type in tlc5948a.c/I5) so the leds_animating = 0 -> ... ->
+// leds_animating = 1 ordering those windows rely on (I11) doesn't depend
+// on HAL_critical_enter()/HAL_critical_exit() staying opaque to the
+// compiler (e.g. under a future whole-program-optimized build that inlines
+// them across translation units).
+volatile uint8_t leds_animating = 0;
 gq_ledcue_frame_t leds_cue_fg_frames[GQ_CUE_MAX_FRAMES];
 gq_ledcue_frame_t leds_cue_bg_frames[GQ_CUE_MAX_FRAMES];
 gq_ledcue_frame_t leds_cue_frame_curr;
@@ -217,7 +225,16 @@ static void led_render_frame() {
 // branch: clears animation/color state but doesn't flush -- callers decide
 // which HAL flush variant is safe for their context (see led_stop() vs.
 // led_anim_done() below).
+//
+// Tiny masked window (I9): from led_anim_done() this is already inside
+// RTC_ISR, so HAL_critical_enter()/HAL_critical_exit() correctly no-op
+// here (see HAL.h); from led_stop() (MAIN, GIE=1) it closes the same
+// ordering gap led_play_cue() does -- leds_animating = 0 must land before
+// leds_cue_bg_saved/gq_leds are cleared, or a tick landing between those
+// stores could still observe leds_animating == 1 with only some of this
+// state reset.
 static void led_stop_state() {
+    HAL_critical_enter();
     // Stop the animation flag.
     leds_animating = 0;
     // Unsave any background cue.
@@ -227,6 +244,7 @@ static void led_stop_state() {
     for (uint8_t i = 0; i < 5; i++) {
         gq_leds[i] = (rgbcolor16_t) {.r = 0, .g = 0, .b = 0};
     }
+    HAL_critical_exit();
 }
 
 void led_stop() {
@@ -367,39 +385,107 @@ void led_setup_frame() {
     leds_cue_frame_ticks_elapsed = 0;
 }
 
+// Quiesce-stage-commit: led_play_cue() is the only main-loop mutator of the
+// cue-active group (leds_cue, leds_cue_fg_frames, leds_cue_bg_frames),
+// leds_animating, and the cue-bg-save group, but RTC_ISR's led_tick() /
+// led_anim_done() / led_setup_frame() read *and write* the same state
+// (gamequeer#366). The old version wrote leds_cue and leds_animating = 1
+// before the (multi-hundred-microsecond, flash-reading) frame-array copies
+// below had even started, so an RTC tick landing mid-copy could act on a
+// torn leds_cue -- including re-reading a torn frame_count *after* the
+// clamp below to size a gq_memcpy_to_ram, i.e. a possible RAM overflow past
+// leds_cue_fg_frames/leds_cue_bg_frames.
+//
+// Fixed by making every context an exclusive owner of this state at every
+// instant, gated by one flag (leds_animating), per
+// docs/led-tlc-concurrency.md (qc2024 repo) I9/§7 rule 5:
+//   1. Tiny masked window: snapshot the bg-save decision inputs (reading
+//      the *old* live cue, which RTC_ISR could otherwise still be
+//      advancing) and clear leds_animating -- RTC_ISR's consumer is now
+//      off: led_tick()/led_anim_done()/led_setup_frame() are all gated by
+//      `if (leds_animating)` (or, for led_setup_frame(), an early return),
+//      so nothing else touches the cue-active or cue-bg-save groups from
+//      here until step 3 turns leds_animating back on.
+//   2. GIE on: do the flash reads (gq_memcpy_to_ram) and the frame-count
+//      clamp into a *local* cue header (new_cue lives on this call's
+//      stack, so it can't be torn by anything else, and its clamped
+//      frame_count can't be re-read stale by a concurrent writer -- there
+//      isn't one). Also apply the bg-save snapshot from step 1: safe now
+//      that the consumer is quiesced. Deliberately not masked: these are
+//      the multi-hundred-microsecond flash reads, and masking around them
+//      would eat into main.c's 10 ms RTC single-pending-tick budget
+//      (qc2024#68).
+//   3. Tiny masked commit: publish the new cue header/frame index, turn
+//      leds_animating back on, and call led_setup_frame() -- all in the
+//      same window. led_setup_frame() only touches RAM already fully
+//      populated by step 2 (no flash I/O), the same work RTC_ISR already
+//      does unmasked-from-its-own-perspective every frame boundary via
+//      led_tick(), so folding it into this window is no more expensive
+//      than what already runs under GIE=0 today, and it closes the
+//      remaining hazard of RTC_ISR racing this call's own
+//      led_setup_frame() against its own led_tick()/led_anim_done() (the
+//      interpolation-state tearing described in gamequeer#366).
 void led_play_cue(t_gq_pointer cue_ptr, uint8_t background) {
+    // --- 1. Quiesce (tiny masked window; O(instructions), no I/O) ---
+    uint8_t save_bg                 = 0;
+    gq_ledcue_t bg_cue_snapshot     = {0};
+    uint16_t bg_frame_index         = 0;
+    uint16_t bg_frame_ticks_elapsed = 0;
+
+    HAL_critical_enter();
     if (leds_animating && !background && leds_cue.bgcue) {
-        // If we're currently playing a background cue, save it for later before interrupting it.
-        leds_cue_bg                     = leds_cue;
+        // Currently playing a background cue and this isn't itself a
+        // background cue: save it for later before interrupting it.
+        save_bg                = 1;
+        bg_cue_snapshot        = leds_cue;
+        bg_frame_index         = leds_cue_frame_index;
+        bg_frame_ticks_elapsed = leds_cue_frame_ticks_elapsed;
+    }
+    leds_animating = 0;
+    HAL_critical_exit();
+
+    // --- 2. Stage (GIE on; the flash reads live here) ---
+    if (save_bg) {
+        // RTC_ISR's consumer is off (leds_animating == 0), so the
+        // cue-bg-save group is exclusively ours until step 3.
+        leds_cue_bg                     = bg_cue_snapshot;
         leds_cue_bg_saved               = 1;
-        leds_cue_bg_frame_index         = leds_cue_frame_index;
-        leds_cue_bg_frame_ticks_elapsed = leds_cue_frame_ticks_elapsed;
+        leds_cue_bg_frame_index         = bg_frame_index;
+        leds_cue_bg_frame_ticks_elapsed = bg_frame_ticks_elapsed;
     }
 
-    // Load the new cue into RAM.
-    gq_memcpy_to_ram((uint8_t *) &leds_cue, cue_ptr, sizeof(gq_ledcue_t));
-    leds_animating       = 1;
-    leds_cue_frame_index = 0;
+    // Load the new cue header into a local: nothing else can write this
+    // copy, so its frame_count can't be re-read torn or stale by anyone,
+    // clamped or not.
+    gq_ledcue_t new_cue;
+    gq_memcpy_to_ram((uint8_t *) &new_cue, cue_ptr, sizeof(gq_ledcue_t));
 
-    if (leds_cue.frame_count > GQ_CUE_MAX_FRAMES) {
+    uint16_t new_frame_count = new_cue.frame_count;
+    if (new_frame_count > GQ_CUE_MAX_FRAMES) {
         // If the cue has too many frames, truncate it.
-        leds_cue.frame_count = GQ_CUE_MAX_FRAMES;
+        new_frame_count = GQ_CUE_MAX_FRAMES;
     }
+    new_cue.frame_count = new_frame_count;
 
     // If this is a background cue, we set it to loop.
     if (background) {
-        leds_cue.bgcue = 1;
-        leds_cue.loop  = 1;
+        new_cue.bgcue = 1;
+        new_cue.loop  = 1;
 
-        // Load the frames into RAM.
-        gq_memcpy_to_ram(
-            (uint8_t *) leds_cue_bg_frames, leds_cue.frames, leds_cue.frame_count * sizeof(gq_ledcue_frame_t));
+        // Load the frames into RAM, sized from the local (already-clamped,
+        // untorn) count above -- never from the shared leds_cue.
+        gq_memcpy_to_ram((uint8_t *) leds_cue_bg_frames, new_cue.frames, new_frame_count * sizeof(gq_ledcue_frame_t));
     } else {
-        // Load the frames into RAM.
-        gq_memcpy_to_ram(
-            (uint8_t *) leds_cue_fg_frames, leds_cue.frames, leds_cue.frame_count * sizeof(gq_ledcue_frame_t));
+        gq_memcpy_to_ram((uint8_t *) leds_cue_fg_frames, new_cue.frames, new_frame_count * sizeof(gq_ledcue_frame_t));
     }
+
+    // --- 3. Commit (tiny masked window; RAM-only work, no I/O) ---
+    HAL_critical_enter();
+    leds_cue             = new_cue;
+    leds_cue_frame_index = 0;
+    leds_animating       = 1; // Last store: turns the RTC-ISR consumer back on.
     led_setup_frame();
+    HAL_critical_exit();
 }
 
 // Runs from the RTC ISR in every build that defines GQ_SUPPRESS_LED_TICK


### PR DESCRIPTION
## Summary

The LED cue-state layer has no mutual exclusion between main-loop and RTC-ISR
code (hazard-matrix cells M13/M14 in the qc2024 concurrency model,
`docs/led-tlc-concurrency.md`). `led_play_cue()` (main-loop, GIE on) wrote
`leds_cue`, the frame arrays, `leds_animating`, and the bg-cue-save group
while RTC_ISR's `led_tick()`/`led_anim_done()`/`led_setup_frame()` read *and
write* the same state, unmasked. Worst case (item 3 in the issue): a torn
`leds_cue.frame_count` re-read *after* its clamp sizes a
`gq_memcpy_to_ram` into the fixed-size 900-byte frame arrays — a RAM
overflow. Plus a spurious end-of-cue silently drops the saved background
cue (item 2).

Part of gamequeer#366.

**Update (4006d75):** an [adversarial concurrency
review](https://github.com/duplico/qc2024/pull/96#issuecomment-5013585242)
found a critical bug in qc2024#96's original badge implementation of
`HAL_critical_enter()`/`HAL_critical_exit()` (a shared-static save that
could be clobbered by an RTC-ISR-nested call, permanently disabling
interrupts on the whole badge). Fixed by changing the primitive's contract
to a token-based API — `uint16_t HAL_critical_enter(void)` /
`HAL_critical_exit(uint16_t prev_state)` — so each caller's saved state
lives in its own register/stack slot instead of shared memory. This PR's
three call sites are updated to match; see "Fix history" below.

## Fix — quiesce-stage-commit

Cross-platform `HAL_critical_enter()`/`HAL_critical_exit()` primitive
(`HAL.h`; badge implementation in the qc2024 PR, no-op on the emulator),
token-based: `HAL_critical_enter()` returns the previous interrupt-enable
state, `HAL_critical_exit()` takes it back as an argument. `led_play_cue()`
now:

1. **Quiesce** (tiny masked window): snapshot the bg-save decision inputs
   from the *live* cue, then `leds_animating = 0`. This turns the RTC-ISR
   consumer off — `led_tick()`/`led_anim_done()`/`led_setup_frame()` are all
   gated by `leds_animating`, so nothing else touches the cue-active or
   cue-bg-save groups until step 3.
2. **Stage** (GIE on): the flash reads (`gq_memcpy_to_ram`) and the
   frame-count clamp happen into a *local* cue header — it can't be torn or
   re-read stale by anyone, because nothing else can write it. Also applies
   the bg-save snapshot from step 1 (safe: consumer is quiesced).
   Deliberately unmasked — these are the multi-hundred-µs flash reads, and
   masking around them would eat into the firmware's 10 ms RTC
   single-pending-tick budget (qc2024#68).
3. **Commit** (tiny masked window): publish the new cue header/frame index,
   turn `leds_animating` back on, and call `led_setup_frame()` in the same
   window — it only touches RAM already populated by step 2 (no I/O), the
   same work RTC_ISR already does unmasked-from-its-own-perspective every
   frame boundary, so this closes the remaining `led_setup_frame()`
   dual-context race (issue item 4) at no extra cost.

`led_stop_state()` (shared by `led_stop()` and `led_anim_done()`'s non-bg
branch) gets the same tiny-masked-window treatment for its own
`leds_animating = 0` → `leds_cue_bg_saved = 0`/`gq_leds` clear ordering. Each
of these three call sites holds its own token across its window (a local
`uint16_t`, e.g. `crit_state`) and passes it back to `HAL_critical_exit()` —
this is what makes the primitive correct when called from inside an
already-masked RTC-ISR context (as `led_anim_done()`'s call to
`led_stop_state()` is): the token there just captures "already disabled"
and restores exactly that, with no shared state for a concurrent MAIN call
to collide with.

`led_anim_done()`'s bg-restore branch and `led_tick()` itself need no
change: they only ever run from RTC_ISR, so they're already exclusive
w.r.t. MAIN by hardware (GIE forced to 0 on ISR entry); the fix above is
what makes MAIN properly excluded from their state while they're active.

`leds_animating` is now `volatile`, layered on top of the critical-section
windows (matching this file's own `gq_game_unload_flag`, and the badge
firmware's analogous `tlc_send_type`/`rtc_ticks_pending` —
`docs/led-tlc-concurrency.md`'s I5 in the qc2024 repo) so the
`leds_animating = 0 → … → leds_animating = 1` ordering the fix relies on
doesn't depend on `HAL_critical_enter()`/`HAL_critical_exit()` staying
opaque to the compiler across translation units (e.g. under a hypothetical
whole-program-optimized build).

## Invariant / hazard mapping

- **I9** (cue-state mutual exclusion): closed. Every mutation of the
  cue-active and cue-bg-save groups is now either inside a
  `HAL_critical_enter()`/`HAL_critical_exit()` window, or runs solely in
  RTC_ISR (already exclusive by hardware) while `leds_animating == 1` — and
  MAIN never sets `leds_animating` back to 1 until its own commit is fully
  done.
- **I8** (`gq_leds` discipline): unaffected/preserved — `led_play_cue()`
  still never touches `gq_leds` directly (unchanged from before); the only
  change is `led_stop_state()`'s `gq_leds` clear is now ordered after
  `leds_animating = 0` inside one masked window instead of relying on the
  compiler not reordering two plain global stores (closes model
  fragility F1 for this call site).
- **I11** (quiescence-flag ordering): the masked windows themselves are the
  ordering guarantee (RTC_ISR cannot preempt mid-window by hardware); the
  new `volatile` on `leds_animating` is defense-in-depth against a future
  build that inlines the critical-section calls across translation units.

### Interleaving enumeration (RTC_ISR firing during each phase of `led_play_cue()`)

- **Before phase 1 / after phase 3**: ordinary case, `leds_animating`
  reflects the old or new cue respectively; RTC_ISR sees a fully consistent
  state either way.
- **During phase 1's masked window**: impossible — GIE is off.
- **Between phase 1 and phase 2** (after `HAL_critical_exit()`,
  `leds_animating` already 0): RTC_ISR's `led_tick()` top-level
  `if (leds_animating)` is false; it no-ops for all cue-active/bg-save/
  `gq_leds` state (only its private `static uint8_t subtick` counter
  advances, which nothing else touches). Safe.
- **During phase 2** (GIE on, doing flash reads into `new_cue`/writing the
  bg-save group): same as above — `leds_animating == 0` the whole time, so
  RTC_ISR can fire any number of times and always no-ops on this state.
  `new_cue` is a stack local invisible to RTC_ISR regardless.
- **Between phase 2 and phase 3**: same as above, still `leds_animating == 0`.
- **During phase 3's masked window**: impossible — GIE is off.
- **After phase 3** (`leds_animating` now 1, next RTC tick): `led_tick()`
  reads the fully-committed `leds_cue`/`leds_cue_frame_curr`/etc. — no
  partial state was ever visible.

## Verification

- Docker `cmake`/`cmake --build` (both plain and `-DGQ_HEADLESS=ON`) — clean
  build, no new warnings.
- `ctest` in the headless build: **27/27 pass**, including the specific
  guardrails for this change — `golden_leds_dump_test`,
  `golden_led_handback`, `led_fade_delta` — byte-identical to their
  pre-fix goldens. This is a concurrency-only fix; no golden changed, which
  is required (the single-threaded emulator can't exercise the race itself,
  but it does prove the sequential LED output is unchanged).
- `clang-format` clean.

## Fix history

- `c92357e`: initial quiesce-stage-commit fix.
- `89f35dc`: round-1 Copilot review — fixed a comment citing qc2024-only
  symbols as if present in this repo, and a misleading "last store" comment.
- `4006d75`: token-based `HAL_critical_enter()`/`HAL_critical_exit()`
  signature, in response to the critical badge-freeze finding on qc2024#96
  (see "Update" above). No logic change to `led_play_cue()`/
  `led_stop_state()` beyond capturing/passing the token.

## Not yet hardware-validated

This is a memory-safety fix for a race the single-threaded emulator can't
reproduce; the static/invariant argument above is the primary proof.
Pre-registered bench check (queued, paired with the qc2024-side PR): flash a
cue-heavy cart (background cue + frequent foreground `PLAY_CUE`s), run for
an extended period, confirm no corruption/hang and correct background-cue
restore after each foreground cue completes.

---
(AI-generated via Claude Code w/ Claude Sonnet 5, from the qc2024 LED/TLC
concurrency model.)
