### PR TITLE
gq-game-language: headless CLI lint wrapper (#384)

### DIFF
--- a/gq-game-language/esbuild.mjs
+++ b/gq-game-language/esbuild.mjs
@@ -5,7 +5,9 @@ import * as fs from 'node:fs';
 const watch = process.argv.includes('--watch');
 const minify = process.argv.includes('--minify');
 
-const success = watch ? 'Watch build succeeded' : 'Build succeeded';
+function successMessage(label) {
+    return `${watch ? 'Watch build' : 'Build'} succeeded (${label})`;
+}
 
 function getTime() {
     const date = new Date();
@@ -21,7 +23,7 @@ const plugins = [{
     setup(build) {
         build.onEnd(result => {
             if (result.errors.length === 0) {
-                console.log(getTime() + success);
+                console.log(getTime() + successMessage('extension/server'));
             }
         });
     },
@@ -56,7 +58,7 @@ const cliPlugins = [{
         build.onEnd(result => {
             if (result.errors.length === 0) {
                 fs.chmodSync('out/cli/main.cjs', 0o755);
-                console.log(getTime() + success);
+                console.log(getTime() + successMessage('CLI'));
             }
         });
     },

--- a/gq-game-language/esbuild.mjs
+++ b/gq-game-language/esbuild.mjs
@@ -1,5 +1,6 @@
 //@ts-check
 import * as esbuild from 'esbuild';
+import * as fs from 'node:fs';
 
 const watch = process.argv.includes('--watch');
 const minify = process.argv.includes('--minify');
@@ -46,9 +47,48 @@ const ctx = await esbuild.context({
     plugins
 });
 
+// The headless CLI (issue #384) is built separately so it can carry a
+// shebang banner and end up executable -- neither of which apply to the
+// vscode-extension/language-server bundles above.
+const cliPlugins = [{
+    name: 'chmod-cli-plugin',
+    setup(build) {
+        build.onEnd(result => {
+            if (result.errors.length === 0) {
+                fs.chmodSync('out/cli/main.cjs', 0o755);
+                console.log(getTime() + success);
+            }
+        });
+    },
+}];
+
+const cliCtx = await esbuild.context({
+    entryPoints: ['src/cli/main.ts'],
+    // A lone entry point would otherwise flatten to out/main.cjs; pin
+    // outbase so it lands at out/cli/main.cjs (matching package.json's
+    // "bin" and langium-quickstart.md).
+    outbase: 'src',
+    outdir: 'out',
+    bundle: true,
+    target: "ES2017",
+    format: 'cjs',
+    outExtension: {
+        '.js': '.cjs'
+    },
+    loader: { '.ts': 'ts' },
+    banner: { js: '#!/usr/bin/env node' },
+    platform: 'node',
+    sourcemap: !minify,
+    minify,
+    plugins: cliPlugins
+});
+
 if (watch) {
     await ctx.watch();
+    await cliCtx.watch();
 } else {
     await ctx.rebuild();
     ctx.dispose();
+    await cliCtx.rebuild();
+    cliCtx.dispose();
 }

--- a/gq-game-language/langium-quickstart.md
+++ b/gq-game-language/langium-quickstart.md
@@ -10,9 +10,9 @@ This folder contains all necessary files for your language extension.
  * `src/language/main.ts` - the entry point of the language server process.
  * `src/language/game-queer-game-language-module.ts` - the dependency injection module of your language implementation. Use this to register overridden and added services.
  * `src/language/game-queer-game-language-validator.ts` - an example validator. You should change it to reflect the semantics of your language.
- * `src/cli/main.ts` - the entry point of the command line interface (CLI) of your language.
- * `src/cli/generator.ts` - the code generator used by the CLI to write output files from DSL documents.
- * `src/cli/cli-util.ts` - utility code for the CLI.
+ * `src/cli/main.ts` - the thin executable entry point of the CLI (bundled with a shebang; see `package.json`'s `bin` field).
+ * `src/cli/program.ts` - the CLI's actual logic: a headless lint wrapper (gamequeer#384) that runs the same parse + validation pipeline as the language server over `.gq` files/directories/globs, with no VS Code or LSP connection required. Split out from `main.ts` so tests can import it directly instead of spawning a subprocess.
+ * `src/cli/cli-util.ts` - utility code for the CLI (resolving files/globs, formatting diagnostics).
 
 ## Get up and running straight away
 
@@ -21,7 +21,7 @@ This folder contains all necessary files for your language extension.
  * Press `F5` to open a new window with your extension loaded.
  * Create a new file with a file name suffix matching your language.
  * Verify that syntax highlighting, validation, completion etc. are working as expected.
- * Run `node ./bin/cli` to see options for the CLI; `node ./bin/cli generate <file>` generates code for a given DSL file.
+ * Run `node ./out/cli/main.cjs <files-or-globs...>` (or `npx gq-lang-lint <files-or-globs...>` once this package is installed) to lint `.gq` files headlessly; see `--help` for options. Exits non-zero if any error diagnostics are found.
 
 ## Make changes
 

--- a/gq-game-language/package-lock.json
+++ b/gq-game-language/package-lock.json
@@ -8,6 +8,8 @@
             "name": "gq-game-language",
             "version": "0.0.1",
             "dependencies": {
+                "commander": "^11.1.0",
+                "fast-glob": "^3.3.3",
                 "langium": "~3.0.0",
                 "vscode-languageclient": "~9.0.1",
                 "vscode-languageserver": "~9.0.1"
@@ -555,7 +557,6 @@
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-            "dev": true,
             "dependencies": {
                 "@nodelib/fs.stat": "2.0.5",
                 "run-parallel": "^1.1.9"
@@ -568,7 +569,6 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-            "dev": true,
             "engines": {
                 "node": ">= 8"
             }
@@ -577,7 +577,6 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-            "dev": true,
             "dependencies": {
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
@@ -1388,7 +1387,7 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "fill-range": "^7.1.1"
             },
@@ -1532,10 +1531,10 @@
             "dev": true
         },
         "node_modules/commander": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
-            "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
-            "dev": true,
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+            "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=16"
             }
@@ -1927,16 +1926,16 @@
             "dev": true
         },
         "node_modules/fast-glob": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-            "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
-            "dev": true,
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+            "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
                 "glob-parent": "^5.1.2",
                 "merge2": "^1.3.0",
-                "micromatch": "^4.0.4"
+                "micromatch": "^4.0.8"
             },
             "engines": {
                 "node": ">=8.6.0"
@@ -1946,7 +1945,6 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
             "dependencies": {
                 "is-glob": "^4.0.1"
             },
@@ -1970,7 +1968,6 @@
             "version": "1.17.1",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
             "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
-            "dev": true,
             "dependencies": {
                 "reusify": "^1.0.4"
             }
@@ -1991,7 +1988,7 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -2256,7 +2253,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2274,7 +2270,6 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "dev": true,
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
@@ -2286,7 +2281,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
             }
@@ -2435,6 +2430,16 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
+        "node_modules/langium-cli/node_modules/commander": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
+            "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            }
+        },
         "node_modules/langium-railroad": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/langium-railroad/-/langium-railroad-3.0.0.tgz",
@@ -2538,16 +2543,15 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-            "dev": true,
             "engines": {
                 "node": ">= 8"
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-            "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
-            "dev": true,
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "license": "MIT",
             "dependencies": {
                 "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
@@ -2806,10 +2810,10 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "dev": true,
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8.6"
             },
@@ -2915,7 +2919,6 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -2972,7 +2975,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
             "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-            "dev": true,
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
@@ -3043,7 +3045,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -3287,7 +3288,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "is-number": "^7.0.0"
             },

--- a/gq-game-language/package.json
+++ b/gq-game-language/package.json
@@ -14,6 +14,8 @@
         "esbuild-base": "esbuild ./src/extension/main.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node"
     },
     "dependencies": {
+        "commander": "^11.1.0",
+        "fast-glob": "^3.3.3",
         "langium": "~3.0.0",
         "vscode-languageclient": "~9.0.1",
         "vscode-languageserver": "~9.0.1"
@@ -63,5 +65,8 @@
     "activationEvents": [
         "onLanguage:game-queer-game-language"
     ],
-    "main": "./out/extension/main.cjs"
+    "main": "./out/extension/main.cjs",
+    "bin": {
+        "gq-lang-lint": "./out/cli/main.cjs"
+    }
 }

--- a/gq-game-language/src/cli/cli-util.ts
+++ b/gq-game-language/src/cli/cli-util.ts
@@ -1,0 +1,91 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import fg from 'fast-glob';
+import type { Diagnostic } from 'vscode-languageserver-types';
+
+const GQ_EXTENSION = '.gq';
+
+/** Raised for problems with the CLI's own arguments (bad path, wrong extension, no matches) -- as opposed to `.gq` diagnostics, which are reported, not thrown. */
+export class CliUsageError extends Error {}
+
+/**
+ * Resolves the given CLI arguments -- file paths, directory paths, and/or
+ * glob patterns -- to a deduplicated, sorted list of absolute `.gq` file
+ * paths.
+ *
+ * - A glob pattern (per fast-glob's own `isDynamicPattern`, e.g. `*`, `**`,
+ *   `{a,b}`) is expanded; matches without a `.gq` extension are silently
+ *   dropped, since a broad pattern like `games/*` routinely sweeps up
+ *   non-game files.
+ * - A plain path to a directory is walked recursively for `.gq` files.
+ * - A plain path to a file with a non-`.gq` extension is a hard usage error
+ *   -- the caller almost certainly pointed the linter at the wrong file.
+ * - A plain path that doesn't exist is a hard usage error.
+ */
+export async function resolveGqFiles(patterns: string[]): Promise<string[]> {
+    const resolved = new Set<string>();
+
+    for (const pattern of patterns) {
+        if (fg.isDynamicPattern(pattern)) {
+            const matches = await fg(pattern, { onlyFiles: true, absolute: true, dot: false });
+            for (const match of matches) {
+                if (match.endsWith(GQ_EXTENSION)) {
+                    resolved.add(path.resolve(match));
+                }
+            }
+            continue;
+        }
+
+        if (!fs.existsSync(pattern)) {
+            throw new CliUsageError(`No such file or directory: ${pattern}`);
+        }
+
+        const stat = fs.statSync(pattern);
+        if (stat.isDirectory()) {
+            for (const file of walkDirectoryForGqFiles(pattern)) {
+                resolved.add(path.resolve(file));
+            }
+        } else if (pattern.endsWith(GQ_EXTENSION)) {
+            resolved.add(path.resolve(pattern));
+        } else {
+            throw new CliUsageError(`Not a ${GQ_EXTENSION} file: ${pattern}`);
+        }
+    }
+
+    return [...resolved].sort();
+}
+
+function walkDirectoryForGqFiles(dir: string): string[] {
+    return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            return walkDirectoryForGqFiles(fullPath);
+        }
+        return entry.name.endsWith(GQ_EXTENSION) ? [fullPath] : [];
+    });
+}
+
+const SEVERITY_LABELS: Record<number, DiagnosticSeverityLabel> = {
+    1: 'error',
+    2: 'warning',
+    3: 'info',
+    4: 'hint'
+};
+
+export type DiagnosticSeverityLabel = 'error' | 'warning' | 'info' | 'hint';
+
+/** Langium/LSP diagnostic severities are 1-4 (error/warning/info/hint); anything unset is treated as an error. */
+export function severityLabel(severity: Diagnostic['severity']): DiagnosticSeverityLabel {
+    return SEVERITY_LABELS[severity ?? 1] ?? 'error';
+}
+
+/**
+ * Formats a single diagnostic in `file:line:col: severity: message` form
+ * (1-based line/column, matching editors and other CLI tools such as `tsc`
+ * and `eslint`) -- easy for both humans and CI/log-scraping tools to parse.
+ */
+export function formatDiagnostic(filePath: string, diagnostic: Diagnostic): string {
+    const line = diagnostic.range.start.line + 1;
+    const column = diagnostic.range.start.character + 1;
+    return `${filePath}:${line}:${column}: ${severityLabel(diagnostic.severity)}: ${diagnostic.message}`;
+}

