### PR TITLE
feat(vm): add GQI_FW_VERSION reserved int (gamequeer#411)

### DIFF
--- a/gamequeer/include/gamequeer.h
+++ b/gamequeer/include/gamequeer.h
@@ -214,6 +214,15 @@ typedef enum gq_special_var_int {
     GQI_LABEL4_Y,
     GQI_LABEL_FLAGS,
     GQI_PLAYER_ID,
+    // gamequeer#411: firmware version, 0x60. Read-only from cart code (gqc
+    // rejects writes -- see structs.py's GQ_RESERVED_INTS) and undefined
+    // (not necessarily 0) on original 2024 firmware, which never heard of
+    // this offset; only meaningful after the gamequeer#410 probe establishes
+    // the running firmware is post-original. Firmware that defines it
+    // populates it once per cart load with a nonzero version (see
+    // HAL_new_game()); 0 continues to mean "original 2024 firmware" by
+    // convention, never an actual populated value.
+    GQI_FW_VERSION,
     GQI_COUNT
 } gq_special_var_int;
 
@@ -281,6 +290,7 @@ extern volatile uint8_t leds_animating;
 extern uint8_t gq_builtin_ints[];
 extern uint8_t gq_builtin_strs[];
 extern t_gq_int *player_id;
+extern t_gq_int *fw_version;
 
 extern uint8_t timer_active;
 extern t_gq_int timer_interval;

--- a/gamequeer/include/gamequeer.h
+++ b/gamequeer/include/gamequeer.h
@@ -214,14 +214,15 @@ typedef enum gq_special_var_int {
     GQI_LABEL4_Y,
     GQI_LABEL_FLAGS,
     GQI_PLAYER_ID,
-    // gamequeer#411: firmware version, 0x60. Read-only from cart code (gqc
-    // rejects writes -- see structs.py's GQ_RESERVED_INTS) and undefined
-    // (not necessarily 0) on original 2024 firmware, which never heard of
-    // this offset; only meaningful after the gamequeer#410 probe establishes
-    // the running firmware is post-original. Firmware that defines it
-    // populates it once per cart load with a nonzero version (see
-    // HAL_new_game()); 0 continues to mean "original 2024 firmware" by
-    // convention, never an actual populated value.
+    // gamequeer#411: firmware version, 0x60. Cart code must never write this
+    // word (writes on original firmware corrupt RAM); gqc enforces it as
+    // read-only per the gamequeer#411 contract. Undefined (not necessarily
+    // 0) on original 2024 firmware, which never heard of this offset; only
+    // meaningful after the gamequeer#410 probe establishes the running
+    // firmware is post-original. Firmware that defines it populates it once
+    // per cart load with a nonzero version (see HAL_new_game()); 0 continues
+    // to mean "original 2024 firmware" by convention, never an actual
+    // populated value.
     GQI_FW_VERSION,
     GQI_COUNT
 } gq_special_var_int;

--- a/gamequeer/src/HAL.c
+++ b/gamequeer/src/HAL.c
@@ -212,8 +212,20 @@ void HAL_critical_exit(uint16_t prev_state) {
     (void) prev_state;
 }
 
+// gamequeer#411: this desktop/headless build's firmware version, reported
+// through GQI_FW_VERSION (see HAL_new_game() below). 0 is reserved to mean
+// "original 2024 firmware" by convention -- never set this to 0. Bump it
+// whenever this build gains a cart-observable capability worth gating on
+// (mirroring whatever scheme the badge firmware adopts for its own,
+// separate GQ_FW_VERSION -- see the qc2024 follow-up in gamequeer#411).
+#define GQ_FW_VERSION 1
+
 void HAL_new_game() {
-    // Nothing to do, on the emulator.
+    // Report this build's firmware version to cart code (gamequeer#411).
+    // Mirrors HAL_badge.c's HAL_new_game(), which does the analogous
+    // *player_id assignment for GQI_PLAYER_ID -- both run once per
+    // load_game() call (see gamequeer.c).
+    *fw_version = GQ_FW_VERSION;
 }
 
 void HAL_init(int argc, char *argv[]) {

--- a/gamequeer/src/gamequeer.c
+++ b/gamequeer/src/gamequeer.c
@@ -73,6 +73,10 @@ t_gq_int *label_flags = (t_gq_int *) &gq_builtin_ints[GQI_LABEL_FLAGS * GQ_INT_S
 
 t_gq_int *player_id = (t_gq_int *) &gq_builtin_ints[GQI_PLAYER_ID * GQ_INT_SIZE];
 
+// gamequeer#411: populated once per cart load by HAL_new_game() (see HAL.c),
+// never by cart bytecode -- gqc refuses to compile a write to GQI_FW_VERSION.
+t_gq_int *fw_version = (t_gq_int *) &gq_builtin_ints[GQI_FW_VERSION * GQ_INT_SIZE];
+
 char *game_title = (char *) &gq_builtin_strs[GQS_GAME_TITLE * GQ_STR_SIZE];
 
 char *labels[4] = {

--- a/gamequeer/src/gamequeer.c
+++ b/gamequeer/src/gamequeer.c
@@ -73,8 +73,11 @@ t_gq_int *label_flags = (t_gq_int *) &gq_builtin_ints[GQI_LABEL_FLAGS * GQ_INT_S
 
 t_gq_int *player_id = (t_gq_int *) &gq_builtin_ints[GQI_PLAYER_ID * GQ_INT_SIZE];
 
-// gamequeer#411: populated once per cart load by HAL_new_game() (see HAL.c),
-// never by cart bytecode -- gqc refuses to compile a write to GQI_FW_VERSION.
+// gamequeer#411: populated once per cart load by HAL_new_game() (see HAL.c).
+// Cart code must never write this word -- on original firmware, which
+// never heard of this offset, a write corrupts whatever adjacent RAM the
+// linker happened to place next. gqc enforces read-only-ness for
+// GQI_FW_VERSION as part of the gamequeer#411 contract.
 t_gq_int *fw_version = (t_gq_int *) &gq_builtin_ints[GQI_FW_VERSION * GQ_INT_SIZE];
 
 char *game_title = (char *) &gq_builtin_strs[GQS_GAME_TITLE * GQ_STR_SIZE];


### PR DESCRIPTION
## Summary

C VM / desktop-emulator side of firmware version reporting. Successor to gamequeer#410, tracked in gamequeer#411, downstream of the gqc (compiler) side in gamequeer#412 (open, unmerged). This PR does **not** depend on #412's Python code -- it only matches the contract #412 already committed to:

- `GQI_FW_VERSION` added to the `GQI_*` enum in `gamequeer/include/gamequeer.h`, immediately after `GQI_PLAYER_ID`, before `GQI_COUNT` (24 -> 25) -- lands at byte offset `0x60`, matching #412's `structs.py` entry exactly (verified below).
- The desktop/headless emulator (`gamequeer/src/HAL.c`) populates it once per cart load, in `HAL_new_game()` -- the same call site and cadence `GQI_PLAYER_ID` already uses (`*player_id = ...` in the same function). It is never written by cart bytecode; #412 already enforces that read-only-ness on the gqc side (`Cannot assign to read-only variable GQI_FW_VERSION`), so no VM-side write-protection was added here -- the contract delegates that entirely to the compiler.

## Version-scheme proposal (for owner ruling)

Kept deliberately simple: a manually-bumped `#define GQ_FW_VERSION` per firmware build, `1` and up (`0` stays reserved for "original 2024 firmware" and is never assigned). Bump it whenever a firmware build gains a cart-observable capability worth gating `fw_version()` on -- not on every commit/release. This PR defines `GQ_FW_VERSION 1` for the desktop/headless emulator in `gamequeer/src/HAL.c`; the badge firmware will need its own, separate `GQ_FW_VERSION` constant (see follow-up below) -- the two platforms are versioned independently, there's no shared registry.

Flagging for explicit ruling: is per-build manual bump enough, or do you want a more structured scheme (e.g. tied to the field-update campaign's release tags, or a capability bitmask instead of a linear version)? I judged linear-and-manual as the right amount of ceremony for a badge fleet the size of this one, but this is exactly the kind of call the issue asked to leave open.

## qc2024 (badge firmware) follow-up -- NOT done in this PR

Grepped both this repo and `/home/george/project/qc2024/ccs_workspace/` for everything that sizes or iterates `GQI_COUNT` / the builtin-int array:

- `gamequeer/src/gamequeer.c:24` -- `uint8_t gq_builtin_ints[GQI_COUNT * GQ_INT_SIZE]` is the only thing that sizes off `GQI_COUNT`, and it's in this repo (shared by both platforms); already picks up the new size automatically, no separate qc2024-side sizing to touch.
- `ccs_workspace/qc2024/HAL_badge.c:209` and `:228` -- `read_byte()`/`write_byte()`'s `GQ_PTR_BUILTIN_INT` cases index `gq_builtin_ints[GQ_PTR_ADDR(ptr)]` generically; no change needed (they don't care about `GQI_COUNT`).
- `ccs_workspace/qc2024/HAL_badge.c:556` (`HAL_new_game()`) -- **this is the one real call site the follow-up PR needs to touch.** It already does the `GQI_PLAYER_ID` analog (`*player_id = badge_id_resolved;` at line 565); the follow-up should add `*fw_version = GQ_FW_VERSION;` right alongside it, plus an `extern t_gq_int *fw_version;` pickup (already declared in this repo's `gamequeer.h`, which qc2024 includes) and the badge firmware's own `GQ_FW_VERSION` constant.

No other qc2024 file references `GQI_*`, `gq_builtin_ints`, or `special_var_int`.

Per gamequeer#411's sequencing constraint: the badge-firmware cut that adds this must be the one used for the QC2026 field-update campaign, since a fleet state of "post-original but wordless" would pass the #410 probe and then read garbage from the still-undefined word.

## Verification

**Full headless ctest suite** (`make test-headless`, Docker + `cmake -DGQ_HEADLESS=ON`): **28/28 passed**, including all golden-framebuffer/LED-CSV fixtures -- confirms the `GQI_COUNT` bump (which grows `gq_builtin_ints[]` by 4 bytes) doesn't shift any existing offset or otherwise regress anything.

**Direct runtime verification of the new offset/population** (gdb against the real built `gamequeer` headless binary + a real golden cart, `tests/golden/hello.gqgame`), since #412's compiler isn't available in this repo to author a `.gq` cart that reads `GQI_FW_VERSION` via `fw_version()`:
- `(long)&fw_version_target - (long)&gq_builtin_ints == 0x60` -- confirms the exact byte offset matches #412's `structs.py` entry.
- `*fw_version == 1` immediately after `HAL_new_game()` returns -- confirms population happens at the right call site with the right value.

`clang-format -n --Werror` on all three touched first-party files: clean, no diffs.

## Lockstep note

This PR's enum change is compatible with #412's `structs.py` entry (same offset, same position) but #412 is unmerged and untouched by this PR -- no code here imports or depends on it. Once both land, no further reconciliation should be needed on the C-VM side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112ypCZr6ktPQtErPaHiADi