### PR TITLE
feat(gqc): add badge_count() intrinsic

### DIFF
--- a/gqc/docs/authoring-and-perf-carts.md
+++ b/gqc/docs/authoring-and-perf-carts.md
@@ -58,7 +58,19 @@ and `input(BTN)` where `BTN` ∈ `A`, `B`, `<-`, `->`, `-` (click).
 with `continue` / `break`, `badge_set`/`badge_clear`, and assignments
 (`x = expr;` int, `s := expr;` string with `+` concat and `str(int)` cast);
 `badge_get` is not a statement but a unary operator usable inside int
-expressions (e.g. `x = badge_get(5) + 1;`).
+expressions (e.g. `x = badge_get(5) + 1;`); `badge_count()` (nullary,
+parens mandatory) is a popcount over the whole badges-seen bitfield, e.g.
+`if (badge_count() >= 5) { ... }`.
+
+**`badge_count()` is heavy -- a ~9-op runtime loop over all 320 badge
+slots, not an O(1) lookup.** Call it once (e.g. on a stage's `enter` event)
+and cache the result in a variable rather than re-evaluating it from a
+per-tick or per-frame handler. It also holds 3 of gqc's 4 int registers
+(`GQ_REGISTERS_INT`) for the duration of that loop -- an enclosing
+expression has at most 1 register free while it's evaluating (3 again once
+it returns); a second `badge_count()` in the *same* expression (or any
+other expression that needs 2+ registers concurrently with the first
+one's still-live result) can hit `No free registers available`.
 The `play` forms are:
 
 ```

--- a/gqc/src/gqc/commands.py
+++ b/gqc/src/gqc/commands.py
@@ -592,6 +592,63 @@ class CommandLoop(Command):
 
         return f"LOOP {self.commands}"
 
+def unregister_orphaned_commands(cmds: list):
+    """Remove `cmds` -- and anything nested inside a `CommandIf`'s
+    true/false branches or a `CommandLoop`'s own body -- from the global
+    `Command.command_list` bookkeeping list.
+
+    `IntExpression.get_result_symbol` (`datamodel.py`) discards an
+    already-built `IntExpression` -- a genuinely parenthesized
+    sub-expression, or one side of a same-precedence chain
+    `parser.parse_int_expression`'s left-fold pre-built in isolation -- and
+    re-derives its subtree from raw tokens under the *outer* expression's
+    own shared register pool instead. That's the only way to safely
+    combine two independently-register-allocated command sequences (a
+    naive splice-the-final-result-register-in instead of rebuilding isn't
+    safe in general: two sibling pre-built sub-expressions, e.g.
+    `(badge_count()) + (badge_count())`, each started from an *empty*
+    register pool in isolation and so can easily have picked the *same*
+    register name for their own internal work -- splicing both command
+    sequences back to back would let the second one's internal register
+    reuse clobber the first one's still-unconsumed result).
+
+    Discarding an already-built `IntExpression` like this is harmless for
+    every leaf/operator that existed before gamequeer#387: their
+    `resolve()` only ever depends on a `Variable`/`Stage` symbol-table
+    lookup, which still succeeds regardless of whether the orphaned copy
+    ever gets attached to the real program tree. It is NOT harmless for a
+    `badge_count()` (gamequeer#387) -- the first feature to put a
+    `CommandLoop`/`CommandIf`/break-or-continue-form `CommandGoto` inside
+    int-expression codegen: `CommandGoto.resolve()` doesn't consult
+    `unresolved_symbols` at all -- it just tests whether *some* owning
+    `CommandLoop.set_addr()` tree-walk has patched its real jump target
+    into `arg1`, which only happens for commands actually attached to the
+    final Event/Stage tree. An orphaned copy is discarded specifically
+    because its containing `CommandLoop` never gets `set_addr()` called on
+    it, so without this cleanup its `arg1` -- and therefore `resolve()` --
+    would stay permanently 0/`False`, and `linker.py`'s final "is
+    everything resolved?" sweep over `Command.command_list` (which doesn't
+    distinguish "genuinely dangling" from "safely discarded and rebuilt
+    elsewhere") would report a fatal unresolved-command error despite
+    nothing in the actual compiled program ever referencing it.
+    """
+    for cmd in cmds:
+        try:
+            Command.command_list.remove(cmd)
+        except ValueError:
+            # Already removed (reachable via more than one nested path) or
+            # never registered -- either way, nothing left to do.
+            pass
+
+        if isinstance(cmd, CommandIf):
+            unregister_orphaned_commands(cmd.true_cmds)
+            if cmd.false_cmds:
+                unregister_orphaned_commands(cmd.false_cmds)
+            if cmd.goto_cmd:
+                unregister_orphaned_commands([cmd.goto_cmd])
+        elif isinstance(cmd, CommandLoop):
+            unregister_orphaned_commands(cmd.commands)
+
 class CommandTimer(CommandWithIntExpressionArgument):
     def __init__(self, instring, loc, interval : GqcIntOperand | IntExpression):
         super().__init__(CommandType.TIMER, instring, loc, interval)

--- a/gqc/src/gqc/datamodel.py
+++ b/gqc/src/gqc/datamodel.py
@@ -33,6 +33,17 @@ GqcIntOperand = namedtuple('GqcIntOperand', 'is_literal value')
 # other operand that needs to be loaded into a register.
 GqcStrCastOperand = namedtuple('GqcStrCastOperand', 'int_expr')
 
+# `badge_count()` -- a nullary popcount intrinsic over the 320-bit
+# badges-seen bitfield (gamequeer#387). It carries no data of its own (no
+# argument, no variable/literal backing it), so -- unlike `GqcIntOperand` --
+# it can never be returned as-is as a subexpression's result; it always has
+# to be lowered into a runtime loop first (see
+# `IntExpression._emit_badge_count`). This is just the marker
+# `parser.parse_badge_count_operand`/`parse_int_operand`/
+# `IntExpression.get_result_symbol` recognize to trigger that lowering, the
+# same role `GqcStrCastOperand` plays for an inline `str(x)` cast.
+GqcBadgeCountOperand = namedtuple('GqcBadgeCountOperand', [])
+
 class Game:
     link_table = dict() # OrderedDict not needed to remember order since Python 3.7
     game_name : str = None
@@ -997,8 +1008,10 @@ def fold_constant_int_expression(node):
     from the VM's actual runtime behavior:
       - any operand references a variable or a register, rather than being
         a literal;
-      - the operator is `badge_get` -- it reads live badge state, not a
-        constant, regardless of whether its operand is a literal;
+      - the operator is `badge_get`, or the node is a `badge_count()` call
+        -- both read live badge state, not a constant, regardless of
+        whether `badge_get`'s own operand is a literal (`badge_count()`
+        never has one);
       - a `/` or `%` whose literal divisor is 0 -- the VM leaves this
         unguarded at runtime (see `run_arithmetic`), so folding it would
         turn a runtime behavior into either a compile-time crash or a
@@ -1029,6 +1042,15 @@ def fold_constant_int_expression(node):
 
     if isinstance(node, GqcIntOperand):
         return node.value if node.is_literal else None
+
+    if isinstance(node, GqcBadgeCountOperand):
+        # badge_count() reads live badge state, not a constant -- same
+        # reasoning as badge_get below, just with no operand of its own to
+        # even consider (gamequeer#387). `node_len not in (2, 3)` a few
+        # lines down would decline this anyway (a 0-field namedtuple has
+        # `len() == 0`), but that's incidental; this is the intentional,
+        # explicit no-fold.
+        return None
 
     # The remaining shape is a raw `[operand, op, operand]` / `[op, operand]`
     # token group -- a plain `list` when built by this module's own
@@ -1154,15 +1176,36 @@ class IntExpression:
         self.used_registers.remove(reg)
 
     def get_result_symbol(self, subexpr : list) -> GqcIntOperand:
-        from .commands import CommandSetInt, CommandArithmetic
+        from .commands import CommandSetInt, CommandArithmetic, unregister_orphaned_commands
 
         if isinstance(subexpr, IntExpression):
+            # About to discard subexpr's own pre-built commands and
+            # re-derive its subtree from raw tokens under *this*
+            # expression's own register pool instead (see
+            # unregister_orphaned_commands's docstring for why that's the
+            # only safe way to combine two independently-allocated
+            # register pools, and why the discard needs this cleanup step
+            # -- gamequeer#387).
+            unregister_orphaned_commands(subexpr.commands)
             subexpr = subexpr.expression_toks
+
+        if isinstance(subexpr, GqcBadgeCountOperand):
+            # A badge_count() leaf reached directly, e.g. as one operand of
+            # a binary op ("badge_count() + 1" hands this get_result_symbol
+            # call subexpr[0] bare, not wrapped in a list) -- gamequeer#387.
+            return self._emit_badge_count()
 
         if isinstance(subexpr, GqcIntOperand):
             return subexpr
         elif len(subexpr) == 1:
-            return subexpr[0]
+            # subexpr[0] may itself be a bare GqcBadgeCountOperand -- e.g.
+            # the sole atom of "x = badge_count();", which
+            # parser.parse_int_expression wraps as
+            # IntExpression([GqcBadgeCountOperand()], ...). Recurse instead
+            # of handing it back unresolved; every other len-1 shape here is
+            # already a GqcIntOperand (or an IntExpression to unwrap), so
+            # this recursion is a no-op passthrough for them.
+            return self.get_result_symbol(subexpr[0])
         elif len(subexpr) > 3:
             raise ValueError(f"Invalid subexpression length {len(subexpr)}: should be [operand, operator, operand] or [operator operand]")
 
@@ -1218,6 +1261,80 @@ class IntExpression:
         # All GQ arithmetic commands are actually accumulators, so the result is always stored in the left operand.
         #  So, we can return the left operand as the result of this subexpression.
         return operand0
+
+    def _emit_badge_count(self) -> GqcIntOperand:
+        """Lower a `badge_count()` leaf (gamequeer#387) to a runtime
+        popcount loop over the *existing* `badge_get` opcode (`QCGET`) --
+        the FROZEN VM CONTRACT rules out both a new dedicated opcode and a
+        new register. The alternative would be to unroll `BADGES_ALLOWED`
+        (320) `QCGET`+`ADDBY` pairs inline; that's ~2x fewer *runtime* ops
+        (no per-iteration `GOTOIFN`/`GOTO` overhead) but ~7x more
+        *bytecode* (320 * 2 = 640 ops vs. this loop's fixed 9, regardless of
+        `BADGES_ALLOWED`) for every call site -- a bad trade for something
+        meant to be sugar. The issue (gamequeer#387) also specifies the
+        loop form directly ("the hand-rolled loop-over-badge_get(i)
+        bytecode").
+
+        Counts the loop variable *down* from `BADGES_ALLOWED` to 0, so the
+        continue-test is a bare truthiness check on the counter register
+        itself (`CommandIf` with that register as its own condition) --
+        not a `>=`/`>` comparison, which would need yet another register:
+        every `CommandArithmetic` op (comparisons included) overwrites its
+        own destination, so comparing the counter directly against a bound
+        would clobber it.
+
+        Register cost: allocates 3 of gqc's 4 `GQ_REGISTERS_INT` for the
+        duration of the loop (accumulator, counter, per-iteration
+        `badge_get` result); only the accumulator survives past this method
+        as the returned result. An enclosing expression that evaluates a
+        second `badge_count()` -- or otherwise needs 2+ registers -- while
+        the first's accumulator is still live can exhaust the register file
+        (`No free registers available`, the same pre-existing diagnostic
+        `test_register_allocation_depth_5_exhausts_registers` covers for
+        deeply nested arithmetic). See docs/authoring-and-perf-carts.md.
+        """
+        from .commands import CommandSetInt, CommandArithmetic, CommandIf, CommandGoto, CommandLoop
+
+        acc_reg = self.alloc_register()
+        idx_reg = self.alloc_register()
+        acc_operand = GqcIntOperand(is_literal=False, value=acc_reg)
+        idx_operand = GqcIntOperand(is_literal=False, value=idx_reg)
+
+        self.commands.append(CommandSetInt(self.instring, self.loc, acc_reg, GqcIntOperand(is_literal=True, value=0)))
+        self.commands.append(CommandSetInt(self.instring, self.loc, idx_reg, GqcIntOperand(is_literal=True, value=structs.BADGES_ALLOWED)))
+
+        bit_reg = self.alloc_register()
+        bit_operand = GqcIntOperand(is_literal=False, value=bit_reg)
+
+        # while (idx) { idx -= 1; bit = badge_get(idx); acc += bit; }
+        # -- idx is decremented *before* use, so it visits BADGES_ALLOWED-1
+        # down to 0 inclusive (BADGES_ALLOWED distinct badge indices), never
+        # BADGES_ALLOWED itself (which get_badge_bit() would reject as
+        # out-of-range and return 0 for anyway -- see gamequeer.c -- but
+        # this keeps the index space exactly [0, BADGES_ALLOWED) with no
+        # reliance on that guard).
+        decrement_and_accumulate = [
+            CommandArithmetic(structs.OpCode.SUBBY, self.instring, self.loc, idx_operand, GqcIntOperand(is_literal=True, value=1)),
+            CommandArithmetic(structs.OpCode.QCGET, self.instring, self.loc, bit_operand, idx_operand),
+            CommandArithmetic(structs.OpCode.ADDBY, self.instring, self.loc, acc_operand, bit_operand),
+        ]
+        guarded_body = [
+            CommandIf(
+                self.instring, self.loc, idx_operand,
+                decrement_and_accumulate,
+                [CommandGoto(self.instring, self.loc, form='break')],
+            )
+        ]
+        self.commands.append(CommandLoop(self.instring, self.loc, guarded_body))
+
+        # idx/bit are pure loop scratch, done for good once the loop is
+        # built; acc is this method's result and stays allocated, exactly
+        # like a unary op's freshly-allocated destination register does at
+        # this same point in the len(subexpr) == 2 branch above.
+        self.free_register(bit_reg)
+        self.free_register(idx_reg)
+
+        return acc_operand
 
     def resolve(self):
         if self.resolved:

--- a/gqc/src/gqc/datamodel.py
+++ b/gqc/src/gqc/datamodel.py
@@ -1267,13 +1267,15 @@ class IntExpression:
         popcount loop over the *existing* `badge_get` opcode (`QCGET`) --
         the FROZEN VM CONTRACT rules out both a new dedicated opcode and a
         new register. The alternative would be to unroll `BADGES_ALLOWED`
-        (320) `QCGET`+`ADDBY` pairs inline; that's ~2x fewer *runtime* ops
-        (no per-iteration `GOTOIFN`/`GOTO` overhead) but ~7x more
-        *bytecode* (320 * 2 = 640 ops vs. this loop's fixed 9, regardless of
-        `BADGES_ALLOWED`) for every call site -- a bad trade for something
-        meant to be sugar. The issue (gamequeer#387) also specifies the
-        loop form directly ("the hand-rolled loop-over-badge_get(i)
-        bytecode").
+        (320) `QCGET`+`ADDBY` pairs inline; that's ~3x fewer *runtime* ops
+        per call (no per-iteration `GOTOIFN`/`GOTO` overhead: ~642 for an
+        unrolled sequence vs. ~1924 for this loop -- 2 init ops, then 320
+        iterations of a 6-op `GOTOIFN`+3-op-body+`GOTO`x2 truthy pass, plus
+        one final falsy pass) but ~70x more *bytecode* (320 * 2 = 640 ops
+        vs. this loop's fixed 9, regardless of `BADGES_ALLOWED`) for every
+        call site -- a bad trade for something meant to be sugar. The issue
+        (gamequeer#387) also specifies the loop form directly ("the
+        hand-rolled loop-over-badge_get(i) bytecode").
 
         Counts the loop variable *down* from `BADGES_ALLOWED` to 0, so the
         continue-test is a bare truthiness check on the counter register

--- a/gqc/src/gqc/grammar.py
+++ b/gqc/src/gqc/grammar.py
@@ -6,6 +6,7 @@ from .parser import parse_event_definition, parse_command, parse_assignment, par
 from .parser import parse_menu_definition, parse_bound_menu, parse_play
 from .parser import parse_int_expression, parse_int_operand, parse_str_literal, parse_if
 from .parser import parse_str_expression, parse_string_cast_operand
+from .parser import parse_badge_count_operand
 
 """
 Grammar for GQC language
@@ -76,9 +77,17 @@ int_assignment = identifier "=" int_expression ";"
 # including str(x) appearing inside a "+" chain (gamequeer#386).
 string_assignment = identifier ":=" ((string_cast &";") | string_expression) ";"
 
-int_operand = identifier | integer
+int_operand = badge_count_call | identifier | integer
 string_cast = 'str' '(' int_expression ')'
 string_operand = identifier | string | string_cast
+
+# badge_count() is a nullary popcount intrinsic over the 320-bit
+# badges-seen bitfield (gamequeer#387): "how many distinct badges has this
+# badge seen?" It always lowers to a runtime loop over the existing
+# badge_get opcode (QCGET) -- there's no argument to type-check, so unlike
+# badge_get it takes an empty, mandatory parameter list, not a bare operand
+# form.
+badge_count_call = "badge_count" "(" ")"
 
 # Shorthand; see https://stackoverflow.com/a/23956778
 # badge_get is a right-associative unary prefix operator, e.g. badge_get(x).
@@ -167,7 +176,18 @@ def build_game_parser():
     event_statements = pp.Forward()
     
     # Assignments and expressions
-    int_operand = identifier | integer
+    # badge_count() -- a nullary popcount intrinsic over the badges-seen
+    # bitfield (gamequeer#387). Keyword("badge_count"), not a bare string,
+    # so it doesn't swallow a `badge_count`-prefixed identifier
+    # (gamequeer#354's badge_get/badge_getter fix, same reasoning). The `-`
+    # after the Keyword commits once "badge_count" itself has matched, so
+    # e.g. `badge_count(5)` fails with a clean, source-located
+    # ParseSyntaxException at the unexpected "5" rather than silently
+    # falling through to some other (wrong) interpretation.
+    badge_count_call = pp.Group(pp.Keyword("badge_count") - pp.Suppress("(") - pp.Suppress(")")).set_name("badge_count_call")
+    badge_count_call.set_parse_action(parse_badge_count_operand)
+
+    int_operand = badge_count_call | identifier | integer
     int_operand.set_parse_action(parse_int_operand)
     int_expression = pp.infix_notation(int_operand, [
         (pp.Keyword('badge_get') | pp.one_of('! - ~'), 1, pp.opAssoc.RIGHT),

--- a/gqc/src/gqc/parser.py
+++ b/gqc/src/gqc/parser.py
@@ -6,7 +6,8 @@ import pyparsing as pp
 from rich import print
 
 from .datamodel import Animation, Game, Stage, Variable, Event, Menu, LightCue, StrExpression
-from .datamodel import IntExpression, GqcIntOperand, GqcStrCastOperand, fold_constant_int_expression
+from .datamodel import IntExpression, GqcIntOperand, GqcStrCastOperand, GqcBadgeCountOperand
+from .datamodel import fold_constant_int_expression
 from .commands import CommandPlay, CommandGoStage, CommandCue, CommandCastStr
 from .commands import CommandSetStr, CommandSetInt, CommandWithIntExpressionArgument
 from .commands import CommandTimer, CommandIf, CommandGoto, CommandLoop, Command, CommandType
@@ -218,8 +219,16 @@ def parse_assignment(instring, loc, toks):
 
     return [['setvar', dst, src, datatype]]
 
+def parse_badge_count_operand(instring, loc, toks):
+    # badge_count() (gamequeer#387) never carries any data of its own -- it
+    # always lowers to the same fixed loop-over-badge_get shape (see
+    # IntExpression._emit_badge_count) -- so the sentinel returned here is
+    # just a marker for parse_int_operand/parse_int_expression/
+    # IntExpression.get_result_symbol to recognize, not a value container.
+    return GqcBadgeCountOperand()
+
 def parse_int_operand(instring, loc, toks):
-    if isinstance(toks[0], GqcIntOperand):
+    if isinstance(toks[0], (GqcIntOperand, GqcBadgeCountOperand)):
         return toks[0]
     elif isinstance(toks[0], int):
         return GqcIntOperand(True, toks[0])
@@ -241,6 +250,19 @@ def parse_int_expression(instring, loc, toks):
         # re-folding/re-constructing it (which would double-alloc its
         # registers -- see gamequeer#345).
         return toks
+    if isinstance(toks, GqcBadgeCountOperand):
+        # badge_count() as the *entire* RHS, e.g. "x = badge_count();" --
+        # with no sibling operator at this nesting level, infix_notation
+        # hands this back as a bare atom rather than a
+        # [operand, op, operand] token group. Unlike a bare variable
+        # reference, badge_count() always emits real commands (its
+        # popcount loop), so it needs an IntExpression wrapper even here;
+        # get_result_symbol recognizes the same sentinel to build that
+        # loop (see IntExpression._emit_badge_count).
+        try:
+            return IntExpression([toks], instring, loc)
+        except ValueError as ve:
+            raise GqcParseError(str(ve), instring, loc)
 
     # pyparsing's infix_notation hands us a flat token list [a, op1, b, op2,
     # c, ...] for a chain of same-precedence (opAssoc.LEFT) operators. Fold

--- a/gqc/tests/test_badge_count.py
+++ b/gqc/tests/test_badge_count.py
@@ -1,0 +1,291 @@
+"""`badge_count()` intrinsic suite for gqc (gamequeer#387).
+
+`badge_count()` is a nullary popcount over the 320-bit badges-seen bitfield
+(`BADGES_ALLOWED` in `gqc/src/gqc/structs.py`, matching `BADGES_ALLOWED` in
+the C VM's `gamequeer.h`). FROZEN VM CONTRACT: it lowers entirely to
+*existing* bytecode -- a runtime `while (idx) { ... }` loop over the
+existing `badge_get` opcode (`QCGET`), built from the same
+`CommandLoop`/`CommandIf`/`CommandGoto`/`CommandArithmetic` machinery a
+hand-written `.gq` `loop { }` statement already uses (see
+`IntExpression._emit_badge_count`, `gqc/src/gqc/datamodel.py`) -- not an
+unrolled `BADGES_ALLOWED`-times sequence and not a new opcode/register.
+
+`test_grammar.py` covers accept/reject grammar forms;
+`test_constant_folding.py` pins that `badge_count()` never folds. This
+module covers the op-stream shape and the register-allocation/re-entrancy
+behavior of embedding it inside a larger int expression -- including a real
+gamequeer#387-shaped bug this feature's development uncovered and fixed:
+gqc has a pre-existing "discard an already-built sub-expression and
+re-derive it under the outer expression's own shared register pool"
+mechanism (used for parenthesized sub-expressions, and for
+`parser.parse_int_expression`'s same-precedence-chain left-fold), which was
+harmless for every leaf/operator that existed before this feature (their
+`resolve()` only ever depends on a `Variable`/`Stage` symbol-table lookup)
+but broke for `badge_count()`, the first thing to put a
+`CommandLoop`/break-or-continue-form `CommandGoto` inside int-expression
+codegen (a discarded copy's `CommandGoto`s never get their real jump target
+patched, and used to trip `linker.py`'s "is everything resolved?" sweep as
+a false-positive FATAL error). See `commands.unregister_orphaned_commands`
+for the fix. `test_badge_count_parenthesized_operand_compiles_once` and
+`test_badge_count_leftmost_in_three_term_chain_compiles` below are direct
+regression pins for that bug, not just feature coverage.
+"""
+
+from gqc import structs
+
+from .opstream import one_event
+
+GAME_HEADER = 'game { id = 1; title := "T"; author := "A"; starting_stage = start; }\n'
+
+
+def game_with_stage(body: str, decls: str = "") -> str:
+    """A minimal valid game with a single stage `start` whose `enter` event
+    runs `body`, optionally preceded by top-level declarations (e.g. a
+    `volatile { ... }` block)."""
+    return f"{GAME_HEADER}{decls}\nstage start {{ event enter {{ {body} }} }}\n"
+
+
+def assert_no_traceback(stderr: str):
+    assert "Traceback" not in stderr, f"raw Python traceback leaked to stderr:\n{stderr}"
+
+
+def _int_register_addrs() -> set:
+    return {
+        structs.gq_ptr_apply_ns(structs.GQ_PTR_NS_HEAP, i * structs.GQ_INT_SIZE)
+        for i in range(len(structs.GQ_REGISTERS_INT))
+    }
+
+
+# --- op-stream shape ----------------------------------------------------------
+
+
+def test_badge_count_op_stream_shape(compile_gq):
+    source = game_with_stage("x = badge_count();", "volatile { int x = 0; }")
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    # 2 init SETVARs (accumulator, counter), a 7-op `while (idx) { ... }`
+    # loop (GOTOIFN + a 3-op true branch + GOTO-skip-false + break-GOTO +
+    # the auto-appended continue-GOTO), then the assignment's own final
+    # SETVAR copying the accumulator into x.
+    assert [op.name for op in ops] == [
+        "SETVAR", "SETVAR",
+        "GOTOIFN", "SUBBY", "QCGET", "ADDBY", "GOTO", "GOTO", "GOTO",
+        "SETVAR", "DONE",
+    ]
+    (
+        init_acc, init_idx,
+        gotoifn, subby, qcget, addby, goto_skip_false, goto_break, goto_continue,
+        final_setvar, _done,
+    ) = ops
+
+    reg_addrs = _int_register_addrs()
+    assert init_acc.arg1 in reg_addrs
+    assert init_idx.arg1 in reg_addrs
+    assert qcget.arg1 in reg_addrs
+    assert len({init_acc.arg1, init_idx.arg1, qcget.arg1}) == 3  # 3 distinct registers
+
+    assert init_acc.flags & structs.OpFlags.LITERAL_ARG2 and init_acc.arg2 == 0
+    assert init_idx.flags & structs.OpFlags.LITERAL_ARG2 and init_idx.arg2 == structs.BADGES_ALLOWED
+
+    # The loop condition is the raw counter register's own truthiness -- no
+    # comparison opcode, which would need a 4th register just to hold the
+    # comparison result without clobbering the counter itself (every
+    # CommandArithmetic op, comparisons included, overwrites its own dst;
+    # see IntExpression._emit_badge_count).
+    assert not (gotoifn.flags & structs.OpFlags.LITERAL_ARG2)
+    assert gotoifn.arg2 == init_idx.arg1
+
+    assert subby.flags & structs.OpFlags.LITERAL_ARG2 and subby.arg2 == 1
+    assert subby.arg1 == init_idx.arg1  # idx -= 1, in place
+
+    assert not (qcget.flags & structs.OpFlags.LITERAL_ARG2)
+    assert qcget.arg2 == init_idx.arg1  # badge_get(idx) -- a register index, not a literal one
+
+    assert addby.arg1 == init_acc.arg1  # accumulates into the same register throughout
+    assert addby.arg2 == qcget.arg1
+
+    # GOTOIFN's false-branch target is the break-goto; the true branch's
+    # own trailing GOTO skips past it to this iteration's end (the
+    # continue-goto); break jumps past the *entire* loop (one GQ_OP_SIZE
+    # past the continue-goto, gqc's actual loop-done address); continue
+    # jumps back to the loop's own top (the GOTOIFN itself).
+    assert gotoifn.arg1 == goto_break.addr
+    assert goto_skip_false.arg1 == goto_continue.addr
+    assert goto_break.arg1 == goto_continue.addr + structs.GQ_OP_SIZE
+    assert goto_continue.arg1 == gotoifn.addr
+
+    assert not (final_setvar.flags & structs.OpFlags.LITERAL_ARG2)
+    assert final_setvar.arg2 == init_acc.arg1  # x = the accumulator register
+
+
+def test_badge_count_bytecode_size_is_fixed_not_proportional_to_badges_allowed(compile_gq):
+    # The whole point of the loop strategy over an unrolled one (see the
+    # module docstring): badge_count()'s own bytecode is a small, *fixed*
+    # 9 ops (90 bytes at GQ_OP_SIZE=10) regardless of BADGES_ALLOWED (320),
+    # not ~2x BADGES_ALLOWED ops for an unrolled QCGET+ADDBY sequence.
+    source = game_with_stage("x = badge_count();", "volatile { int x = 0; }")
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    # Everything except the assignment's own trailing SETVAR and the
+    # event's final DONE belongs to badge_count() itself.
+    badge_count_ops = ops[:-2]
+    assert len(badge_count_ops) == 9
+    assert len(badge_count_ops) < 2 * structs.BADGES_ALLOWED
+
+
+# --- embedding inside a larger expression: register pressure and re-entrancy --
+
+
+def test_badge_count_combined_with_binary_op_has_two_registers_free(compile_gq):
+    source = game_with_stage("x = badge_count() + y;", "volatile { int x = 0; int y = 0; }")
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    assert sum(1 for op in ops if op.name == "QCGET") == 1
+
+
+def test_badge_count_used_twice_in_one_expression_compiles(compile_gq):
+    # Re-entrancy: two independent badge_count() evaluations in the same
+    # expression, each with its own accumulator/counter/bit registers --
+    # exactly fits gqc's 4-register int file (2 accumulators, this
+    # expression's own peak of one call's 3 scratch registers while the
+    # other's single surviving accumulator is still live).
+    source = game_with_stage(
+        "x = badge_count() + badge_count();", "volatile { int x = 0; }"
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    assert sum(1 for op in ops if op.name == "QCGET") == 2
+
+
+def test_badge_count_long_left_associative_chain_compiles(compile_gq):
+    # A left-associative chain of badge_count() calls never exceeds the
+    # 4-register budget at any length: each call's own idx/bit scratch
+    # registers free immediately after its loop is built, leaving only the
+    # single running accumulator (1 register) live while the *next* call's
+    # own 3 (accumulator/idx/bit) are allocated -- 1 + 3 = 4, regardless of
+    # chain length. This also regression-pins the discard-and-rebuild fix
+    # (see module docstring): a same-precedence chain longer than 3 tokens
+    # routes every prefix through parser.parse_int_expression's left-fold,
+    # which builds and discards an intermediate IntExpression for every
+    # non-terminal prefix.
+    source = game_with_stage(
+        "x = badge_count() + badge_count() + badge_count() + badge_count();",
+        "volatile { int x = 0; }",
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    assert sum(1 for op in ops if op.name == "QCGET") == 4
+
+
+def test_badge_count_leftmost_in_three_term_chain_compiles(compile_gq):
+    # Regression pin: badge_count() as the *left*most operand of a
+    # same-precedence chain longer than 3 tokens -- this specific shape
+    # used to crash with "FATAL: Unresolved symbols remain in command GOTO
+    # 0x00000000" (the orphaned-discarded-copy bug; see module docstring)
+    # before gamequeer#387's unregister_orphaned_commands fix.
+    source = game_with_stage(
+        "x = badge_count() + y + z;", "volatile { int x = 0; int y = 0; int z = 0; }"
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    assert sum(1 for op in ops if op.name == "QCGET") == 1
+
+
+def test_badge_count_middle_of_three_term_chain_compiles(compile_gq):
+    # Same regression as above, badge_count() in the *middle* position.
+    source = game_with_stage(
+        "x = y + badge_count() + z;", "volatile { int x = 0; int y = 0; int z = 0; }"
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    assert sum(1 for op in ops if op.name == "QCGET") == 1
+
+
+def test_badge_count_parenthesized_operand_compiles_once(compile_gq):
+    # Regression pin: explicit parenthesization forces gqc's grammar to
+    # pre-build badge_count() as its own standalone IntExpression *before*
+    # the outer "+" is even parsed (pyparsing's own recursive descent into
+    # the parenthesized group) -- exactly the shape that used to trigger
+    # the orphaned-discarded-copy bug (see module docstring). Also asserts
+    # there's exactly one QCGET, not two -- i.e. the fix genuinely drops
+    # the discarded copy rather than emitting it twice.
+    source = game_with_stage("x = (badge_count()) + 1;", "volatile { int x = 0; }")
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    assert sum(1 for op in ops if op.name == "QCGET") == 1
+
+
+def test_badge_count_sibling_parenthesized_operands_compile(compile_gq):
+    # Two independently-pre-built badge_count() sub-expressions combined
+    # by an outer operator -- each one's own internal register allocation
+    # started from an empty pool in isolation, so (before the fix) a naive
+    # "reuse the discarded copy instead of rebuilding" approach would have
+    # let the second one's internal temp-register reuse clobber the
+    # first's still-unconsumed result (see
+    # commands.unregister_orphaned_commands's docstring for why gqc
+    # rebuilds under a shared pool instead of splicing).
+    source = game_with_stage(
+        "x = (badge_count()) + (badge_count());", "volatile { int x = 0; }"
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    assert sum(1 for op in ops if op.name == "QCGET") == 2
+
+
+def test_badge_count_nested_pairs_exhausts_registers(compile_gq):
+    # Two badge_count()-pair sub-expressions, each needing its own
+    # transient 4-register peak while being (re)built under the *outer*
+    # expression's shared pool, with the first pair's own accumulator
+    # still live when the second pair starts -- 1 (first pair's surviving
+    # accumulator) + up to 4 (second pair's own transient peak) exceeds
+    # gqc's 4-register file. A clean diagnostic, not a crash or (worse) a
+    # silent wrong answer -- same shape/precedent as
+    # test_register_allocation_depth_5_exhausts_registers in
+    # test_codegen.py.
+    source = game_with_stage(
+        "x = (badge_count() + badge_count()) + (badge_count() + badge_count());",
+        "volatile { int x = 0; }",
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+    assert_no_traceback(stderr)
+    assert "No free registers available" in stderr
+
+
+# --- realistic usage ----------------------------------------------------------
+
+
+def test_badge_count_threshold_unlock_idiom_compiles(compile_gq):
+    # The realistic idiom from the gamequeer#387 issue: gate content behind
+    # a minimum number of distinct badges seen.
+    source = game_with_stage(
+        "if (badge_count() >= 5) { unlocked = 1; badge_set 63; }",
+        "volatile { int unlocked = 0; }",
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    assert sum(1 for op in ops if op.name == "QCGET") == 1
+    ge = next(op for op in ops if op.name == "GE")
+    assert ge.flags & structs.OpFlags.LITERAL_ARG2
+    assert ge.arg2 == 5
+    assert "QCSET" in [op.name for op in ops]

--- a/gqc/tests/test_constant_folding.py
+++ b/gqc/tests/test_constant_folding.py
@@ -24,7 +24,8 @@ Folding policy, pinned here:
     folding it would turn a runtime behavior into either a compile-time
     crash or a silently wrong constant);
   - `badge_get` never folds, regardless of its operand -- it reads live
-    badge state, not a constant;
+    badge state, not a constant; `badge_count()` (gamequeer#387), which has
+    no operand at all, never folds for the same reason;
   - a result that wouldn't fit `t_gq_int` (signed 32-bit) is left unfolded
     (gqc does not replicate the target compiler's signed-overflow
     behavior), as is a `<<`/`>>` shift amount outside `[0, 31]` or a `<<`
@@ -370,3 +371,26 @@ def test_badge_get_never_folds_even_with_a_literal_operand(compile_gq):
     addby = next(op for op in ops if op.name == "ADDBY")
     assert addby.flags & structs.OpFlags.LITERAL_ARG2
     assert addby.arg2 == 1
+
+
+# --- badge_count() never folds (gamequeer#387) -------------------------------
+
+
+def test_badge_count_never_folds(compile_gq):
+    # badge_count() reads live badge state, not a constant, even though it
+    # (unlike badge_get) has no operand at all to tempt a naive fold check
+    # -- combined with a literal `+ 1` so a bug that treated it as foldable
+    # would visibly collapse the whole expression to a single SETVAR
+    # instead of a real loop + ADDBY.
+    source = game_with_stage("x = badge_count() + 1;", "volatile { int x = 0; }")
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+    cmds = (out_dir / "cmds.gqasm").read_text()
+    ops = one_event(cmds).ops
+    assert any(op.name == "QCGET" for op in ops)
+    addby_ops = [op for op in ops if op.name == "ADDBY"]
+    # One ADDBY inside the popcount loop (acc += bit) and one for the "+ 1"
+    # itself, with the literal on the outer one.
+    assert len(addby_ops) == 2
+    addby_literal = next(op for op in addby_ops if op.flags & structs.OpFlags.LITERAL_ARG2)
+    assert addby_literal.arg2 == 1

--- a/gqc/tests/test_grammar.py
+++ b/gqc/tests/test_grammar.py
@@ -64,6 +64,74 @@ def test_badge_get_standalone_statement_rejects(compile_gq):
     assert "ParseSyntaxException" in stderr
 
 
+# --- badge_count() (gamequeer#387) -------------------------------------------
+# Unlike badge_get, badge_count() is a nullary *call* -- no bare-operand
+# form, and its parens are mandatory (empty) rather than wrapping an
+# argument.
+
+
+def test_badge_count_call_accepts(compile_gq):
+    source = game_with_stage("x = badge_count();", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_badge_count_combined_with_binary_op_accepts(compile_gq):
+    source = game_with_stage("x = badge_count() + 1;", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_badge_count_in_if_condition_accepts(compile_gq):
+    # The realistic threshold-unlock idiom from the gamequeer#387 issue.
+    source = game_with_stage(
+        "if (badge_count() >= 5) { badge_set 42; }", "volatile { int x = 0; }"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_badge_count_with_argument_rejects(compile_gq):
+    # badge_count() is nullary -- Keyword("badge_count") commits (via the
+    # grammar's `-`) as soon as "badge_count" itself matches, so a spurious
+    # argument fails with a clean, source-located ParseSyntaxException
+    # rather than silently being ignored or falling through to some other
+    # (wrong) grammar interpretation.
+    source = game_with_stage("x = badge_count(5);", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+    assert "ParseSyntaxException" in stderr
+
+
+def test_badge_count_standalone_statement_rejects(compile_gq):
+    # Like badge_get, badge_count() only appears inside an int_expression --
+    # it's not a statement on its own.
+    source = game_with_stage("badge_count();")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+
+
+def test_badge_count_prefixed_identifier_in_expression_accepts(compile_gq):
+    # "badge_count" is matched via Keyword(), so it doesn't swallow a
+    # badge_count-*prefixed* identifier -- same reasoning as
+    # test_badge_get_prefixed_identifier_in_expression_accepts above
+    # (gamequeer#354).
+    source = game_with_stage(
+        "y = badge_counter + 1;",
+        "volatile { int badge_counter = 0; int y = 0; }",
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_badge_count_bare_no_parens_rejects(compile_gq):
+    # Unlike badge_get, badge_count has no bare-operand form -- the parens
+    # (even though empty) are mandatory.
+    source = game_with_stage("x = badge_count;", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+
+
 # --- str() cast: whole-RHS and inline (gamequeer#386) ------------------------
 
 


### PR DESCRIPTION
## Summary

Closes #387. Adds `badge_count()` -- a nullary popcount intrinsic over the 320-bit badges-seen bitfield -- as gqc sugar for the hand-rolled `loop { ... badge_get(i) ... }` idiom.

**Strategy: runtime loop, not unrolled** (per the issue's own wording, "the hand-rolled loop-over-badge_get(i) bytecode"). Lowers to a `while (idx) { idx -= 1; bit = badge_get(idx); acc += bit; }` shape built entirely from *existing* bytecode (`SETVAR`/`SUBBY`/`QCGET`/`ADDBY`/`GOTOIFN`/`GOTO`) -- the same `CommandLoop`/`CommandIf`/`CommandGoto`/`CommandArithmetic` machinery a hand-written `.gq` `loop { }` statement already uses. **FROZEN VM CONTRACT respected: no new opcodes, no new registers, no cart-format changes** -- the C VM (`gamequeer/`) is untouched.

### Cost accounting: loop vs. unrolled

| | Loop (this PR) | Unrolled (rejected) |
|---|---|---|
| Bytecode size | **9 ops fixed** (`GQ_OP_SIZE`=10B → 90B), independent of `BADGES_ALLOWED` | 320 × (QCGET+ADDBY) = 640 ops → 6400B, *scales with* `BADGES_ALLOWED` |
| Runtime ops/call | ~1924 (320 × 6-op iteration + 1 exit check + 2 init) | ~642 (320 × 2, no per-iteration branch overhead) |
| Registers held | 3 of 4 (`GQ_REGISTERS_INT`) for the loop's duration; 1 survives as the result | 0 extra (each QCGET/ADDBY pair references its own literal index, no register) |

The loop is ~3x *heavier at runtime* than an unrolled sequence would be (no way around that within the frozen contract -- every iteration re-pays `GOTOIFN`+`GOTO`×2 overhead an unrolled sequence wouldn't), but the unrolled form is **~70x more bytecode per call site**, scales with `BADGES_ALLOWED`, and the issue explicitly specifies the loop form. Given `badge_count()` is meant to replace a single hand-rolled `loop{}` a game author would otherwise write per call site (not be called every frame), bytecode-size-per-call-site was weighted over runtime ops here.

### Perf note (added to `docs/authoring-and-perf-carts.md`)

Explicitly flagged as heavy for a 20 FPS event-driven badge: cache the result in a variable on stage `enter` rather than re-evaluating per-tick/per-event. Also documents the register cost below.

### Register/temporary cost

Peak 3 of gqc's 4 `GQ_REGISTERS_INT` (accumulator, loop counter, per-iteration `badge_get` result) held for the loop's duration; only the accumulator survives as the returned result. Verified empirically:
- A **left-associative chain** of `badge_count()` calls (`bc()+bc()+bc()+bc()`) never exceeds the 4-register budget at *any* length -- each call's own scratch (idx/bit) frees immediately, leaving only the running accumulator (1) live against the next call's own peak (3).
- **Two independently pre-built** `badge_count()` sub-expressions (e.g. explicit parens, or nested balanced pairs) *can* exhaust the register file -- a clean `No free registers available` diagnostic, not a crash or wrong answer. Pinned in `tests/test_badge_count.py`.

### A real bug this uncovered (and fixed)

gqc has a pre-existing "discard a pre-built sub-expression (parenthesized operand, or one prefix of a long same-precedence chain) and re-derive it from raw tokens under the *outer* expression's own register pool" mechanism -- the only safe way to combine two independently-register-allocated command sequences (a naive splice-in-the-result-register isn't safe in general: two sibling pre-built sub-expressions can pick the same register name for their own internal work in isolation).

This was harmless for every leaf/operator that existed before this feature -- their `resolve()` only ever depends on a `Variable`/`Stage` symbol-table lookup, which still succeeds even for an orphaned, never-attached copy. `badge_count()` is the first feature to put a `CommandLoop`/break-or-continue-form `CommandGoto` inside int-expression codegen, and `CommandGoto.resolve()` doesn't work that way -- it just checks whether *some* owning `CommandLoop.set_addr()` tree-walk ever patched its real jump target in, which only happens for commands actually attached to the final tree. An orphaned copy's GOTOs stayed permanently unpatched, and `linker.py`'s final "is everything resolved?" sweep treated that as a fatal `Unresolved symbols remain in command GOTO 0x00000000` error for otherwise-completely-valid programs like `x = (badge_count()) + 1;` or `x = badge_count() + y + z;`.

Fixed with `commands.unregister_orphaned_commands()`, called at the one discard site (`IntExpression.get_result_symbol`) to remove a discarded sub-expression's commands from the global sweep-checked list before rebuilding. Regression-pinned in `tests/test_badge_count.py` (parenthesized operand, leftmost/middle position in a 3-term chain, sibling parenthesized operands).

### No-fold pin (gamequeer#385 interaction)

`badge_count()` reads live state, so it must never constant-fold -- `fold_constant_int_expression` now explicitly declines it (was already implicitly declined via a length check, made explicit), pinned in `test_constant_folding.py`.

## Golden state

Byte-identical -- `make golden-fixture` in the builder container produces zero diff against committed goldens. No fixture added (this feature doesn't touch any existing golden `.gq` source).

## Tests

- `tests/test_grammar.py`: accept (bare call, combined w/ binary op, in `if` condition), reject (with an argument -- clean `ParseSyntaxException`; bare no-parens; standalone statement), keyword-boundary (`badge_counter` identifier untouched).
- `tests/test_constant_folding.py`: no-fold pin.
- `tests/test_badge_count.py` (new): op-stream shape pin (exact 9-op sequence + jump-target algebra), fixed-bytecode-size-vs-`BADGES_ALLOWED` pin, register-pressure (long chain fits, nested pairs exhausts cleanly), re-entrancy (two calls in one expression), the three discard/rebuild regression cases above, and the realistic `if (badge_count() >= 5) { ... }` threshold-unlock idiom from the issue.
- **Local**: `pytest tests` → 273 passed, 2 skipped (ffmpeg-gated, same as baseline).
- **Builder container** (authoritative): `pytest tests` → 275 passed (ffmpeg present there). `make golden-fixture` → zero diff.
- **Headless C VM ctest** (`make test-headless`, control-flow codegen touched): 28/28 passed.
- **Behavioral, on the real headless emulator** (beyond golden/unit coverage -- adversarial self-review per the review protocol): three scratch carts driving `badge_set`+`badge_count()`+`if`+`cue`, checked via `--dump-leds`:
  - 5 badges set, `>= 5` → lime (true branch) ✓
  - 4 badges set, `>= 5` → red (false branch) ✓
  - badges **0 and 319** (the two ends of the 320-bit range) set, `== 2` → lime -- confirms no off-by-one drops either boundary index and no double-count ✓

(AI-generated via Claude Code w/ Fable 5)