### PR TITLE
fix(gqc): fix latent parser/datamodel traps from test-plan exploration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,12 @@ DOCKER_CMD_NIT := docker run --rm --workdir /workspaces/gamequeer -v $(PWD):/wor
 #    CSV fixture (#356), using if_literal_condition_{lime,red}.gqcue under
 #    gamequeer/tests/golden/assets/lighting/; same light-cue CWD-resolution
 #    requirement as leds_dump_test.gq above.
-golden-fixture: builder-build gamequeer/tests/golden/hello.gq gamequeer/tests/golden/mask_encoding_a.gq gamequeer/tests/golden/mask_encoding_b.gq gamequeer/tests/golden/mask_encoding_c.gq gamequeer/tests/golden/redundant_write.gq gamequeer/tests/golden/anim_advance.gq gamequeer/tests/golden/rowmajor_byte_blit.gq gamequeer/tests/golden/edge_coverage.gq gamequeer/tests/golden/full_frame_row_blit.gq gamequeer/tests/golden/full_frame_mask_row_blit.gq gamequeer/tests/golden/label_text.gq gamequeer/tests/golden/menu_choice.gq gamequeer/tests/golden/menu_text.gq gamequeer/tests/golden/leds_dump_test.gq gamequeer/tests/golden/if_literal_condition.gq
+#  - led_handback.gq: fg-over-bg cue completion/handback --dump-leds golden
+#    CSV fixture, using led_handback_{bg,fg}.gqcue under gamequeer/tests/
+#    golden/assets/lighting/; same light-cue CWD-resolution requirement as
+#    leds_dump_test.gq above. (#338: this fixture was already committed but
+#    missing from this recipe.)
+golden-fixture: builder-build gamequeer/tests/golden/hello.gq gamequeer/tests/golden/mask_encoding_a.gq gamequeer/tests/golden/mask_encoding_b.gq gamequeer/tests/golden/mask_encoding_c.gq gamequeer/tests/golden/redundant_write.gq gamequeer/tests/golden/anim_advance.gq gamequeer/tests/golden/rowmajor_byte_blit.gq gamequeer/tests/golden/edge_coverage.gq gamequeer/tests/golden/full_frame_row_blit.gq gamequeer/tests/golden/full_frame_mask_row_blit.gq gamequeer/tests/golden/label_text.gq gamequeer/tests/golden/menu_choice.gq gamequeer/tests/golden/menu_text.gq gamequeer/tests/golden/leds_dump_test.gq gamequeer/tests/golden/if_literal_condition.gq gamequeer/tests/golden/led_handback.gq
 	$(DOCKER_CMD_NIT) /bin/bash -c "PYTHONPATH=gqc/src python -m gqc compile --no-mem-map -o gamequeer/tests/golden gamequeer/tests/golden/hello.gq && \
 		PYTHONPATH=gqc/src python -m gqc compile --no-mem-map -o gamequeer/tests/golden gamequeer/tests/golden/redundant_write.gq && \
 		PYTHONPATH=gqc/src python -m gqc compile --no-mem-map -o gamequeer/tests/golden gamequeer/tests/golden/label_text.gq && \
@@ -118,6 +123,7 @@ golden-fixture: builder-build gamequeer/tests/golden/hello.gq gamequeer/tests/go
 		PYTHONPATH=/workspaces/gamequeer/gqc/src python -m gqc compile --no-mem-map -o . full_frame_mask_row_blit.gq && \
 		PYTHONPATH=/workspaces/gamequeer/gqc/src python -m gqc compile --no-mem-map -o . leds_dump_test.gq && \
 		PYTHONPATH=/workspaces/gamequeer/gqc/src python -m gqc compile --no-mem-map -o . if_literal_condition.gq && \
+		PYTHONPATH=/workspaces/gamequeer/gqc/src python -m gqc compile --no-mem-map -o . led_handback.gq && \
 		rm -rf build"
 
 # Build the headless emulator and run the golden framebuffer test.

--- a/gqc/src/gqc/datamodel.py
+++ b/gqc/src/gqc/datamodel.py
@@ -284,7 +284,14 @@ class Variable:
         self.storageclass = None
 
         if name in Variable.var_table:
-            if Variable.var_table[name].storageclass.startswith('builtin'):
+            existing_storageclass = Variable.var_table[name].storageclass
+            # existing_storageclass is None for a same-section duplicate
+            # (gamequeer#338): both definitions are constructed before
+            # either one has a storage class assigned, which happens once
+            # for the whole section afterwards via set_storageclass(). Treat
+            # that the same as any other non-builtin duplicate rather than
+            # crashing on None.startswith(...).
+            if existing_storageclass and existing_storageclass.startswith('builtin'):
                 raise ValueError(f"Cannot redefine builtin variable {name}")
             else:
                 raise ValueError(f"Duplicate definition of {name}")
@@ -413,11 +420,15 @@ class Animation:
         if self.height > 128:
             raise ValueError(f"Animation {name} height {self.height} exceeds maximum of 128")
 
+        if name in Animation.anim_table:
+            raise ValueError("Animation {} already defined".format(name))
+
+        # Only claim an id once the duplicate-name check has passed, so a
+        # rejected redefinition doesn't leak an id that no Animation ends up
+        # using (gamequeer#338).
         self.id = Animation.next_id
         Animation.next_id += 1
 
-        if name in Animation.anim_table:
-            raise ValueError("Animation {} already defined".format(name))
         Animation.anim_table[name] = self
 
         self.frames = []
@@ -615,6 +626,11 @@ class Frame:
 
     def deserialize(self, in_path : pathlib.Path):
         with open(in_path, 'rb') as file:
+            # pickle.load() trusts in_path's contents; this is a local
+            # build-cache file gqc itself wrote (see serialize(), above), not
+            # untrusted input. A poisoned build directory could still use
+            # this for arbitrary code execution -- not changing the format
+            # here (aligns #46, a separate decision).
             d = pickle.load(file)
             self.compression_type_name = d.compression_type_name
             self.compression_type_number = Frame.image_formats[self.compression_type_name]
@@ -797,6 +813,8 @@ class LightCue:
     
     def deserialize(self, in_path : pathlib.Path):
         with open(in_path, 'rb') as file:
+            # Same local-build-cache trust assumption as Frame.deserialize,
+            # above (not changing the pickle format here, aligns #46).
             c = pickle.load(file)
         self.frames = c.frames
         self.colors = c.colors

--- a/gqc/src/gqc/grammar_gqcue.py
+++ b/gqc/src/gqc/grammar_gqcue.py
@@ -3,8 +3,6 @@ from pyparsing import pyparsing_common as ppc
 
 from .cues import parse_color_definition, parse_cue_frame, parse_lightcue_definition
 