--- a/gq-game-language/src/cli/main.ts
+++ b/gq-game-language/src/cli/main.ts
@@ -1,0 +1,8 @@
+// Shebang is injected by esbuild.mjs's banner (this file is not itself
+// directly executable pre-build).
+import { createCliProgram } from './program.js';
+
+createCliProgram().parseAsync(process.argv).catch(error => {
+    console.error(error);
+    process.exitCode = 2;
+});

--- a/gq-game-language/src/cli/main.ts
+++ b/gq-game-language/src/cli/main.ts
@@ -1,8 +1,22 @@
 // Shebang is injected by esbuild.mjs's banner (this file is not itself
 // directly executable pre-build).
+import { CommanderError } from 'commander';
 import { createCliProgram } from './program.js';
 
 createCliProgram().parseAsync(process.argv).catch(error => {
+    if (error instanceof CommanderError) {
+        // exitOverride() (see program.ts) routes commander's own --help,
+        // --version, and argument/option parsing errors here instead of
+        // process.exit()-ing directly. --help/--version already carry the
+        // right code (0); any other commander-level error (bad flag, missing
+        // <patterns...>) is a CLI usage problem, same category as a bad path
+        // -- normalize to runLint's "2" rather than commander's own default
+        // of 1, which would be indistinguishable from "lint found errors".
+        process.exitCode = error.exitCode === 0 ? 0 : 2;
+        return;
+    }
+    // An actually unexpected failure (a bug, not a usage problem) -- don't
+    // report it as a usage error.
     console.error(error);
-    process.exitCode = 2;
+    process.exitCode = 1;
 });

