### PR TITLE
feat(gqc): fw_version() intrinsic + GQI_FW_VERSION reserved int

### DIFF
--- a/gqc/docs/authoring-and-perf-carts.md
+++ b/gqc/docs/authoring-and-perf-carts.md
@@ -193,9 +193,13 @@ gamequeer#410, for the full mechanism and tick-margin derivation.
 happened to place next, since that firmware has no bounds check for a
 reserved-int offset it's never heard of. `gqc` refuses to compile a write to
 it (`Cannot assign to read-only variable GQI_FW_VERSION`). Read it only
-through `fw_version()`, not directly: a direct read before the probe has
-run — including on original firmware, which never populates it at all —
-returns that same undefined value, not `0`.
+through `fw_version()`, not directly: on original 2024 firmware — which
+never populates `GQI_FW_VERSION` at all — a direct read returns unspecified
+adjacent RAM, not `0`. Firmware that defines it populates it unconditionally
+at cart boot, so a direct read is well-defined there regardless of probe
+state — but a cart has no way to know which firmware it's on without
+running the probe, which is exactly the problem `fw_version()` exists to
+solve.
 
 ## 2. Labels (on-screen text)
 

--- a/gqc/docs/authoring-and-perf-carts.md
+++ b/gqc/docs/authoring-and-perf-carts.md
@@ -153,6 +153,50 @@ if (state <= 0) {
 // roll: r = state % N; for a 0..N-1 result
 ```
 
+### Firmware detection: `fw_version()`
+
+`fw_version()` (nullary, parens mandatory, like `badge_count()`) returns an
+int: `0` on the original 2024 fleet firmware, otherwise the value of the
+`GQI_FW_VERSION` reserved builtin int on firmware that defines it. Use it to
+gate content on a firmware capability instead of assuming every badge in the
+field is running the same build:
+
+```
+if (fw_version() == 0) {
+    // original 2024 firmware: don't rely on feature X
+} else {
+    // firmware that defines GQI_FW_VERSION: feature X is available
+}
+```
+
+Calling `fw_version()` anywhere in a game makes `gqc` splice a hidden probe
+stage in ahead of the game's declared `starting_stage` — the compiled cart's
+actual entry point becomes the probe, which falls through to the declared
+starting stage as soon as it's done. This is fully automatic: nothing to
+declare, no extra stage to author, no reference to the probe anywhere in
+source. A game that never calls `fw_version()` gets none of this: no probe
+stage, no extra boot delay, no probe animation asset.
+
+**The probe costs up to ~1s (21 ticks) of boot delay, but only on original
+2024 firmware, and only for a game that calls `fw_version()` at all.** On any
+firmware that clamps background-animation frames to 5 ticks (the 20 FPS
+line and later), the probe resolves in ~5 ticks (about 50ms) instead. It
+works by racing a 1-frame background animation against a 13-tick timer, both
+armed the instant the probe stage is entered, and — like the global-timer
+monopolization the Randomness recipe above calls out — the probe is the only
+thing running a timer while it's armed. See
+`linker.inject_fw_version_probe`'s docstring (`gqc/src/gqc/linker.py`), and
+gamequeer#410, for the full mechanism and tick-margin derivation.
+
+**Never write `GQI_FW_VERSION` from cart code.** It's undefined on original
+2024 firmware — writing it there corrupts whatever adjacent RAM the linker
+happened to place next, since that firmware has no bounds check for a
+reserved-int offset it's never heard of. `gqc` refuses to compile a write to
+it (`Cannot assign to read-only variable GQI_FW_VERSION`). Read it only
+through `fw_version()`, not directly: a direct read before the probe has
+run — including on original firmware, which never populates it at all —
+returns that same undefined value, not `0`.
+
 ## 2. Labels (on-screen text)
 
 Four label slots (`GQI_LABEL{1..4}_X/Y` position, `GQS_LABEL{1..4}` text,

--- a/gqc/src/gqc/commands.py
+++ b/gqc/src/gqc/commands.py
@@ -194,11 +194,13 @@ class CommandArithmetic(Command):
         if self.dst_name in Variable.var_table and Variable.var_table[self.dst_name].addr != 0x00000000:
             if Variable.var_table[self.dst_name].datatype != 'int':
                 raise GqcParseError(f"Variable {self.dst_name} is not an int", self.instring, self.loc)
+            if not Variable.var_table[self.dst_name].writable:
+                raise GqcParseError(f"Cannot assign to read-only variable {self.dst_name}", self.instring, self.loc)
             self.arg1 = Variable.var_table[self.dst_name].addr
         else:
             self.unresolved_symbols.append(self.dst_name)
             resolved = False
-        
+
         if self.src.is_literal:
             self.arg2 = self.src.value
             self.command_flags |= structs.OpFlags.LITERAL_ARG2
@@ -349,6 +351,8 @@ class CommandSetInt(CommandWithIntExpressionArgument):
         if self.dst_name in Variable.var_table and Variable.var_table[self.dst_name].addr != 0x00000000:
             if Variable.var_table[self.dst_name].datatype != 'int':
                 raise GqcParseError(f"Cannot assign int expression to non-int {self.dst_name}", self.instring, self.loc)
+            if not Variable.var_table[self.dst_name].writable:
+                raise GqcParseError(f"Cannot assign to read-only variable {self.dst_name}", self.instring, self.loc)
             self.arg1 = Variable.var_table[self.dst_name].addr
         else:
             self.unresolved_symbols.append(self.dst_name)

--- a/gqc/src/gqc/datamodel.py
+++ b/gqc/src/gqc/datamodel.py
@@ -61,6 +61,13 @@ class Game:
 
         self.persistent_crc16_ptr = None
 
+        # Set by parser.parse_fw_version_operand the first time a game
+        # calls fw_version() (gamequeer#411). linker.inject_fw_version_probe
+        # only synthesizes the probe stage -- and its firmware pays for the
+        # probe's BGDONE/TIMER race -- when this is True, so a game that
+        # never calls fw_version() has zero footprint from this feature.
+        self.needs_fw_probe = False
+
         if Game.game is not None:
             raise ValueError("Game already defined")
         Game.game = self
@@ -305,6 +312,12 @@ class Variable:
         self.name = name
         self.value = value
         self.storageclass = None
+        # Read-only by cart convention (gamequeer#411, e.g. GQI_FW_VERSION):
+        # writing an as-yet-undefined reserved int corrupts adjacent RAM on
+        # firmware that predates it. Only linker.create_reserved_variables()
+        # ever sets this False; every other Variable stays writable. See
+        # commands.CommandSetInt/CommandArithmetic.resolve() for enforcement.
+        self.writable = True
 
         if name in Variable.var_table:
             existing_storageclass = Variable.var_table[name].storageclass

--- a/gqc/src/gqc/gqc.py
+++ b/gqc/src/gqc/gqc.py
@@ -61,6 +61,13 @@ def compile(input : pathlib.Path, no_mem_map : bool, out_dir : pathlib.Path):
     with open(input, 'r') as f:
         parsed = parser.parse(f)
 
+    # If the game calls fw_version() anywhere (gamequeer#411), splice the
+    # compiler-synthesized firmware-detection probe stage in ahead of its
+    # declared starting stage. Games that never call fw_version() skip this
+    # entirely -- no probe stage, no extra boot delay.
+    if Game.game.needs_fw_probe:
+        linker.inject_fw_version_probe()
+
     # Place symbols into the symbol table
     mem_map_path = out_dir / 'map.txt'
     cmd_asm_path = out_dir / 'cmds.gqasm'

--- a/gqc/src/gqc/grammar.py
+++ b/gqc/src/gqc/grammar.py
@@ -7,6 +7,7 @@ from .parser import parse_menu_definition, parse_bound_menu, parse_play
 from .parser import parse_int_expression, parse_int_operand, parse_str_literal, parse_if
 from .parser import parse_str_expression, parse_string_cast_operand
 from .parser import parse_badge_count_operand
+from .parser import parse_fw_version_operand
 
 """
 Grammar for GQC language
@@ -187,7 +188,13 @@ def build_game_parser():
     badge_count_call = pp.Group(pp.Keyword("badge_count") - pp.Suppress("(") - pp.Suppress(")")).set_name("badge_count_call")
     badge_count_call.set_parse_action(parse_badge_count_operand)
 
-    int_operand = badge_count_call | identifier | integer
+    # fw_version() -- a nullary firmware-detection intrinsic (gamequeer#411).
+    # Same Keyword-not-bare-string reasoning as badge_count_call above, so a
+    # `fw_version`-prefixed identifier isn't swallowed.
+    fw_version_call = pp.Group(pp.Keyword("fw_version") - pp.Suppress("(") - pp.Suppress(")")).set_name("fw_version_call")
+    fw_version_call.set_parse_action(parse_fw_version_operand)
+
+    int_operand = badge_count_call | fw_version_call | identifier | integer
     int_operand.set_parse_action(parse_int_operand)
     int_expression = pp.infix_notation(int_operand, [
         (pp.Keyword('badge_get') | pp.one_of('! - ~'), 1, pp.opAssoc.RIGHT),

--- a/gqc/src/gqc/linker.py
+++ b/gqc/src/gqc/linker.py
@@ -1,11 +1,15 @@
+import os
+import pathlib
 import sys
+import tempfile
 
+from PIL import Image
 from tabulate import tabulate
 from rich.progress import Progress, TextColumn, BarColumn, TaskProgressColumn, TimeElapsedColumn
 
 from .datamodel import Game, Stage, Variable, Animation, Frame, FrameData, Event, Menu
-from .datamodel import LightCue, LightCueFrame
-from .commands import Command, CommandDone
+from .datamodel import LightCue, LightCueFrame, GqcIntOperand
+from .commands import Command, CommandDone, CommandGoStage, CommandSetInt, CommandTimer
 
 from . import structs
 
@@ -14,21 +18,125 @@ def create_reserved_variables():
     for gq_var in structs.GQ_RESERVED_INTS:
         var = Variable('int', gq_var.name, gq_var.description, 'builtin_int')
         var.set_addr(gq_var.addr, namespace=structs.GQ_PTR_BUILTIN_INT)
-    
+        var.writable = gq_var.writable
+
     for gq_var in structs.GQ_RESERVED_STRS:
         var = Variable('str', gq_var.name, gq_var.description, 'builtin_str')
         var.set_addr(gq_var.addr, namespace=structs.GQ_PTR_BUILTIN_STR)
-    
+
     for gq_var in structs.GQ_RESERVED_PERSISTENT:
         var = Variable(gq_var.type, gq_var.name, gq_var.description, 'persistent')
 
     # Create the reserved integer registers for the game:
     for reg_name in structs.GQ_REGISTERS_INT:
         var = Variable('int', reg_name, 0, 'volatile')
-    
+
     # Create the reserved string registers for the game:
     for reg_name in structs.GQ_REGISTERS_STR:
         var = Variable('str', reg_name, '', 'volatile')
+
+def _make_fw_probe_frame_source() -> pathlib.Path:
+    # inject_fw_version_probe's bganim needs *a* frame to exist and load --
+    # its content is never meaningful (it's not actually rendered for more
+    # than a tick or two before the probe stage transitions away), so this
+    # synthesizes a throwaway solid-black still image into a temp file
+    # instead of shipping a package/author asset: no assets/animations/
+    # authoring surface, no packaging footprint, nothing for a project's
+    # asset digest cache to ever go stale against. Animation()'s `source`
+    # resolves relative to the CWD (pathlib.Path() / 'assets' / 'animations'
+    # / source) *unless* source is itself absolute, in which case the join
+    # returns the absolute path unchanged -- so passing this temp file's
+    # absolute path in bypasses that CWD-relative convention entirely.
+    fd, path = tempfile.mkstemp(prefix='gqc_fw_probe_', suffix='.png')
+    os.close(fd)
+    Image.new('1', (structs.GQ_FW_PROBE_FRAME_SIZE, structs.GQ_FW_PROBE_FRAME_SIZE), 0).save(path)
+    return pathlib.Path(path)
+
+def inject_fw_version_probe():
+    """Splice a compiler-synthesized firmware-detection probe stage in
+    ahead of the game's declared starting stage, backing the fw_version()
+    intrinsic (gamequeer#411). Only called (from gqc.py, after parsing) when
+    Game.game.needs_fw_probe is True, i.e. the game actually calls
+    fw_version() somewhere -- a game that never does pays nothing for this:
+    no extra stage, no extra boot delay, no probe animation asset.
+
+    Design choice over an author-designated probe window (the alternative
+    the issue raises): this is fully transparent to game authors -- no new
+    authoring surface, no stage they have to remember to add -- at the cost
+    of an unconditional ~1s (21-tick) delay before the game's *own* first
+    stage appears, but *only* on original 2024 firmware, and *only* for
+    carts that call fw_version() at all. Carts that don't call it are
+    unaffected; carts running on post-original firmware resolve the probe
+    in ~5 ticks (~50ms), not ~1s. That trade was judged worth it for a
+    detection primitive whose entire point is to be effortless to reach for
+    at the top of a game rather than something authors have to choreograph
+    around their own splash/intro stage.
+
+    Lowers entirely to *existing* bytecode (frozen VM contract -- see
+    gamequeer#410 for the full derivation): a 1-frame background animation
+    clamped to GQ_FW_PROBE_TICKS_PER_FRAME (5) ticks/frame races a
+    GQ_FW_PROBE_TIMER_TICKS (13)-tick timer, both started on stage entry.
+    Firmware that clamps bganim frames to 5 ticks (the 20 FPS line,
+    gamequeer#312 on) fires BGDONE first (~5th tick); original firmware,
+    which clamps to 20 ticks, fires TIMER first (13th tick) -- an 8-tick
+    margin either way. Both the timer and the probe stage are fully
+    consumed by the race itself: nothing else may run a competing timer
+    while the probe is armed, which is guaranteed here because this stage
+    is the very first thing the cart does.
+
+    On BGDONE (post-original firmware): GQI_FW_VERSION is only ever *read*
+    here, once the probe has established the firmware actually defines it
+    -- reading it on original firmware, where it's undefined, returns
+    unspecified adjacent RAM, not 0 (gamequeer#410) -- and it is never
+    written by gqc-generated code (see `writable=False` on its
+    GqReservedVariable entry in structs.py, enforced in
+    commands.CommandSetInt/CommandArithmetic).
+
+    On TIMER (original firmware): the hidden result variable is left at its
+    zero-initialized value, giving fw_version() its documented "0 =
+    original firmware" result.
+    """
+    original_starting_stage_name = Game.game.starting_stage_name
+
+    Variable('int', structs.GQ_FW_PROBE_RESULT_VAR, 0, storageclass='volatile')
+
+    probe_frame_source = _make_fw_probe_frame_source()
+    try:
+        Animation(
+            structs.GQ_FW_PROBE_ANIM_NAME,
+            str(probe_frame_source),
+            dithering='none',
+            duration=structs.GQ_FW_PROBE_TICKS_PER_FRAME,
+            w=structs.GQ_FW_PROBE_FRAME_SIZE,
+            h=structs.GQ_FW_PROBE_FRAME_SIZE,
+        )
+    finally:
+        probe_frame_source.unlink(missing_ok=True)
+
+    enter_event = Event(structs.EventType.ENTER, [
+        CommandTimer(None, None, GqcIntOperand(True, structs.GQ_FW_PROBE_TIMER_TICKS)),
+    ])
+    bgdone_event = Event(structs.EventType.BGDONE, [
+        CommandSetInt(None, None, structs.GQ_FW_PROBE_RESULT_VAR, GqcIntOperand(False, 'GQI_FW_VERSION')),
+        CommandGoStage(None, None, original_starting_stage_name),
+    ])
+    timer_event = Event(structs.EventType.TIMER, [
+        CommandSetInt(None, None, structs.GQ_FW_PROBE_RESULT_VAR, GqcIntOperand(True, 0)),
+        CommandGoStage(None, None, original_starting_stage_name),
+    ])
+
+    probe_stage = Stage(
+        structs.GQ_FW_PROBE_STAGE_NAME,
+        bganim=structs.GQ_FW_PROBE_ANIM_NAME,
+        events=[enter_event, bgdone_event, timer_event],
+    )
+
+    # Stage.__init__ -> Game.add_stage only sets Game.game.starting_stage
+    # when a stage's own name matches starting_stage_name, which the probe
+    # stage's compiler-internal name deliberately never does -- so it has to
+    # be spliced in as the actual entry point explicitly, here.
+    Game.game.starting_stage_name = probe_stage.name
+    Game.game.starting_stage = probe_stage
 
 def create_symbol_table(table_dest = sys.stdout, cmd_dest = sys.stdout):
     # Output order (.game .anim .stage .frame .framedata .cues .cuedata

--- a/gqc/src/gqc/linker.py
+++ b/gqc/src/gqc/linker.py
@@ -37,19 +37,25 @@ def create_reserved_variables():
 
 def _make_fw_probe_frame_source() -> pathlib.Path:
     # inject_fw_version_probe's bganim needs *a* frame to exist and load --
-    # its content is never meaningful (it's not actually rendered for more
-    # than a tick or two before the probe stage transitions away), so this
-    # synthesizes a throwaway solid-black still image into a temp file
-    # instead of shipping a package/author asset: no assets/animations/
-    # authoring surface, no packaging footprint, nothing for a project's
-    # asset digest cache to ever go stale against. Animation()'s `source`
-    # resolves relative to the CWD (pathlib.Path() / 'assets' / 'animations'
-    # / source) *unless* source is itself absolute, in which case the join
-    # returns the absolute path unchanged -- so passing this temp file's
-    # absolute path in bypasses that CWD-relative convention entirely.
+    # its content is never meaningful (it's on screen for up to ~21 ticks
+    # (~1s) on original firmware, which doesn't resolve the probe's race
+    # until its own 20-tick frame-duration clamp fires; only ~5-6 ticks on
+    # firmware that clamps to 5), so this synthesizes a throwaway
+    # solid-black still image into a temp file instead of shipping a
+    # package/author asset: no assets/animations/ authoring surface, no
+    # packaging footprint, nothing for a project's asset digest cache to
+    # ever go stale against. Animation()'s `source` resolves relative to
+    # the CWD (pathlib.Path() / 'assets' / 'animations' / source) *unless*
+    # source is itself absolute, in which case the join returns the
+    # absolute path unchanged -- so passing this temp file's absolute path
+    # in bypasses that CWD-relative convention entirely.
     fd, path = tempfile.mkstemp(prefix='gqc_fw_probe_', suffix='.png')
     os.close(fd)
-    Image.new('1', (structs.GQ_FW_PROBE_FRAME_SIZE, structs.GQ_FW_PROBE_FRAME_SIZE), 0).save(path)
+    try:
+        Image.new('1', (structs.GQ_FW_PROBE_FRAME_SIZE, structs.GQ_FW_PROBE_FRAME_SIZE), 0).save(path)
+    except Exception:
+        os.unlink(path)
+        raise
     return pathlib.Path(path)
 
 def inject_fw_version_probe():

--- a/gqc/src/gqc/parser.py
+++ b/gqc/src/gqc/parser.py
@@ -227,6 +227,20 @@ def parse_badge_count_operand(instring, loc, toks):
     # IntExpression.get_result_symbol to recognize, not a value container.
     return GqcBadgeCountOperand()
 
+def parse_fw_version_operand(instring, loc, toks):
+    # fw_version() (gamequeer#411) carries no data of its own: unlike
+    # badge_count() (which builds a real runtime loop at every call site),
+    # it's pure sugar for a reference to the hidden volatile int that the
+    # compiler-injected probe stage (see linker.inject_fw_version_probe)
+    # writes its result into -- exactly what parse_int_operand would already
+    # build for a bare identifier reference to that variable. Setting
+    # needs_fw_probe here is what tells gqc.py to actually call
+    # inject_fw_version_probe after parsing: a game that never calls
+    # fw_version() gets no probe stage, and pays none of its ~1s cost on
+    # original firmware.
+    Game.game.needs_fw_probe = True
+    return GqcIntOperand(False, structs.GQ_FW_PROBE_RESULT_VAR)
+
 def parse_int_operand(instring, loc, toks):
     if isinstance(toks[0], (GqcIntOperand, GqcBadgeCountOperand)):
         return toks[0]

--- a/gqc/src/gqc/structs.py
+++ b/gqc/src/gqc/structs.py
@@ -248,7 +248,11 @@ GqStage = namedtuple('GqStage', 'id anim_bg_pointer cue_bg_pointer menu_pointer 
 GQ_STAGE_FORMAT = f'<H{T_GQ_POINTER_FORMAT}{T_GQ_POINTER_FORMAT}{T_GQ_POINTER_FORMAT}{T_GQ_POINTER_FORMAT}{len(EventType)}{T_GQ_POINTER_FORMAT}'
 GQ_STAGE_SIZE = struct.calcsize(GQ_STAGE_FORMAT)
 
-GqReservedVariable = namedtuple('GqReservedVariable', 'name type description addr')
+# `writable` defaults to True (via the namedtuple field default below) for
+# every existing entry, so none of them need to be touched to pick it up.
+# GQI_FW_VERSION (gamequeer#411) is the first read-only one: see its own
+# comment for why.
+GqReservedVariable = namedtuple('GqReservedVariable', 'name type description addr writable', defaults=(True,))
 
 GQ_RESERVED_INTS = [
     GqReservedVariable('GQI_GAME_ID', 'int', 'ID of the game', 0x000000),
@@ -275,6 +279,17 @@ GQ_RESERVED_INTS = [
     GqReservedVariable('GQI_LABEL4_Y', 'int', 'Label 4 Y', 0x000054),
     GqReservedVariable('GQI_LABEL_FLAGS', 'int', 'Label flags', 0x000058),
     GqReservedVariable('GQI_PLAYER_ID', 'int', 'Player ID', 0x00005C),
+    # gamequeer#411: compile-time only from gqc's perspective (it just emits
+    # this address) -- firmware carrying the GQI_FW_VERSION init (>= the
+    # version-word release cut for the QC2026 field-update campaign)
+    # populates it at cart boot with a nonzero version value; the original
+    # 2024 fleet firmware never heard of this offset and does not initialize
+    # it. A read of it is therefore only meaningful *after* establishing
+    # (via the gamequeer#410 behavioral probe -- see linker.py's
+    # inject_fw_version_probe) that the running firmware is post-original;
+    # gqc never emits a write to it (see `writable=False` below and its
+    # enforcement in commands.CommandSetInt/CommandArithmetic).
+    GqReservedVariable('GQI_FW_VERSION', 'int', 'Firmware version (0/undefined on original 2024 firmware)', 0x000060, False),
 ]
 
 GQ_RESERVED_STRS = [
@@ -291,6 +306,29 @@ GQ_RESERVED_PERSISTENT = []
 
 for i in range(math.ceil(BADGES_ALLOWED / (8 * GQ_INT_SIZE))):
     GQ_RESERVED_PERSISTENT.append(GqReservedVariable(f'GQ_PERSISTENT_BADGES_{i}.builtin', 'int', 0, 0x000000 + 8 * i * GQ_INT_SIZE))
+
+# fw_version() intrinsic (gamequeer#411): compiler-injected probe stage
+# naming/timing. See linker.py's inject_fw_version_probe for the full
+# derivation; this is just the shared vocabulary between it and
+# parser.parse_fw_version_operand. The dotted names can't collide with any
+# author identifier (identifiers are pp.Word(alphas, alphanums + "_") --
+# see grammar.py -- so a literal "." never appears in one), the same
+# convention used for GQ_REGISTERS_INT/STR and Variable.get_str_literal's
+# "S{n}.strlit" names below.
+GQ_FW_PROBE_RESULT_VAR = '__gq_fw_probe_result.reg'
+GQ_FW_PROBE_STAGE_NAME = '__gq_fw_probe.stage'
+GQ_FW_PROBE_ANIM_NAME = '__gq_fw_probe.anim'
+# 1 frame, clamped by whichever firmware's own minimum-frame-duration floor
+# is in effect (5 ticks post-original, 20 ticks on original firmware) --
+# see gamequeer#410's tick-margin derivation for why 13 sits cleanly between
+# the two.
+GQ_FW_PROBE_TICKS_PER_FRAME = 5
+GQ_FW_PROBE_TIMER_TICKS = 13
+# The probe frame is a single solid-black still (see
+# linker._make_fw_probe_frame_source); its content is irrelevant, so this
+# is sized just large enough to keep the RLE-encoded frame data trivially
+# small.
+GQ_FW_PROBE_FRAME_SIZE = 8
 
 GQ_REGISTERS_INT = [
     'GQ_RI0.reg', 'GQ_RI1.reg', 'GQ_RI2.reg', 'GQ_RI3.reg',

--- a/gqc/tests/test_constant_folding.py
+++ b/gqc/tests/test_constant_folding.py
@@ -36,7 +36,7 @@ import pytest
 
 from gqc import structs
 
-from .opstream import one_event
+from .opstream import one_event, parse_gqasm
 
 GAME_HEADER = 'game { id = 1; title := "T"; author := "A"; starting_stage = start; }\n'
 
@@ -394,3 +394,31 @@ def test_badge_count_never_folds(compile_gq):
     assert len(addby_ops) == 2
     addby_literal = next(op for op in addby_ops if op.flags & structs.OpFlags.LITERAL_ARG2)
     assert addby_literal.arg2 == 1
+
+
+# --- fw_version() never folds (gamequeer#411) ---------------------------------
+
+
+def test_fw_version_never_folds(compile_gq):
+    # fw_version() is sugar for a reference to a hidden runtime-populated
+    # variable (see linker.inject_fw_version_probe), not a literal -- so
+    # "fw_version() + 1" must load it into a register and ADDBY the literal
+    # 1, not collapse to a single literal SETVAR the way "1 + 1" would.
+    source = game_with_stage("x = fw_version() + 1;", "volatile { int x = 0; }")
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+    cmds = (out_dir / "cmds.gqasm").read_text()
+    # opstream.one_event's default ENTER lookup is ambiguous here: the
+    # compiler-injected probe stage (linker.inject_fw_version_probe) has its
+    # own ENTER event. The author's own `start` stage is always the first
+    # ENTER block -- its Stage is registered before the probe stage's (see
+    # inject_fw_version_probe's docstring).
+    ops = next(b for b in parse_gqasm(cmds) if b.event_type == "ENTER").ops
+    addby = next(op for op in ops if op.name == "ADDBY")
+    assert addby.flags & structs.OpFlags.LITERAL_ARG2
+    assert addby.arg2 == 1
+    # The dst register was loaded from a variable (a SETVAR with a
+    # non-literal source), not initialized with a literal -- i.e. gqc really
+    # read fw_version()'s backing variable at runtime instead of folding it.
+    load = next(op for op in ops if op.name == "SETVAR" and op.arg1 == addby.arg1)
+    assert not (load.flags & structs.OpFlags.LITERAL_ARG2)

--- a/gqc/tests/test_fw_version.py
+++ b/gqc/tests/test_fw_version.py
@@ -1,0 +1,286 @@
+"""`fw_version()` intrinsic suite for gqc (gamequeer#411, successor to
+gamequeer#410).
+
+`fw_version()` lets cart code branch on the host firmware's identity: 0 on
+original 2024 fleet firmware, otherwise the value of the new `GQI_FW_VERSION`
+reserved int (populated by firmware that defines it -- see
+`structs.GQ_RESERVED_INTS`). GQI_FW_VERSION is *undefined* on original
+firmware -- gamequeer#410 established that reading it there returns
+unspecified adjacent RAM, not 0, and that *writing* it corrupts RAM -- so
+`fw_version()` can't just be a bare reference to that reserved int. Instead,
+it's sugar for a hidden variable that a compiler-injected probe stage
+populates once, at cart boot, via the gamequeer#410 timer-vs-bganim race (a
+1-frame background animation clamped to 5 ticks/frame vs. a 13-tick timer;
+whichever fires first -- BGDONE or TIMER -- distinguishes post-original
+firmware from original firmware without ever touching GQI_FW_VERSION on
+firmware that might not define it). See `linker.inject_fw_version_probe`'s
+docstring for the full design, including why the probe stage is injected
+unconditionally ahead of the game's *declared* starting stage rather than
+requiring an author-designated probe window, and why that injection only
+happens (Game.needs_fw_probe) for games that actually call fw_version().
+
+test_grammar.py covers accept/reject parsing; test_constant_folding.py pins
+that fw_version() never folds (it's a variable reference, not a literal).
+This module covers what it actually lowers to: the probe stage's shape, its
+zero footprint when unused, and the GQI_FW_VERSION write-protection its
+correctness depends on.
+"""
+
+import struct
+
+from gqc import structs
+
+from .opstream import parse_gqasm
+
+GAME_HEADER = 'game { id = 1; title := "T"; author := "A"; starting_stage = start; }\n'
+
+
+def game_with_stage(body: str, decls: str = "") -> str:
+    """A minimal valid game with a single stage `start` whose `enter` event
+    runs `body`, optionally preceded by top-level declarations (e.g. a
+    `volatile { ... }` block)."""
+    return f"{GAME_HEADER}{decls}\nstage start {{ event enter {{ {body} }} }}\n"
+
+
+def _compile_and_read(compile_gq, source: str, game_name: str = "game"):
+    """Compile `source` via the CLI and return `(gqgame_bytes, cmds_text,
+    map_text)`, asserting a clean (exit 0) compile first."""
+    exit_code, stderr, out_dir = compile_gq(source, game_name=game_name)
+    assert exit_code == 0, stderr
+    gqgame_bytes = (out_dir / f"{game_name}.gqgame").read_bytes()
+    cmds_text = (out_dir / "cmds.gqasm").read_text()
+    map_text = (out_dir / "map.txt").read_text()
+    return gqgame_bytes, cmds_text, map_text
+
+
+def _unpack_header(gqgame_bytes: bytes) -> structs.GqHeader:
+    return structs.GqHeader._make(
+        struct.unpack(structs.GQ_HEADER_FORMAT, gqgame_bytes[: structs.GQ_HEADER_SIZE])
+    )
+
+
+def _author_enter_ops(cmds_text: str) -> list:
+    """The ops of the *first* ENTER event block in a cmds.gqasm listing --
+    the author's own `start` stage. Needed instead of
+    opstream.one_event("ENTER") whenever the game calls fw_version(): the
+    probe stage (linker.inject_fw_version_probe) has its own ENTER event
+    too, and its Stage is always registered after every author-defined
+    stage (see that function's docstring), so the author's own ENTER event
+    is always the first ENTER block."""
+    return next(b for b in parse_gqasm(cmds_text) if b.event_type == "ENTER").ops
+
+
+GQI_FW_VERSION_ADDR = structs.gq_ptr_apply_ns(
+    structs.GQ_PTR_BUILTIN_INT,
+    next(v.addr for v in structs.GQ_RESERVED_INTS if v.name == "GQI_FW_VERSION"),
+)
+
+
+# --- GQI_FW_VERSION reserved word ---------------------------------------------
+
+
+def test_gqi_fw_version_is_next_free_reserved_int_slot():
+    # GQI_PLAYER_ID (the last pre-existing entry) sits at 0x5C; GQI_FW_VERSION
+    # must be the very next 4-byte-aligned slot, matching the C VM's
+    # GQI_COUNT * GQ_INT_SIZE (gamequeer.h) -- this is the exact address the
+    # downstream C-side task (gamequeer.h/gamequeer.c/badge firmware) has to
+    # agree on.
+    player_id = next(v for v in structs.GQ_RESERVED_INTS if v.name == "GQI_PLAYER_ID")
+    fw_version = next(v for v in structs.GQ_RESERVED_INTS if v.name == "GQI_FW_VERSION")
+    assert fw_version.addr == player_id.addr + structs.GQ_INT_SIZE
+    assert fw_version.addr == 0x60
+
+
+def test_gqi_fw_version_is_read_only():
+    fw_version = next(v for v in structs.GQ_RESERVED_INTS if v.name == "GQI_FW_VERSION")
+    assert fw_version.writable is False
+
+
+def test_gqi_fw_version_write_rejects_as_compile_error(compile_gq):
+    source = game_with_stage("GQI_FW_VERSION = 5;")
+    exit_code, stderr, _out_dir = compile_gq(source)
+    assert exit_code != 0
+    assert "Cannot assign to read-only variable GQI_FW_VERSION" in stderr
+
+
+def test_gqi_fw_version_read_is_allowed(compile_gq):
+    # Reading it directly (as opposed to through fw_version()) isn't
+    # forbidden by gqc -- only writes are. Whether it's *meaningful* to read
+    # directly (without the probe having run first) is an authoring concern
+    # documented in authoring-and-perf-carts.md, not something gqc enforces.
+    source = game_with_stage("x = GQI_FW_VERSION;", "volatile { int x = 0; }")
+    exit_code, stderr, _out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+# --- zero footprint when unused -----------------------------------------------
+
+
+def test_fw_version_unused_injects_no_probe_stage(compile_gq):
+    source = game_with_stage("badge_set 1;")
+    _gqgame_bytes, cmds_text, map_text = _compile_and_read(compile_gq, source)
+    assert structs.GQ_FW_PROBE_STAGE_NAME not in map_text
+    assert structs.GQ_FW_PROBE_RESULT_VAR not in map_text
+    assert "EVENT:BGDONE" not in cmds_text
+    assert "EVENT:TIMER" not in cmds_text
+
+
+def test_fw_version_unused_starting_stage_is_the_authors_own(compile_gq):
+    source = game_with_stage("badge_set 1;")
+    gqgame_bytes, _cmds_text, map_text = _compile_and_read(compile_gq, source)
+    header = _unpack_header(gqgame_bytes)
+    stage_start = int(
+        next(line for line in map_text.splitlines() if line.startswith(".stage")).split()[1],
+        16,
+    )
+    assert header.starting_stage_ptr == stage_start
+
+
+# --- probe injection when used ------------------------------------------------
+
+
+def test_fw_version_used_makes_probe_stage_the_entry_point(compile_gq):
+    source = game_with_stage("x = fw_version();", "volatile { int x = 0; }")
+    gqgame_bytes, _cmds_text, map_text = _compile_and_read(compile_gq, source)
+    header = _unpack_header(gqgame_bytes)
+    probe_line = next(
+        line for line in map_text.splitlines() if structs.GQ_FW_PROBE_STAGE_NAME in line
+    )
+    probe_addr = int(probe_line.split()[0], 16)
+    assert header.starting_stage_ptr == probe_addr
+    # The probe is a real cart-namespaced stage pointer, not left as a null
+    # or heap/save pointer.
+    assert structs.gq_ptr_get_ns(header.starting_stage_ptr) == structs.GQ_PTR_NS_CART
+
+
+def test_fw_version_probe_enter_event_arms_a_13_tick_timer(compile_gq):
+    source = game_with_stage("x = fw_version();", "volatile { int x = 0; }")
+    _gqgame_bytes, cmds_text, _map_text = _compile_and_read(compile_gq, source)
+    blocks = parse_gqasm(cmds_text)
+    enter_blocks = [b for b in blocks if b.event_type == "ENTER"]
+    assert len(enter_blocks) == 2  # the author's own start stage, and the probe's
+    probe_enter = enter_blocks[1]
+    timer_op = next(op for op in probe_enter.ops if op.name == "TIMER")
+    assert timer_op.flags & structs.OpFlags.LITERAL_ARG2
+    assert timer_op.arg2 == structs.GQ_FW_PROBE_TIMER_TICKS == 13
+
+
+def test_fw_version_probe_bgdone_reads_gqi_fw_version_into_hidden_var(compile_gq):
+    source = game_with_stage("x = fw_version();", "volatile { int x = 0; }")
+    _gqgame_bytes, cmds_text, _map_text = _compile_and_read(compile_gq, source)
+    blocks = parse_gqasm(cmds_text)
+    bgdone = next(b for b in blocks if b.event_type == "BGDONE")
+    setvar = next(op for op in bgdone.ops if op.name == "SETVAR")
+    # Non-literal: this is a variable-to-variable copy (a read), never a
+    # literal write.
+    assert not (setvar.flags & structs.OpFlags.LITERAL_ARG2)
+    assert setvar.arg2 == GQI_FW_VERSION_ADDR
+    assert any(op.name == "GOSTAGE" for op in bgdone.ops)
+
+
+def test_fw_version_probe_timer_branch_sets_zero(compile_gq):
+    source = game_with_stage("x = fw_version();", "volatile { int x = 0; }")
+    _gqgame_bytes, cmds_text, _map_text = _compile_and_read(compile_gq, source)
+    blocks = parse_gqasm(cmds_text)
+    timer_block = next(b for b in blocks if b.event_type == "TIMER")
+    setvar = next(op for op in timer_block.ops if op.name == "SETVAR")
+    assert setvar.flags & structs.OpFlags.LITERAL_ARG2
+    assert setvar.arg2 == 0
+    assert any(op.name == "GOSTAGE" for op in timer_block.ops)
+
+
+def test_fw_version_probe_both_branches_gostage_to_the_authors_stage(compile_gq):
+    source = game_with_stage("x = fw_version();", "volatile { int x = 0; }")
+    gqgame_bytes, cmds_text, map_text = _compile_and_read(compile_gq, source)
+    del gqgame_bytes
+    author_stage_addr = int(
+        next(
+            line
+            for line in map_text.splitlines()
+            if "Stage(start," in line
+        ).split()[0],
+        16,
+    )
+    blocks = parse_gqasm(cmds_text)
+    bgdone = next(b for b in blocks if b.event_type == "BGDONE")
+    timer_block = next(b for b in blocks if b.event_type == "TIMER")
+    bgdone_gostage = next(op for op in bgdone.ops if op.name == "GOSTAGE")
+    timer_gostage = next(op for op in timer_block.ops if op.name == "GOSTAGE")
+    assert bgdone_gostage.arg1 == author_stage_addr
+    assert timer_gostage.arg1 == author_stage_addr
+
+
+def test_fw_version_reads_the_hidden_result_variable(compile_gq):
+    # fw_version() itself, wherever it's called, is just a read of the
+    # hidden variable the probe populates -- not the probe machinery again.
+    source = game_with_stage("x = fw_version();", "volatile { int x = 0; }")
+    _gqgame_bytes, cmds_text, _map_text = _compile_and_read(compile_gq, source)
+    ops = _author_enter_ops(cmds_text)
+    assert [op.name for op in ops] == ["SETVAR", "DONE"]
+    setvar = ops[0]
+    assert not (setvar.flags & structs.OpFlags.LITERAL_ARG2)
+
+
+def test_fw_version_hidden_result_variable_zero_initialized(compile_gq):
+    # Every volatile variable (the hidden result variable included) gets a
+    # literal-zero SETVAR in the init table (linker.create_symbol_table),
+    # which runs before the probe stage -- the cart's actual entry point --
+    # ever does. Belt-and-suspenders with the probe's own TIMER-branch
+    # explicit zero-set (test_fw_version_probe_timer_branch_sets_zero).
+    source = game_with_stage("x = fw_version();", "volatile { int x = 0; }")
+    gqgame_bytes, _cmds_text, map_text = _compile_and_read(compile_gq, source)
+    del gqgame_bytes
+    result_var_addr = int(
+        next(
+            line for line in map_text.splitlines()
+            if structs.GQ_FW_PROBE_RESULT_VAR in line and "Variable(" in line
+        ).split()[0],
+        16,
+    )
+    init_lines = map_text.split(".init", 1)[1].split(".var", 1)[0]
+    matches = [
+        line for line in init_lines.splitlines()
+        if "SETVAR" in line and f"{result_var_addr:#0{10}x}" in line
+    ]
+    assert len(matches) == 1
+    assert matches[0].rstrip().endswith("0x00000000)")
+
+
+# --- never emits a write to GQI_FW_VERSION ------------------------------------
+
+
+def test_fw_version_never_emits_a_write_to_gqi_fw_version(compile_gq):
+    # The hard requirement (gamequeer#411/gamequeer#410): no op gqc emits
+    # for fw_version() may ever target GQI_FW_VERSION as a *destination* --
+    # writing an undefined reserved int corrupts adjacent RAM on firmware
+    # that predates it. Scan every op in the whole compiled program, not
+    # just the probe's own events, since this has to hold no matter what
+    # else the game does.
+    source = game_with_stage(
+        "x = fw_version(); y = fw_version() + 1; if (fw_version() == 0) { badge_set 1; }",
+        "volatile { int x = 0; int y = 0; }",
+    )
+    _gqgame_bytes, cmds_text, _map_text = _compile_and_read(compile_gq, source)
+    for block in parse_gqasm(cmds_text):
+        for op in block.ops:
+            assert op.arg1 != GQI_FW_VERSION_ADDR, (
+                f"op {op} targets GQI_FW_VERSION ({GQI_FW_VERSION_ADDR:#x}) as a "
+                "destination"
+            )
+
+
+def test_fw_version_called_multiple_times_shares_one_probe(compile_gq):
+    # Calling fw_version() more than once must not inject the probe stage
+    # more than once (which would be a duplicate-stage-name compile error)
+    # -- every call reads the same hidden variable.
+    source = game_with_stage(
+        "x = fw_version(); y = fw_version();",
+        "volatile { int x = 0; int y = 0; }",
+    )
+    _gqgame_bytes, cmds_text, map_text = _compile_and_read(compile_gq, source)
+    assert map_text.count(structs.GQ_FW_PROBE_STAGE_NAME) == 1
+    ops = _author_enter_ops(cmds_text)
+    setvars = [op for op in ops if op.name == "SETVAR"]
+    assert len(setvars) == 2
+    assert all(not (op.flags & structs.OpFlags.LITERAL_ARG2) for op in setvars)
+    assert setvars[0].arg2 == setvars[1].arg2  # both read the same hidden var

--- a/gqc/tests/test_grammar.py
+++ b/gqc/tests/test_grammar.py
@@ -132,6 +132,80 @@ def test_badge_count_bare_no_parens_rejects(compile_gq):
     assert exit_code != 0
 
 
+# --- fw_version() (gamequeer#411) ---------------------------------------------
+# Same nullary-call shape as badge_count() above: mandatory-but-empty parens,
+# no bare-operand form. test_fw_version.py covers what it actually lowers to
+# (the compiler-injected probe stage) and the GQI_FW_VERSION write-protection
+# it relies on; this section is just accept/reject grammar coverage.
+
+
+def test_fw_version_call_accepts(compile_gq):
+    source = game_with_stage("x = fw_version();", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_fw_version_combined_with_binary_op_accepts(compile_gq):
+    source = game_with_stage("x = fw_version() + 1;", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_fw_version_in_if_condition_accepts(compile_gq):
+    source = game_with_stage(
+        "if (fw_version() == 0) { badge_set 42; }", "volatile { int x = 0; }"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_fw_version_with_argument_rejects(compile_gq):
+    # fw_version() is nullary -- Keyword("fw_version") commits (via the
+    # grammar's `-`) as soon as "fw_version" itself matches, so a spurious
+    # argument fails with a clean, source-located ParseSyntaxException.
+    source = game_with_stage("x = fw_version(5);", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+    assert "ParseSyntaxException" in stderr
+
+
+def test_fw_version_standalone_statement_rejects(compile_gq):
+    source = game_with_stage("fw_version();")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+
+
+def test_fw_version_prefixed_identifier_in_expression_accepts(compile_gq):
+    # "fw_version" is matched via Keyword(), so it doesn't swallow a
+    # fw_version-*prefixed* identifier -- same reasoning as
+    # test_badge_count_prefixed_identifier_in_expression_accepts above
+    # (gamequeer#354).
+    source = game_with_stage(
+        "y = fw_version_flag + 1;",
+        "volatile { int fw_version_flag = 0; int y = 0; }",
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_fw_version_bare_no_parens_rejects(compile_gq):
+    # Like badge_count, fw_version has no bare-operand form -- the parens
+    # (even though empty) are mandatory.
+    source = game_with_stage("x = fw_version;", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+
+
+def test_fw_version_write_rejects(compile_gq):
+    # GQI_FW_VERSION is read-only by cart convention (gamequeer#411): writing
+    # an as-yet-undefined reserved int corrupts adjacent RAM on firmware that
+    # predates it (gamequeer#410). See test_fw_version.py for more on this.
+    source = game_with_stage("GQI_FW_VERSION = 5;")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+    assert "read-only" in stderr
+
+
 # --- str() cast: whole-RHS and inline (gamequeer#386) ------------------------
 
 


### PR DESCRIPTION
## Summary

gqc (compiler) side of firmware detection ([gamequeer#411](https://github.com/duplico/gamequeer/issues/411), successor to [gamequeer#410](https://github.com/duplico/gamequeer/issues/410)). **This PR does not touch the C VM or badge firmware** — see "Downstream contract" below for exactly what that follow-up task needs to do.

- **`GQI_FW_VERSION`** — next free reserved-int slot (`0x60`, right after `GQI_PLAYER_ID`), added to `GQ_RESERVED_INTS` in `gqc/src/gqc/structs.py`. Compile-time only from gqc's perspective (it just emits this address). Firmware that defines it populates it at cart boot; original 2024 fleet firmware never heard of this offset. **Read-only by cart convention**: gqc now rejects any attempt to write a reserved int flagged `writable=False` (`Cannot assign to read-only variable GQI_FW_VERSION`) — writing it on original firmware would corrupt adjacent RAM (gamequeer#410's finding).
- **`fw_version()`** — a nullary intrinsic (same shape as `badge_count()`, gamequeer#387): `0` on original firmware, else the value read from `GQI_FW_VERSION`.

## Design choice: compiler-injected hidden probe stage, gated on actual use

The issue left this open. I went with a **hidden, compiler-injected probe stage spliced in ahead of the game's declared `starting_stage`** — but **only when the game actually calls `fw_version()` somewhere** (`Game.needs_fw_probe`, set by the parser the first time it sees a `fw_version()` call).

Trade-off, made explicit:
- **Cost**: up to ~1s (21 ticks) of boot delay before the game's own first stage appears — but *only* on original 2024 firmware, and *only* for carts that call `fw_version()` at all. On post-original firmware (5-tick bganim clamp) the probe resolves in ~5 ticks (~50ms). A cart that never calls `fw_version()` gets zero footprint: no probe stage, no extra animation asset, no boot delay.
- **Benefit**: zero authoring surface. No stage to remember to add, no window to choreograph around an intro/splash — `fw_version()` is a plain expression usable from anywhere, and by the time *any* author code runs, the probe has already resolved (since it's the actual entry point).

The alternative (author-designated probe window, e.g. "run this during your own splash stage") avoids the unconditional delay but pushes real bookkeeping onto every author who wants firmware detection — arming/disarming the timer correctly around it, ordering it before any other `timer` use, etc. Given `fw_version()`'s whole value proposition is being effortless to reach for, I judged the boot-delay trade worth it. Flagging this explicitly for review since it's the actual design decision the issue asked for.

### Probe mechanics (gamequeer#410's race, lowered to existing bytecode only)

The probe stage's `enter` event arms a 13-tick timer; its `bganim` is a single frame clamped to `duration=5` ticks/frame. Firmware that clamps bganim frames to 5 ticks (the 20 FPS line, gamequeer#312+) fires `BGDONE` first (~5th tick); original firmware, which clamps to 20 ticks, fires `TIMER` first (13th tick) — an 8-tick margin either way, matching gamequeer#410's derivation. `BGDONE` reads `GQI_FW_VERSION` into a hidden volatile int and `gostage`s to the real starting stage; `TIMER` sets that hidden var to `0` (also its zero-initialized default) and does the same `gostage`. **`GQI_FW_VERSION` is only ever read** (never written) by gqc-generated code, enforced by the new write-protection above. See `linker.inject_fw_version_probe`'s docstring for the full writeup.

### Probe frame asset: compiler-synthesized, not shipped or author-provided

The probe's 1-frame bganim needs *a* frame to exist and load — its content is irrelevant (never meaningfully rendered). Rather than ship a package asset (packaging footprint, `pyproject.toml` `package-data` config) or require an author-provided placeholder, `linker._make_fw_probe_frame_source` synthesizes a throwaway 8×8 solid-black PNG into a temp file at compile time via Pillow (already a dependency) and deletes it right after `Animation()` consumes it. `Animation()`'s `source` resolves relative to CWD unless the string is itself absolute, in which case the join returns it unchanged — so the temp file's absolute path bypasses the normal `assets/animations/` convention entirely, with no ffmpeg dependency (PNG routes through the pure-Pillow `make_animation_from_image` path).

## Verification

**Full gqc test suite** (`cd gqc && make test`, i.e. `pytest tests`): **297 passed, 2 skipped** (pre-existing, ffmpeg-build-gated golden cases, unaffected by this change — baseline before this PR was 273 passed/2 skipped; all 24 new tests are additions, nothing else changed shape).

New/updated coverage:
- `tests/test_fw_version.py` (new): `GQI_FW_VERSION`'s address/read-only-ness, the compile error on writing it, zero footprint when `fw_version()` is unused, the probe stage becoming the cart's actual entry point (verified against the real `.gqgame` header bytes), the probe's op-stream shape (13-tick timer; `BGDONE` reads `GQI_FW_VERSION` non-literally; `TIMER` sets literal `0`; both branches `gostage` to the author's real starting stage), a whole-program scan asserting **no emitted op ever targets `GQI_FW_VERSION` as a destination**, and multiple-call-site sharing (one probe, one hidden variable).
- `tests/test_grammar.py`: accept/reject grammar coverage for `fw_version()`, mirroring `badge_count()`'s existing section.
- `tests/test_constant_folding.py`: pins that `fw_version()` never folds (it's a variable reference, not a literal).

**Headless-emulator behavioral verification** (manual, not wired into pytest — no existing suite in this repo builds the C VM as part of a gqc test run, so I didn't invent new plumbing for it): built `gamequeer` with `-DGQ_HEADLESS=ON` and compiled a cart whose `start` stage renders a label. Dumping the framebuffer with `--ticks N --dump` across `N ∈ {1,3,5,6,8,13,15,21,25}` shows the probe's all-black frame through tick 5, and the `start` stage's label from tick 6 onward — confirming `BGDONE` (not the 13-tick `TIMER`) resolves the probe on this build, whose frame-duration clamp is the *new* (post-#312) 5-tick behavior. This is the "post-original" branch end-to-end; the "original firmware" (`TIMER`-wins) branch can't be exercised until the downstream firmware task lands, since it needs the *old* clamp value.

## Downstream contract (C VM + badge firmware — separate task)

- `GQI_FW_VERSION` must be added to the `GQI_*` enum in `gamequeer/include/gamequeer.h`, immediately after `GQI_PLAYER_ID` and before `GQI_COUNT` (bumping `GQI_COUNT` from 24 to 25) — this yields byte offset `0x60`, matching this PR's `structs.py` entry.
- Firmware that defines it must populate it with a nonzero version value at cart boot (exact numbering scheme TBD by that task).
- Per gamequeer#411, the firmware carrying this must be the one used for the QC2026 field-update campaign, since a fleet state of "post-original but wordless" would pass the gamequeer#410 probe and then read garbage from the still-undefined word.

## Docs

`gqc/docs/authoring-and-perf-carts.md` gets a new "Firmware detection: `fw_version()`" subsection (End of §1, alongside the existing Randomness recipe) covering usage, the boot-delay trade-off, the timer-monopolization caveat, and the hard "never write `GQI_FW_VERSION` from cart code" warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Sonnet 5)

https://claude.ai/code/session_0112ypCZr6ktPQtErPaHiADi