### PR TITLE
fix(gqc): make mkanim digest cache hit for single-still animations

### DIFF
--- a/gqc/src/gqc/datamodel.py
+++ b/gqc/src/gqc/datamodel.py
@@ -1,5 +1,6 @@
 import sys
 import struct
+import itertools
 from enum import IntEnum
 from typing import Iterable
 import pathlib
@@ -458,36 +459,41 @@ class Animation:
             self.dst_path = pathlib.Path() / 'build' / 'assets' / 'animations' / Game.game_name / name
             digest_path = self.dst_path / '.digest'
 
-            # If a previous run already left build output in dst_path, use it
-            # to tentatively determine whether this is a single-still-image
-            # animation *before* the digest cache is checked, so
-            # self.ticks_per_frame - and therefore self.digest() - matches
-            # what was in effect when the stored digest was written. Without
-            # this, the single-still override further down (`if
-            # len(frame_paths) == 1: self.ticks_per_frame = duration`) only
-            # ever happens *after* the cache check, so the digest checked
-            # against the cache could never match the one that was stored,
-            # and the cache never hit for stills (gamequeer#376). The real
-            # frame count - and the corresponding permanent override - is
-            # (re)determined below once dst_path is known to be current.
-            original_ticks_per_frame = self.ticks_per_frame
-            if len(sorted(self.dst_path.glob('frame*.bmp'))) == 1:
-                self.ticks_per_frame = duration
-
             # Check if the dst_path has a file in it called .digest and compare it to self.digest()
             # If they match, skip the ffmpeg conversion step
             ffmpeged = False
             if digest_path.exists():
-                animation_progress.update(hash_task, total=1)
-                animation_progress.start_task(hash_task)
-                with open(digest_path, 'r') as digest_file:
-                    if digest_file.read() == self.digest():
-                        animation_progress.update(hash_task, completed=1, total=1)
-                        animation_progress.update(anim_task, completed=1, total=1)
-                        ffmpeged = True
-                        animation_progress.update(hash_task, advance=1)
+                # If a previous run already left build output in dst_path,
+                # use it to tentatively determine whether this is a
+                # single-still-image animation before comparing digests, so
+                # self.ticks_per_frame - and therefore self.digest() -
+                # matches what was in effect when the stored digest was
+                # written. Without this, the single-still override further
+                # down (`if len(frame_paths) == 1: self.ticks_per_frame =
+                # duration`) only ever happens *after* the cache check, so
+                # the digest checked against the cache could never match the
+                # one that was stored, and the cache never hit for stills
+                # (gamequeer#376). The real frame count - and the
+                # corresponding permanent override - is (re)determined below
+                # once dst_path is known to be current. Only the first two
+                # matches are needed (and the directory isn't otherwise
+                # touched), so this doesn't pay for a full sorted listing.
+                original_ticks_per_frame = self.ticks_per_frame
+                try:
+                    existing_frames = list(itertools.islice(self.dst_path.glob('frame*.bmp'), 2))
+                    if len(existing_frames) == 1:
+                        self.ticks_per_frame = duration
 
-            self.ticks_per_frame = original_ticks_per_frame
+                    animation_progress.update(hash_task, total=1)
+                    animation_progress.start_task(hash_task)
+                    with open(digest_path, 'r') as digest_file:
+                        if digest_file.read() == self.digest():
+                            animation_progress.update(hash_task, completed=1, total=1)
+                            animation_progress.update(anim_task, completed=1, total=1)
+                            ffmpeged = True
+                            animation_progress.update(hash_task, advance=1)
+                finally:
+                    self.ticks_per_frame = original_ticks_per_frame
 
             # Reformat the animation source file into the build directory.
             if not ffmpeged:

--- a/gqc/src/gqc/datamodel.py
+++ b/gqc/src/gqc/datamodel.py
@@ -457,7 +457,23 @@ class Animation:
             self.src_path = pathlib.Path() / 'assets' / 'animations' / source
             self.dst_path = pathlib.Path() / 'build' / 'assets' / 'animations' / Game.game_name / name
             digest_path = self.dst_path / '.digest'