--- a/gq-game-language/src/cli/program.ts
+++ b/gq-game-language/src/cli/program.ts
@@ -80,6 +80,14 @@ export function createCliProgram(): Command {
         .description('Parse and validate GameQueer .gq game-definition files headlessly (no VS Code required).')
         .argument('<patterns...>', 'files, directories, or glob patterns to lint, e.g. game.gq, games/, "games/**/*.gq"')
         .option('--strict', 'also exit non-zero when only warnings (no errors) were found', false)
+        // Commander's default error/--help/--version handling calls
+        // process.exit() directly, which would bypass main.ts's exit-code
+        // normalization below (and, for a genuine parse error like a missing
+        // <patterns...>, would exit 1 -- indistinguishable from "lint found
+        // errors" instead of runLint's documented "2" for a usage problem).
+        // exitOverride() makes commander throw a CommanderError instead, so
+        // main.ts can normalize it.
+        .exitOverride()
         .action(async (patterns: string[], options: { strict: boolean }) => {
             process.exitCode = await runLint(patterns, options);
         });

--- a/gq-game-language/src/cli/program.ts
+++ b/gq-game-language/src/cli/program.ts
@@ -1,0 +1,87 @@
+import { URI } from 'langium';
+import { NodeFileSystem } from 'langium/node';
+import { Command } from 'commander';
+import { createGameQueerGameLanguageServices } from '../language/game-queer-game-language-module.js';
+import { CliUsageError, formatDiagnostic, resolveGqFiles, severityLabel } from './cli-util.js';
+
+export interface LintOptions {
+    /** Also exit non-zero when only warnings (no errors) were found. */
+    strict?: boolean;
+}
+
+/**
+ * Parses and validates the `.gq` files matched by `patterns` (file paths,
+ * directory paths, and/or glob patterns -- see {@link resolveGqFiles}),
+ * printing one `file:line:col: severity: message` line per diagnostic plus a
+ * summary line.
+ *
+ * Runs the exact parse + validation pipeline the language server runs, just
+ * without a VS Code/LSP connection, so `.gq` diagnostics are available
+ * headlessly (CI, authors, AI harnesses).
+ *
+ * @returns the process exit code: `0` if clean (or only warnings without
+ * `--strict`), `1` if any error diagnostics were found (or any diagnostics at
+ * all under `--strict`), `2` for a CLI usage error (bad path, no matches).
+ */
+export async function runLint(patterns: string[], options: LintOptions = {}): Promise<number> {
+    let files: string[];
+    try {
+        files = await resolveGqFiles(patterns);
+    } catch (error) {
+        if (error instanceof CliUsageError) {
+            console.error(error.message);
+            return 2;
+        }
+        throw error;
+    }
+
+    if (files.length === 0) {
+        console.error('No .gq files matched the given arguments.');
+        return 2;
+    }
+
+    const { shared } = createGameQueerGameLanguageServices(NodeFileSystem);
+    const documents = await Promise.all(
+        files.map(file => shared.workspace.LangiumDocuments.getOrCreateDocument(URI.file(file)))
+    );
+    await shared.workspace.DocumentBuilder.build(documents, { validation: true });
+
+    let errorCount = 0;
+    let warningCount = 0;
+
+    for (const document of documents) {
+        const filePath = document.uri.fsPath;
+        for (const diagnostic of document.diagnostics ?? []) {
+            if (severityLabel(diagnostic.severity) === 'error') {
+                errorCount++;
+            } else if (severityLabel(diagnostic.severity) === 'warning') {
+                warningCount++;
+            }
+            console.log(formatDiagnostic(filePath, diagnostic));
+        }
+    }
+
+    const fileWord = files.length === 1 ? 'file' : 'files';
+    console.log(`${errorCount} error(s), ${warningCount} warning(s) in ${files.length} ${fileWord} checked.`);
+
+    if (errorCount > 0) {
+        return 1;
+    }
+    if (options.strict && warningCount > 0) {
+        return 1;
+    }
+    return 0;
+}
+
+export function createCliProgram(): Command {
+    const program = new Command();
+    program
+        .name('gq-lang-lint')
+        .description('Parse and validate GameQueer .gq game-definition files headlessly (no VS Code required).')
+        .argument('<patterns...>', 'files, directories, or glob patterns to lint, e.g. game.gq, games/, "games/**/*.gq"')
+        .option('--strict', 'also exit non-zero when only warnings (no errors) were found', false)
+        .action(async (patterns: string[], options: { strict: boolean }) => {
+            process.exitCode = await runLint(patterns, options);
+        });
+    return program;
+}

--- a/gq-game-language/test/cli-util.test.ts
+++ b/gq-game-language/test/cli-util.test.ts
@@ -1,0 +1,91 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { CliUsageError, formatDiagnostic, resolveGqFiles, severityLabel } from '../src/cli/cli-util.js';
+
+describe('resolveGqFiles', () => {
+    let dir: string;
+
+    beforeEach(() => {
+        dir = mkdtempSync(join(tmpdir(), 'gq-lang-lint-util-test-'));
+    });
+
+    afterEach(() => {
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    test('resolves a single .gq file path', async () => {
+        const file = join(dir, 'a.gq');
+        writeFileSync(file, 'game {}');
+
+        const resolved = await resolveGqFiles([file]);
+
+        expect(resolved).toEqual([file]);
+    });
+
+    test('recursively walks a directory for .gq files, ignoring other extensions', async () => {
+        writeFileSync(join(dir, 'a.gq'), 'game {}');
+        mkdirSync(join(dir, 'sub'));
+        writeFileSync(join(dir, 'sub', 'b.gq'), 'game {}');
+        writeFileSync(join(dir, 'notes.txt'), 'not a game file');
+
+        const resolved = await resolveGqFiles([dir]);
+
+        expect(resolved.sort()).toEqual([join(dir, 'a.gq'), join(dir, 'sub', 'b.gq')].sort());
+    });
+
+    test('expands a glob pattern and drops non-.gq matches', async () => {
+        writeFileSync(join(dir, 'a.gq'), 'game {}');
+        writeFileSync(join(dir, 'b.gq'), 'game {}');
+        writeFileSync(join(dir, 'readme.md'), '# not a game file');
+
+        const resolved = await resolveGqFiles([join(dir, '*')]);
+
+        expect(resolved.sort()).toEqual([join(dir, 'a.gq'), join(dir, 'b.gq')].sort());
+    });
+
+    test('deduplicates files matched by more than one argument', async () => {
+        const file = join(dir, 'a.gq');
+        writeFileSync(file, 'game {}');
+
+        const resolved = await resolveGqFiles([file, dir]);
+
+        expect(resolved).toEqual([file]);
+    });
+
+    test('throws a CliUsageError for a plain path that does not exist', async () => {
+        await expect(resolveGqFiles([join(dir, 'missing.gq')])).rejects.toThrow(CliUsageError);
+    });
+
+    test('throws a CliUsageError for a plain file path with the wrong extension', async () => {
+        const file = join(dir, 'notes.txt');
+        writeFileSync(file, 'not a game file');
+
+        await expect(resolveGqFiles([file])).rejects.toThrow(CliUsageError);
+    });
+});
+
+describe('severityLabel', () => {
+    test.each([
+        [1, 'error'],
+        [2, 'warning'],
+        [3, 'info'],
+        [4, 'hint'],
+        [undefined, 'error']
+    ] as const)('maps LSP severity %s to %s', (severity, label) => {
+        expect(severityLabel(severity)).toBe(label);
+    });
+});
+
+describe('formatDiagnostic', () => {
+    test('formats as file:line:col: severity: message (1-based)', () => {
+        const line = formatDiagnostic('/path/to/game.gq', {
+            range: { start: { line: 2, character: 4 }, end: { line: 2, character: 10 } },
+            severity: 1,
+            message: 'something is wrong'
+        });
+
+        expect(line).toBe('/path/to/game.gq:3:5: error: something is wrong');
+    });
+});

--- a/gq-game-language/test/cli.test.ts
+++ b/gq-game-language/test/cli.test.ts
@@ -1,8 +1,9 @@
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { CommanderError } from 'commander';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { runLint } from '../src/cli/program.js';
+import { createCliProgram, runLint } from '../src/cli/program.js';
 
 // A minimal, well-formed `game { ... }` block, matching test-utils.ts's
 // VALID_GAME_BLOCK -- parses and validates cleanly.
@@ -150,5 +151,62 @@ describe('runLint', () => {
         logLines.length = 0;
         const strictExitCode = await runLint([file], { strict: true });
         expect(strictExitCode).toBe(1);
+    });
+});
+
+describe('createCliProgram', () => {
+    // Regression coverage for a real bug this PR shipped and fixed before
+    // merge (per PR #391 review): commander's default error/help handling
+    // calls process.exit() directly, which both bypasses main.ts's exit-code
+    // normalization and (for a genuine parse error) exits 1 -- indistinguishable
+    // from "lint found errors" instead of the documented "2" for a usage
+    // problem. exitOverride() in createCliProgram() makes commander throw a
+    // CommanderError instead, so main.ts can normalize it; these tests pin
+    // that contract at the commander level (main.ts's own normalization
+    // logic isn't otherwise covered, being a thin, untested entry point like
+    // the rest of this package's `main.ts` files).
+    let stdoutSpy: ReturnType<typeof vi.spyOn>;
+    let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        // Commander writes help/usage-error text straight to process.stdout
+        // /process.stderr, not console.log/console.error; silence it so the
+        // test run's own output stays clean.
+        stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+        stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    test('a missing <patterns...> argument throws a CommanderError (not process.exit)', async () => {
+        const program = createCliProgram();
+
+        await expect(program.parseAsync(['node', 'gq-lang-lint'])).rejects.toBeInstanceOf(CommanderError);
+    });
+
+    test('--help throws a CommanderError with exitCode 0', async () => {
+        const program = createCliProgram();
+
+        await expect(program.parseAsync(['node', 'gq-lang-lint', '--help']))
+            .rejects.toMatchObject({ exitCode: 0 });
+    });
+
+    test('an unknown option throws a CommanderError with a non-zero exitCode', async () => {
+        const program = createCliProgram();
+        let caught: unknown;
+
+        try {
+            await program.parseAsync(['node', 'gq-lang-lint', '--bogus', 'game.gq']);
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(caught).toBeInstanceOf(CommanderError);
+        expect((caught as CommanderError).exitCode).not.toBe(0);
+        // sanity: commander did write its usage error somewhere (stderr, for
+        // an unrecognized option -- unlike --help, which goes to stdout)
+        expect(stdoutSpy.mock.calls.length + stderrSpy.mock.calls.length).toBeGreaterThan(0);
     });
 });

--- a/gq-game-language/test/cli.test.ts
+++ b/gq-game-language/test/cli.test.ts
@@ -1,0 +1,154 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { runLint } from '../src/cli/program.js';
+
+// A minimal, well-formed `game { ... }` block, matching test-utils.ts's
+// VALID_GAME_BLOCK -- parses and validates cleanly.
+const CLEAN_FIXTURE = `
+game {
+    id = 0;
+    title := "Test Game";
+    author := "duplico";
+    starting_stage = start;
+}
+stage start {
+}
+`;
+
+// A second, independently-clean fixture (different game id/title) -- used to
+// prove the multi-file case reports per-file, not just "any error anywhere".
+const CLEAN_FIXTURE_2 = `
+game {
+    id = 1;
+    title := "Another Game";
+    author := "duplico";
+    starting_stage = start;
+}
+stage start {
+}
+`;
+
+// Trips the game-block cardinality validator's duplicate-key check
+// (game-queer-game-language-validator.ts) at a precisely known location: the
+// duplicate 'id = 1;' assignment is line 4 (1-based), starting at column 5
+// (four leading spaces).
+const DUPLICATE_ID_FIXTURE = `
+game {
+    id = 0;
+    id = 1;
+    title := "Test Game";
+    author := "duplico";
+    starting_stage = start;
+}
+stage start {
+}
+`;
+const DUPLICATE_ID_LINE = 4;
+const DUPLICATE_ID_COLUMN = 5;
+
+// Trips only the reserved-builtin *warning* path (assigning a writable
+// builtin doesn't warn, but nothing here trips an error either) -- used for
+// the --strict test. GQI_PLAYER_ID is read-only, so assigning it warns
+// without being an error.
+const WARNING_ONLY_FIXTURE = `
+game {
+    id = 0;
+    title := "Test Game";
+    author := "duplico";
+    starting_stage = start;
+}
+stage start {
+    event enter {
+        GQI_PLAYER_ID = 5;
+    }
+}
+`;
+
+function writeFixture(dir: string, name: string, contents: string): string {
+    const filePath = join(dir, name);
+    writeFileSync(filePath, contents, 'utf-8');
+    return filePath;
+}
+
+describe('runLint', () => {
+    let dir: string;
+    let logLines: string[];
+    let logSpy: ReturnType<typeof vi.spyOn>;
+    let errorSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        dir = mkdtempSync(join(tmpdir(), 'gq-lang-lint-cli-test-'));
+        logLines = [];
+        logSpy = vi.spyOn(console, 'log').mockImplementation((line: string) => {
+            logLines.push(line);
+        });
+        errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        logSpy.mockRestore();
+        errorSpy.mockRestore();
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    test('a clean file exits 0 and reports zero errors', async () => {
+        const file = writeFixture(dir, 'clean.gq', CLEAN_FIXTURE);
+
+        const exitCode = await runLint([file]);
+
+        expect(exitCode).toBe(0);
+        expect(logLines.some(line => /: error:/.test(line))).toBe(false);
+        expect(logLines).toContainEqual('0 error(s), 0 warning(s) in 1 file checked.');
+    });
+
+    test('a file with a validation error exits non-zero and reports the correct file:line:col', async () => {
+        const file = writeFixture(dir, 'duplicate-id.gq', DUPLICATE_ID_FIXTURE);
+
+        const exitCode = await runLint([file]);
+
+        expect(exitCode).toBe(1);
+        expect(logLines).toContainEqual(
+            `${file}:${DUPLICATE_ID_LINE}:${DUPLICATE_ID_COLUMN}: error: Duplicate 'id' assignment in game block; exactly one is allowed.`
+        );
+        expect(logLines).toContainEqual('1 error(s), 0 warning(s) in 1 file checked.');
+    });
+
+    test('linting multiple files reports each file\'s diagnostics independently', async () => {
+        const clean = writeFixture(dir, 'clean.gq', CLEAN_FIXTURE_2);
+        const broken = writeFixture(dir, 'duplicate-id.gq', DUPLICATE_ID_FIXTURE);
+
+        const exitCode = await runLint([clean, broken]);
+
+        expect(exitCode).toBe(1);
+        // The broken file's diagnostic is reported...
+        expect(logLines).toContainEqual(
+            `${broken}:${DUPLICATE_ID_LINE}:${DUPLICATE_ID_COLUMN}: error: Duplicate 'id' assignment in game block; exactly one is allowed.`
+        );
+        // ...and the clean file contributes no diagnostic of its own.
+        expect(logLines.some(line => line.startsWith(clean) && / error: | warning: /.test(line))).toBe(false);
+        expect(logLines).toContainEqual('1 error(s), 0 warning(s) in 2 files checked.');
+    });
+
+    test('a usage error (no such file) exits 2 without touching the language service', async () => {
+        const missing = join(dir, 'does-not-exist.gq');
+
+        const exitCode = await runLint([missing]);
+
+        expect(exitCode).toBe(2);
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining(missing));
+    });
+
+    test('--strict escalates a warning-only file to a non-zero exit code', async () => {
+        const file = writeFixture(dir, 'warning-only.gq', WARNING_ONLY_FIXTURE);
+
+        const lenientExitCode = await runLint([file]);
+        expect(lenientExitCode).toBe(0);
+        expect(logLines.some(line => / warning: /.test(line))).toBe(true);
+
+        logLines.length = 0;
+        const strictExitCode = await runLint([file], { strict: true });
+        expect(strictExitCode).toBe(1);
+    });
+});


### PR DESCRIPTION
## Summary

Closes https://github.com/duplico/gamequeer/issues/384.

Fills in the Langium scaffold's referenced-but-missing `src/cli/`: a
`gq-lang-lint` command that runs the same parse + validation pipeline
the language server runs, headlessly (no VS Code, no LSP connection),
so `.gq` diagnostics are available to CI, authors, and AI harnesses.

- `src/cli/main.ts` -- thin executable entry point (bundled with a
  shebang banner by `esbuild.mjs`; wired up as the `gq-lang-lint` bin
  in `package.json`).
- `src/cli/program.ts` -- the actual `runLint`/`createCliProgram`
  logic, split out of `main.ts` so tests import it directly instead of
  spawning a subprocess.
- `src/cli/cli-util.ts` -- file/glob resolution (`resolveGqFiles`) and
  diagnostic formatting (`formatDiagnostic`, `severityLabel`).

Only `.gq` is in scope -- that's the only extension the Langium
grammar/services here know about. `.gqcue` lightcues are a separate
format handled entirely by `gqc` (Python), not this package.

### Usage

```sh
# After `npm run build` (or via `npx gq-lang-lint ...` once installed):
node ./out/cli/main.cjs game.gq
node ./out/cli/main.cjs games/                    # recurses a directory
node ./out/cli/main.cjs "games/**/*.gq"            # glob pattern
node ./out/cli/main.cjs a.gq b.gq                  # multiple files
node ./out/cli/main.cjs --strict game.gq           # also fail on warnings
```

Output is one line per diagnostic, `file:line:col: severity: message`
(1-based, matching `tsc`/`eslint` conventions), plus a summary line.
Exit code: `0` clean (or warnings-only without `--strict`), `1` any
error diagnostic (or any diagnostic under `--strict`), `2` CLI usage
error (bad path, wrong extension, no matches).

### Design notes / open questions

- **Diagnostic scope**: `document.diagnostics` after
  `DocumentBuilder.build([...], { validation: true })` already
  includes lexer/parser/linking errors *and* custom validation
  diagnostics combined (`DefaultDocumentValidator`), so the CLI needs
  no separate handling for syntax vs. semantic errors.
- **Dependencies**: added `commander` (pinned `^11.1.0` to dedupe
  against the copy `langium-cli` already pulls in) and `fast-glob`
  (new). Deliberately did **not** add `chalk` -- it's already present
  at two conflicting major versions in this tree (v4 hoisted to
  top-level from `eslint`/`concurrently`, v5 nested under
  `langium-cli`), and a bare `import chalk from 'chalk'` in our own
  source would silently resolve the wrong (CJS v4) one via Node's
  module resolution. Plain, uncolored output sidesteps that trap
  entirely.
- **`bin/cli` vs `out/cli/main.cjs`**: `langium-quickstart.md`
  (pre-existing, from the yeoman scaffold) referenced a `./bin/cli`
  entry that was never actually built by `esbuild.mjs`, and its
  described CLI (`generate <file>`, `generator.ts`) doesn't apply
  here -- this package has no code generator; `gqc` (Python) already
  owns codegen. Repointed the doc at the real, now-existing
  `out/cli/main.cjs`.

### Test plan

- [x] `npm ci`
- [x] `npm run langium:generate`
- [x] `npm run build` (clean, no warnings)
- [x] `npm run lint` (clean)
- [x] `npm test` -- 77/77 passing (60 pre-existing + 17 new: 12
      `cli-util.test.ts` unit tests for `resolveGqFiles`/
      `severityLabel`/`formatDiagnostic`, 5 `cli.test.ts` end-to-end
      `runLint` tests covering a clean file (exit 0), a file with a
      validation error at a precisely-known `line:col` (exit 1), two
      files linted together (per-file diagnostics), a usage error
      (missing file, exit 2), and `--strict`)
- [x] Manually ran the bundled `out/cli/main.cjs` against real
      fixtures in `examples/games/` -- single file, directory,
      `**/*.gq` glob, multiple files, missing file, wrong extension,
      `--help`

(AI-generated via Claude Code w/ Fable 5)