### PR TITLE
docs(gqc): fix manual flashrom recipe drift, point to cart_flash.py

### DIFF
--- a/gqc/docs/authoring-and-perf-carts.md
+++ b/gqc/docs/authoring-and-perf-carts.md
@@ -400,8 +400,8 @@ Windows shell, `usbipd bind --busid <id>` once, then
 `1a86:5512` (verify with `lsusb`).
 
 **Manual fallback**, for when the wrapper isn't available. This is the exact
-sequence `cart_flash.py` automates — its flashrom invocations use `-c
-"W25Q128.V"` to pin the expected chip on every call, and `-N`
+sequence `cart_flash.py` automates — its flashrom invocations use
+`-c "W25Q128.V"` to pin the expected chip on every call, and `-N`
 (`--noverify-all`) on region-limited writes so `-w`'s own auto-verify reads
 back only the written region instead of the whole 16 MiB chip:
 

--- a/gqc/docs/authoring-and-perf-carts.md
+++ b/gqc/docs/authoring-and-perf-carts.md
@@ -377,16 +377,37 @@ data lines. flashrom detects the chip as `W25Q128.V` (16384 kB).
 Software: distro `flashrom` (v1.3.0) and `usbutils`; run `flashrom` with
 `sudo`.
 
+**Recommended: `qc2024`'s `flashing/cart_flash.py`.** It automates all of
+padding, layout-file generation, and the flashrom invocations below —
+region-limited erase/program/verify by default (`--full` for a whole-chip
+write), with a `--dry-run` that prints the exact commands without touching
+hardware:
+
+```bash
+python3 flashing/cart_flash.py write <name>.gqgame
+python3 flashing/cart_flash.py verify <name>.gqgame   # optional, independent read-back check
+```
+
+See `flashing/cart_flash.py --help` (or its module docstring) in the
+`qc2024` repo for the full flag set, including the WSL2/usbipd pre-flight
+check and `--programmer`/`--expect-chip` overrides.
+
 On WSL2 the CH341A enumerates Windows-side and is attached into the distro
 with [usbipd-win](https://github.com/dorssel/usbipd-win). From an elevated
 Windows shell, `usbipd bind --busid <id>` once, then
 `usbipd attach --wsl --busid <id>`; it then appears in the distro as USB ID
 `1a86:5512` (verify with `lsusb`).
 
+**Manual fallback**, for when the wrapper isn't available. This is the exact
+sequence `cart_flash.py` automates — its flashrom invocations use `-c
+"W25Q128.V"` to pin the expected chip on every call, and `-N`
+(`--noverify-all`) on region-limited writes so `-w`'s own auto-verify reads
+back only the written region instead of the whole 16 MiB chip:
+
 1. **Probe** the programmer and chip:
 
    ```bash
-   sudo flashrom -p ch341a_spi
+   sudo flashrom -p ch341a_spi -c "W25Q128.V"
    ```
 
    It must print `Found Winbond flash chip "W25Q128.V" (16384 kB, SPI)`. A
@@ -415,25 +436,22 @@ Windows shell, `usbipd bind --busid <id>` once, then
    seconds):
 
    ```bash
-   sudo flashrom -p ch341a_spi --layout cart.layout --include game -w cart_padded.bin
+   sudo flashrom -p ch341a_spi -c "W25Q128.V" --layout cart.layout --include game -N -w cart_padded.bin
    ```
 
 5. Optionally **read back** the same region and byte-compare the image
    extent for an independent verification:
 
    ```bash
-   sudo flashrom -p ch341a_spi --layout cart.layout --include game -r cart_readback.bin
+   sudo flashrom -p ch341a_spi -c "W25Q128.V" --layout cart.layout --include game -r cart_readback.bin
    ```
 
 The burned cart boots and renders on a physical badge. A region-limited write
 leaves any data past the new image's end intact — harmless, since the VM
 follows the header's cart pointers and never reads past them, but if the cart
 previously held a larger game and you want the tail scrubbed, drop
