### PR TITLE
fix(gq-game-language): make GQS_PLAYER_HANDLE game-writable

### DIFF
--- a/gq-game-language/src/language/gq-builtins.ts
+++ b/gq-game-language/src/language/gq-builtins.ts
@@ -58,7 +58,7 @@ export const GQ_RESERVED_INTS: readonly GqBuiltin[] = [
 
 export const GQ_RESERVED_STRS: readonly GqBuiltin[] = [
     { name: 'GQS_GAME_NAME', kind: 'str', description: 'Name of the game', writable: false },
-    { name: 'GQS_PLAYER_HANDLE', kind: 'str', description: 'Player handle', writable: false },
+    { name: 'GQS_PLAYER_HANDLE', kind: 'str', description: 'Player handle', writable: true },
     { name: 'GQS_LABEL1', kind: 'str', description: 'Label 1', writable: true },
     { name: 'GQS_LABEL2', kind: 'str', description: 'Label 2', writable: true },
     { name: 'GQS_LABEL3', kind: 'str', description: 'Label 3', writable: true },


### PR DESCRIPTION
## Summary

Step 1 of the persistent-player-handle feature (duplico/qc2024#103). Flips
`GQS_PLAYER_HANDLE`'s `writable` flag from `false` to `true` in the Langium
builtins table (`gq-game-language/src/language/gq-builtins.ts`), one line.

This was never actually enforced at the VM/compiler level -- it's the status
quo today, confirmed by re-reading the write paths:
- `write_byte()`'s `GQ_PTR_BUILTIN_STR` case writes `gq_builtin_strs[]`
  unconditionally, with no slot-specific gating, on both firmware
  (`ccs_workspace/qc2024/HAL_badge.c`) and the emulator
  (`gamequeer/src/HAL.c`).
- `gqc`'s `CommandSetStr.resolve()` (`gqc/src/gqc/commands.py`) has no
  `writable` concept at all -- `GqReservedVariable` doesn't even have that
  field.
- The *only* place `writable: false` was enforced for this builtin was this
  Langium extension, and only as a non-blocking warning (see gamequeer#326).

The owner has decided the handle should be writable by game code. This PR
does exactly that and nothing else:

- **Only** `GQS_PLAYER_HANDLE` changes. Every other read-only builtin
  (`GQI_GAME_ID`, `GQI_MENU_ACTIVE`, `GQI_MENU_VALUE`, `GQI_GAME_COLOR`,
  `GQI_PLAYER_ID`, `GQS_GAME_NAME`) is untouched.
- **Zero bytecode/struct/VM-contract/gqc surface.** This is a lint-only
  change confined to the editor extension's data table. The validator
  (`game-queer-game-language-validator.ts`) is fully data-driven off
  `builtin.writable`, so no other code changes needed -- the "read-only"
  warning simply stops firing for `GQS_PLAYER_HANDLE` assignments.

## Verification

Checked `gq-game-language/test/*.test.ts` for any fixture/snapshot keyed on
`GQS_PLAYER_HANDLE`'s writable/read-only status before making the change --
none exists. The existing read-only-warning tests use `GQI_PLAYER_ID` and
`GQS_GAME_NAME` instead, both of which stay `writable: false` and are
unaffected.

Ran the package's own build/lint/test locally (`npm ci`, Node v22.21.1):
- `npm run langium:generate` -- succeeded
- `npm test` (vitest) -- **59/59 tests pass**, 7 files
- `npm run lint` (eslint) -- clean, no warnings
- `npm run build` (`tsc -b` + esbuild) -- succeeded

## Review

Not merge-ready on self-report -- flagging for reviewer pass.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>