-            
+
+            # If a previous run already left build output in dst_path, use it
+            # to tentatively determine whether this is a single-still-image
+            # animation *before* the digest cache is checked, so
+            # self.ticks_per_frame - and therefore self.digest() - matches
+            # what was in effect when the stored digest was written. Without
+            # this, the single-still override further down (`if
+            # len(frame_paths) == 1: self.ticks_per_frame = duration`) only
+            # ever happens *after* the cache check, so the digest checked
+            # against the cache could never match the one that was stored,
+            # and the cache never hit for stills (gamequeer#376). The real
+            # frame count - and the corresponding permanent override - is
+            # (re)determined below once dst_path is known to be current.
+            original_ticks_per_frame = self.ticks_per_frame
+            if len(sorted(self.dst_path.glob('frame*.bmp'))) == 1:
+                self.ticks_per_frame = duration
+
             # Check if the dst_path has a file in it called .digest and compare it to self.digest()
             # If they match, skip the ffmpeg conversion step
             ffmpeged = False
@@ -470,6 +486,8 @@ class Animation:
                         animation_progress.update(anim_task, completed=1, total=1)
                         ffmpeged = True
                         animation_progress.update(hash_task, advance=1)
+
+            self.ticks_per_frame = original_ticks_per_frame
 
             # Reformat the animation source file into the build directory.
             if not ffmpeged:

--- a/gqc/tests/test_assets.py
+++ b/gqc/tests/test_assets.py
@@ -293,23 +293,23 @@ def test_digest_cache_invalidated_by_source_touch(tmp_path, monkeypatch):
     assert first_bytes != second_bytes
 
 
-def test_still_image_digest_cache_is_never_reused(tmp_path, monkeypatch):
-    # Pins a currently-observed bug (not fixed here -- this test suite is
-    # test-only; filed as gamequeer#376): Animation.digest() depends on
-    # self.ticks_per_frame, which is computed from `frame_rate` *before*
-    # frames are counted, then silently overwritten with `duration` right
-    # after (the single-still override) -- but *before* the digest is
-    # written to `.digest`. So the digest checked against the cache file on
-    # a later run (pre-override value) can never match the one that was
-    # stored (post-override value) for any still image, and the cache
-    # always misses. This doesn't need ffmpeg either way, since the still
-    # path never calls it regardless of cache outcome.
+def test_still_image_digest_cache_is_reused(tmp_path, monkeypatch):
+    # Regression test for gamequeer#376: Animation.digest() depends on
+    # self.ticks_per_frame, which is computed from `frame_rate` before
+    # frames are counted, then overwritten with `duration` for a
+    # single-still animation. The digest checked against the cache file on
+    # a later run must use the same (post-override) value as the one that
+    # was stored, or the cache can never hit for stills. This doesn't need
+    # ffmpeg either way, since the still path never calls it regardless of
+    # cache outcome -- the assertion is just that `make_animation_from_image`
+    # (routed to via `make_animation`) isn't re-invoked once cached.
     assets_dir = tmp_path / "assets" / "animations"
     assets_dir.mkdir(parents=True)
     _make_still(assets_dir / "still.png")
     decls = 'animations { a1 <- "still.png" { frame_rate = 5; duration = 77; } }'
 
     _parse_in_process(tmp_path, monkeypatch, decls)
+    first_bytes = [f.bytes for f in Animation.anim_table["a1"].frames]
 
     calls = []
     original_make_animation = anim.make_animation
@@ -321,11 +321,28 @@ def test_still_image_digest_cache_is_never_reused(tmp_path, monkeypatch):
     monkeypatch.setattr("gqc.datamodel.make_animation", _spy)
 
     _parse_in_process(tmp_path, monkeypatch, decls)
+    second_bytes = [f.bytes for f in Animation.anim_table["a1"].frames]
 