-from .grammar import VAR_STRING_MAXLEN
-
 """
 Grammar for GQC light cues
 ==========================

--- a/gqc/src/gqc/linker.py
+++ b/gqc/src/gqc/linker.py
@@ -31,16 +31,19 @@ def create_reserved_variables():
         var = Variable('str', reg_name, '', 'volatile')
 
 def create_symbol_table(table_dest = sys.stdout, cmd_dest = sys.stdout):
-    # Output order:
+    # Output order (.game .anim .stage .frame .framedata .cues .cuedata
+    # .menu .event .init .var):
     # header (fixed size)
     # animations (fixed size by count)
     # stages (fixed size by count)
     # frames (fixed size by count)
     # frame data (variable size)
+    # light cues (fixed size by count)
+    # light cue data (variable size)
     # menus (variable size)
-    # variable area (variable size)
-    # initialization code (variable size)
     # events code (variable size)
+    # initialization code (variable size)
+    # variable area (variable size)
 
     frame_count = sum([len(anim.frames) for anim in Animation.anim_table.values()])
 

--- a/gqc/src/gqc/parser.py
+++ b/gqc/src/gqc/parser.py
@@ -171,13 +171,13 @@ def parse_variable_definition_storageclass(instring, loc, toks):
     storageclass = toks[0]
     
     if Variable.storageclass_table[storageclass]:
-        non_init_vars_present = False
+        non_init_var = None
         for var in Variable.storageclass_table[storageclass].values():
             if not var.name in structs.GQ_REGISTERS_INT and not var.name in structs.GQ_REGISTERS_STR and not var.name.endswith(".init") and not var.name.endswith(".strlit") and not var.name.endswith(".builtin"):
-                non_init_vars_present = True
+                non_init_var = var
                 break
-        if non_init_vars_present:
-            raise GqcParseError(f"Storage class {storageclass} already defined by {var.name}", instring, loc)
+        if non_init_var is not None:
+            raise GqcParseError(f"Storage class {storageclass} already defined by {non_init_var.name}", instring, loc)
     
     for var in toks[1]:
         var.set_storageclass(storageclass)
@@ -346,10 +346,16 @@ def parse_command(instring, loc, toks):
                     raise GqcParseError(f"Invalid source {src} for string variable {dst}", instring, loc)
             else:
                 if isinstance(src, int):
+                    # Not currently reachable: parse_int_operand's parse
+                    # action wraps every bare int atom in a GqcIntOperand
+                    # before it ever gets here, so `src` arrives as a
+                    # GqcIntOperand or IntExpression already. Kept explicit
+                    # (rather than silently falling through with no return,
+                    # gamequeer#338) so a future grammar change that lets a
+                    # bare int through doesn't drop the setvar statement.
                     src = GqcIntOperand(is_literal=True, value=src)
-                else:
-                    assert isinstance(src, GqcIntOperand) or isinstance(src, IntExpression)
-                    return CommandSetInt(instring, loc, dst, src)
+                assert isinstance(src, GqcIntOperand) or isinstance(src, IntExpression)
+                return CommandSetInt(instring, loc, dst, src)
         elif command == 'timer':
             return CommandTimer(instring, loc, toks[1])
         elif command in ['break', 'continue']:

--- a/gqc/tests/test_assets.py
+++ b/gqc/tests/test_assets.py
@@ -328,6 +328,36 @@ def test_still_image_digest_cache_is_never_reused(tmp_path, monkeypatch):
     )
 
 
+# --- Animation.id assignment (gamequeer#338) ---------------------------------
+
+
+def test_animation_duplicate_name_does_not_leak_id(tmp_path, monkeypatch):
+    # Before gamequeer#338, Animation.__init__ claimed Animation.next_id
+    # (incrementing the class-level counter) *before* its duplicate-name
+    # check, so a rejected redefinition still consumed an id -- the next
+    # legitimately-constructed Animation would skip one. Constructed
+    # directly (rather than through a full compile, which aborts the whole
+    # process on the very first GqcParseError, never reaching a subsequent
+    # animation) to observe both attempts in the same process.
+    monkeypatch.chdir(tmp_path)
+    reset_compiler_state()
+    linker.create_reserved_variables()
+    Game.game_name = "g"
+    assets_dir = tmp_path / "assets" / "animations"
+    assets_dir.mkdir(parents=True)
+    _make_still(assets_dir / "a.png")
+    _make_still(assets_dir / "b.png")
+
+    first = Animation("a1", "a.png")
+    assert first.id == 0
+
+    with pytest.raises(ValueError, match="Animation a1 already defined"):
+        Animation("a1", "a.png")
+
+    second = Animation("b1", "b.png")
+    assert second.id == 1
+
+
 # --- mkanim: CLI (black-box) --------------------------------------------------
 
 

--- a/gqc/tests/test_codegen.py
+++ b/gqc/tests/test_codegen.py
@@ -187,6 +187,30 @@ def test_register_allocation_depth_5_exhausts_registers(compile_gq):
     assert "No free registers available" in stderr
 
 
+# --- setvar-int control-flow (gamequeer#338) -----------------------------------
+
+
+def test_parse_command_setvar_bare_int_returns_command_set_int():
+    # Not driven through compile_gq: parse_int_operand's own parse action
+    # (gqc/src/gqc/parser.py) wraps every bare int atom in a GqcIntOperand
+    # before parse_command ever sees it, so a plain Python `int` `src` for a
+    # non-str setvar is dead through the real grammar. Before gamequeer#338,
+    # that branch wrapped such a bare int in a GqcIntOperand and then fell
+    # off the end of parse_command with no return, silently dropping the
+    # statement (returning None) instead of the CommandSetInt it built the
+    # operand for. Call parse_command directly, bypassing the grammar, to
+    # exercise the fixed control flow as if a future grammar change let a
+    # bare int through.
+    reset_compiler_state()
+    linker.create_reserved_variables()
+    try:
+        cmd = parser.parse_command("", 0, [["setvar", "x", 5, "int"]])
+        assert isinstance(cmd, CommandSetInt)
+        assert cmd.dst_name == "x"
+    finally:
+        reset_compiler_state()
+
+
 # --- statement lowering --------------------------------------------------------
 
 

--- a/gqc/tests/test_diagnostics.py
+++ b/gqc/tests/test_diagnostics.py
@@ -275,24 +275,24 @@ def test_persistent_section_overflow_exits_2_with_message(compile_gq):
     assert_no_traceback(stderr)
 
 
-# --- same-section duplicate variable name (gamequeer#338's known trap) ------
+# --- same-section duplicate variable name (gamequeer#338) -------------------
 
 
-def test_duplicate_variable_name_within_same_section_crashes_with_attributeerror(
+def test_duplicate_variable_name_within_same_section_rejects_cleanly(
     compile_gq,
 ):
-    # Pins current *broken* behavior, cross-ref gamequeer#338: reusing a
-    # variable name *within the same* volatile/persistent block crashes with
-    # an unhandled AttributeError instead of the clean "Duplicate definition
-    # of x" GqcParseError that the cross-section case gets (see
-    # test_grammar.py's test_duplicate_variable_name_across_sections_rejects).
-    # Both same-section definitions are constructed via parse_variable_definition
-    # before either has a storageclass assigned (that happens once for the
-    # whole block, afterwards, via parse_variable_definition_storageclass),
-    # so Variable.__init__'s duplicate-name check
-    # (`Variable.var_table[name].storageclass.startswith('builtin')`) hits
-    # `None.startswith(...)`. Fixing gamequeer#338 should flip this test to
-    # assert a clean GqcParseError instead.
+    # Flipped by gamequeer#338 (previously pinned the *broken* behavior:
+    # reusing a variable name *within the same* volatile/persistent block
+    # crashed with an unhandled AttributeError instead of a clean
+    # GqcParseError). Both same-section definitions are constructed via
+    # parse_variable_definition before either has a storageclass assigned
+    # (that happens once for the whole block, afterwards, via
+    # parse_variable_definition_storageclass), so
+    # Variable.__init__'s duplicate-name check used to dereference
+    # `.storageclass.startswith('builtin')` on a `None` storageclass.
+    # Guarding that check now produces the same clean "Duplicate definition
+    # of x" diagnostic as the cross-section case (see test_grammar.py's
+    # test_duplicate_variable_name_across_sections_rejects).
     source = (
         f"{GAME_HEADER}"
         "volatile { int x = 0; int x = 1; }\n"
@@ -300,7 +300,30 @@ def test_duplicate_variable_name_within_same_section_crashes_with_attributeerror
     )
     exit_code, stderr, _ = compile_gq(source)
     assert exit_code == 1
-    assert "Traceback (most recent call last):" in stderr
-    assert (
-        "AttributeError: 'NoneType' object has no attribute 'startswith'" in stderr
+    assert "Duplicate definition of x" in stderr
+    assert_no_traceback(stderr)
+
+
+# --- duplicate storage-class section (gamequeer#338) -------------------------
+
+
+def test_duplicate_storage_class_section_rejects_cleanly(compile_gq):
+    # Exercises parse_variable_definition_storageclass's "already defined"
+    # error path (a second `persistent { ... }` section reusing a storage
+    # class already claimed by a real, non-init/non-register variable from
+    # the first one). gamequeer#338 hardened this path's loop-variable
+    # handling (it used to reference the `for` loop's variable directly,
+    # which is only ever bound when the error condition is true today, but
+    # was one refactor away from a NameError instead of this GqcParseError
+    # if that stopped holding) -- this pins the fixed path's observable
+    # behavior unchanged.
+    source = (
+        f"{GAME_HEADER}"
+        "persistent { int a = 0; }\n"
+        "persistent { int b = 1; }\n"
+        "stage start { event enter { badge_set 1; } }\n"
     )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 1
+    assert "Storage class persistent already defined by a" in stderr
+    assert_no_traceback(stderr)

--- a/gqc/tests/test_grammar.py
+++ b/gqc/tests/test_grammar.py
@@ -298,12 +298,10 @@ def test_duplicate_animation_name_rejects(compile_gq):
 def test_duplicate_variable_name_across_sections_rejects(compile_gq):
     # A variable name reused across two *different* storage-class sections
     # takes the clean diagnostic path (Variable.__init__ raises ValueError,
-    # caught and reported as a GqcParseError). Note: reusing a name *within
-    # the same* volatile/persistent block currently crashes with an
-    # unhandled AttributeError instead -- both definitions are constructed
-    # before either has a storageclass assigned, so the duplicate-name
-    # check's `.storageclass.startswith(...)` hits None. Not covered here;
-    # flagged for gamequeer#338 (latent traps).
+    # caught and reported as a GqcParseError). Reusing a name *within the
+    # same* volatile/persistent block takes the same clean path (fixed by
+    # gamequeer#338); see test_diagnostics.py's
+    # test_duplicate_variable_name_within_same_section_rejects_cleanly.
     source = (
         f"{GAME_HEADER}"
         "volatile { int x = 0; }\n"


### PR DESCRIPTION
## Summary

Closes #338, the final child of epic #329. Fixes the latent traps found
while writing gqc's test-plan suites (none of which currently fire except
where noted), plus two small items folded in since:

1. **`parser.py` setvar-int fall-through** (~324-328): the branch that
   wraps a bare int `src` in a `GqcIntOperand` fell off the end of
   `parse_command` with no `return`, silently dropping the statement.
   Currently dead -- `parse_int_operand`'s own parse action wraps every
   bare int atom before `parse_command` ever sees one -- but no longer a
   silent-drop trap if a future grammar change lets one through. Now always
   returns a `CommandSetInt`. Regression test calls `parse_command`
   directly (bypassing the grammar) in `test_codegen.py`.
2. **`parse_variable_definition_storageclass` unbound-`var` risk**
   (169-180): the error path referenced the `for` loop's variable directly,
   which only survives past the loop today because it's set in the same
   iteration that triggers the error condition -- one refactor away from a
   `NameError` instead of the intended `GqcParseError`. Replaced with an
   explicit sentinel. Regression test in `test_diagnostics.py` pins the
   (unchanged) "Storage class already defined" diagnostic for a duplicate
   `persistent { }` section.
3. **Same-section duplicate variable crash** (from this issue's comment):
   `volatile { int x = 0; int x = 1; }` crashed with `AttributeError:
   'NoneType' object has no attribute 'startswith'` instead of a clean
   `GqcParseError`, because both same-section definitions are constructed
   before either has a storage class assigned. Fixed to produce the same
   "Duplicate definition of x" diagnostic as the cross-section case.
   **Flips** `test_diagnostics.py`'s pinned-broken-behavior test to pin the
   clean diagnostic instead (and updates the cross-reference comment in
   `test_grammar.py`).
4. **`Animation.next_id` ID leak**: incremented before the duplicate-name
   check, so a rejected redefinition consumed an id. Reordered so the id is
   only claimed after the check passes. Verified two ways: a direct
   regression test in `test_assets.py` (constructs `Animation` objects
   in-process to observe both the failed and a subsequent successful
   construction, since a real compile aborts entirely on the first parse
   error) and, more importantly, **every committed golden `.gqgame`/CSV
   fixture recompiles byte-identical** (zero `git diff` after `make
   golden-fixture`), proving the reorder doesn't change any happy-path
   animation id.
5. **`grammar_gqcue.py`**: removed the unused `VAR_STRING_MAXLEN` import.
6. **`linker.py` doc comment**: `create_symbol_table()`'s top-of-function
   comment misstated the section order (omitted light cues; placed
   persistent vars before init/events code). Corrected to the actual
   emitted order: `.game .anim .stage .frame .framedata .cues .cuedata
   .menu .event .init .var`.
7. **Makefile golden-fixture recipe**: `led_handback.gq` was already
   committed under `gamequeer/tests/golden/` but missing from the
   top-level Makefile's `golden-fixture` regen target (`if_literal_condition.gq`
   had the same gap before #370 added it). Added it to both the
   prerequisite list and the compile invocations.
8. **Pickle cache trust assumption**: added a one-line comment at both
   `.gqframe`/`.gqcue` pickle load sites (`Frame.deserialize`,
   `LightCue.deserialize`) noting these trust a local build-cache file gqc
   itself wrote, not untrusted input -- not changing the format here
   (aligns #46, a separate decision).

## Verification

- `pytest tests`: **168 passed** (was 165 before this PR; +3 new
  regression tests, 0 skipped/xfailed).
- `make test-headless` (headless emulator ctest suite): **28/28 passed**.
- `make golden-fixture`: runs clean end to end (including the newly-added
  `led_handback.gq`) and produces **zero `git diff`** against every
  committed golden `.gqgame`/CSV fixture -- this is the byte-identical
  proof for item 4's `Animation.next_id` reorder.
- `test_diagnostics.py`'s flipped test
  (`test_duplicate_variable_name_within_same_section_rejects_cleanly`,
  formerly `..._crashes_with_attributeerror`) passes against the fix and
  was confirmed to fail against the pre-fix code.

## AI disclosure

This PR was authored with AI assistance (Claude Code, Claude Sonnet 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)