-`--layout`/`--include` and write the full 16 MiB `cart_padded.bin`.
-
-A user-friendly wrapper that automates padding, layout generation, and the
-flashrom invocation is tracked as
-[duplico/qc2024#62](https://github.com/duplico/qc2024/issues/62).
+`--layout`/`--include`/`-N` and write the full 16 MiB `cart_padded.bin`
+(matching `cart_flash.py`'s own `--full`).
 
 The recipe above assumes the cart is pulled and seated directly in the
 CH341A. An **in-system** variant also exists: the cart stays seated in the

--- a/gqc/docs/authoring-and-perf-carts.md
+++ b/gqc/docs/authoring-and-perf-carts.md
@@ -381,7 +381,8 @@ Software: distro `flashrom` (v1.3.0) and `usbutils`; run `flashrom` with
 padding, layout-file generation, and the flashrom invocations below —
 region-limited erase/program/verify by default (`--full` for a whole-chip
 write), with a `--dry-run` that prints the exact commands without touching
-hardware:
+hardware. Run it from the root of a `qc2024` checkout (a separate repo from
+`gamequeer`; the path below is relative to it):
 
 ```bash
 python3 flashing/cart_flash.py write <name>.gqgame
@@ -450,8 +451,8 @@ The burned cart boots and renders on a physical badge. A region-limited write
 leaves any data past the new image's end intact — harmless, since the VM
 follows the header's cart pointers and never reads past them, but if the cart
 previously held a larger game and you want the tail scrubbed, drop
-`--layout`/`--include`/`-N` and write the full 16 MiB `cart_padded.bin`
-(matching `cart_flash.py`'s own `--full`).
+`--layout`/`--include`/`-N` (keep `-c "W25Q128.V"`) and write the full
+16 MiB `cart_padded.bin` (matching `cart_flash.py`'s own `--full`).
 
 The recipe above assumes the cart is pulled and seated directly in the
 CH341A. An **in-system** variant also exists: the cart stays seated in the


### PR DESCRIPTION
## Summary

Fixes #381. `gqc/docs/authoring-and-perf-carts.md` section 7's manual `flashrom` recipe had drifted from `flashing/cart_flash.py` (the `qc2024` wrapper it parallels): it was missing `-c "W25Q128.V"` on every invocation and `-N`/`--noverify-all` on region-limited writes.

- Added a "Recommended" callout pointing at `flashing/cart_flash.py write`/`verify` (which now exists — the doc's old "tracked as duplico/qc2024#62" line was itself stale, since that issue is implemented) ahead of the manual steps.
- Relabeled the manual steps as a flag-accurate fallback and corrected all three flashrom invocations (probe, write, read) to match the wrapper's actual builders.
- Updated the closing note about dropping `--layout`/`--include` for a full-chip write to also mention `-N`, matching `--full`.

## Evidence (traced to `flashing/cart_flash.py` on `qc2024`'s current `default`, commit `968b0af` / PR duplico/qc2024#111)

```python
def flashrom_probe_cmd(programmer, chip=DEFAULT_EXPECT_CHIP, use_sudo=True):
    return (["sudo"] if use_sudo else []) + ["flashrom", "-p", programmer, "-c", chip]

def flashrom_write_cmd(programmer, image_path, layout_path=None, region=REGION_NAME,
                        chip=DEFAULT_EXPECT_CHIP, use_sudo=True):
    cmd = (["sudo"] if use_sudo else []) + ["flashrom", "-p", programmer, "-c", chip]
    if layout_path is not None:
        # --include scopes erase+program to the region; -N ("skip not
        # included regions during automatic verification") scopes -w's own
        # auto-verify to that same region instead of the whole 16 MiB chip.
        cmd += ["--layout", str(layout_path), "--include", region, "-N"]
    cmd += ["-w", str(image_path)]
    return cmd

def flashrom_read_cmd(programmer, out_path, layout_path=None, region=REGION_NAME,
                       chip=DEFAULT_EXPECT_CHIP, use_sudo=True):
    cmd = (["sudo"] if use_sudo else []) + ["flashrom", "-p", programmer, "-c", chip]
    if layout_path is not None:
        cmd += ["--layout", str(layout_path), "--include", region]
    cmd += ["-r", str(out_path)]
```

`DEFAULT_EXPECT_CHIP = "W25Q128.V"` — matches the doc's `-c "W25Q128.V"`. `-N` is correctly omitted from the read/verify command (confirmed not applicable to `-r` in the wrapper's PR #111 body) and from `--full` writes (`layout_path=None`), both reflected in the doc's fallback and its closing note.

I also confirmed the rest of section 7's factual claims against current code while I was in there (linker layout, `gq_header` fields, cart-namespace pointers, `flash.py`/`HAL_badge.c` write-refusal, section numbering referenced by `cart_flash.py`'s own docstring/self-test) — no further drift found; this PR is scoped to the flashrom-recipe section only.

## Test plan

- [x] `cd gqc && make test` — 183 passed, 2 skipped (docs-only change, unaffected).

(AI-generated via Claude Code w/ Fable 5)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S6CTNoncMd7oGjJja2fLBy