-    assert calls, (
-        "if this starts failing, the still-image digest-cache bug this "
-        "test pins has been fixed -- update/remove it accordingly"
-    )
+    assert not calls, "digest cache hit should skip re-running make_animation"
+    assert first_bytes == second_bytes
+
+
+def test_still_image_digest_cache_invalidated_by_duration_change(tmp_path, monkeypatch):
+    # Companion to test_still_image_digest_cache_is_reused: a still image's
+    # `duration` becomes self.ticks_per_frame, which the digest depends on,
+    # so changing it must still invalidate the cache rather than being
+    # masked by the gamequeer#376 fix.
+    assets_dir = tmp_path / "assets" / "animations"
+    assets_dir.mkdir(parents=True)
+    _make_still(assets_dir / "still.png")
+
+    decls = 'animations { a1 <- "still.png" { frame_rate = 5; duration = 77; } }'
+    _parse_in_process(tmp_path, monkeypatch, decls)
+    assert Animation.anim_table["a1"].ticks_per_frame == 77
+
+    decls = 'animations { a1 <- "still.png" { frame_rate = 5; duration = 200; } }'
+    _parse_in_process(tmp_path, monkeypatch, decls)
+    assert Animation.anim_table["a1"].ticks_per_frame == 200
 
 
 # --- Animation.id assignment (gamequeer#338) ---------------------------------

--- a/gqc/tests/test_assets.py
+++ b/gqc/tests/test_assets.py
@@ -331,7 +331,11 @@ def test_still_image_digest_cache_invalidated_by_duration_change(tmp_path, monke
     # Companion to test_still_image_digest_cache_is_reused: a still image's
     # `duration` becomes self.ticks_per_frame, which the digest depends on,
     # so changing it must still invalidate the cache rather than being
-    # masked by the gamequeer#376 fix.
+    # masked by the gamequeer#376 fix. Spies on make_animation (as the other
+    # digest-cache tests do) rather than just checking the final
+    # ticks_per_frame value, since a wrongly-hit cache would leave
+    # ticks_per_frame correct too (it's set directly from `duration`,
+    # independent of whether the cache was consulted).
     assets_dir = tmp_path / "assets" / "animations"
     assets_dir.mkdir(parents=True)
     _make_still(assets_dir / "still.png")
@@ -340,8 +344,19 @@ def test_still_image_digest_cache_invalidated_by_duration_change(tmp_path, monke
     _parse_in_process(tmp_path, monkeypatch, decls)
     assert Animation.anim_table["a1"].ticks_per_frame == 77
 
+    calls = []
+    original_make_animation = anim.make_animation
+
+    def _spy(*args, **kwargs):
+        calls.append(1)
+        return original_make_animation(*args, **kwargs)
+
+    monkeypatch.setattr("gqc.datamodel.make_animation", _spy)
+
     decls = 'animations { a1 <- "still.png" { frame_rate = 5; duration = 200; } }'
     _parse_in_process(tmp_path, monkeypatch, decls)
+
+    assert calls, "digest cache should miss when duration changes"
     assert Animation.anim_table["a1"].ticks_per_frame == 200
 
 


### PR DESCRIPTION
## Summary
- `Animation.__init__` (`gqc/src/gqc/datamodel.py`) checked its `.digest` cache before the frame count was known, comparing against `self.digest()` computed with the pre-override (`frame_rate`-derived) `self.ticks_per_frame`. For single-still animations, `self.ticks_per_frame` is then overridden with `duration` right after the frame count is known, and *that* post-override digest is what actually gets written to `.digest`. The two digests could never match, so the cache always missed for still-image animations and every compile re-ran `make_animation_from_image`, even with nothing changed.
- Fix: before checking the cache, tentatively determine from any build output already present in `dst_path` whether this animation is a single still, and apply the `duration` override for that check only, so it matches what a previous successful run would have stored. `self.ticks_per_frame` is restored immediately after the check; the real (permanent) override is still applied later, once the current frame count is actually known from `dst_path`.
- Video/animated-gif sources are unaffected — `ticks_per_frame` was never overridden for them, so their pre/post-override digests were already identical.

Fixes #376. No opcode/builtin/register/cart-format changes (tooling-internal digest-cache fix only).

## Test plan
- [x] `gqc/tests/test_assets.py::test_still_image_digest_cache_is_reused` (new — was `test_still_image_digest_cache_is_never_reused`, which pinned the bug; now asserts `make_animation` is *not* re-invoked on a second compile of an unchanged still)
- [x] `gqc/tests/test_assets.py::test_still_image_digest_cache_invalidated_by_duration_change` (new — a still's `duration` change must still invalidate the cache)
- [x] Verified the new test fails against pre-fix `datamodel.py` and passes against the fix
- [x] `cd gqc && make test` — 184 passed, 2 skipped (ffmpeg-marked, no ffmpeg on this machine), 0 failed

(AI-generated via Claude Code w/ Fable 5)