### PR TITLE
DEF CON authoring sprint: game-as-directory, const/enum, random+math, social vocabulary (#419)

### DIFF
--- a/docs/defcon-authoring-sprint-plan.md
+++ b/docs/defcon-authoring-sprint-plan.md
@@ -1,0 +1,119 @@
+# DEF CON authoring sprint — plan & handoff record
+
+**Status:** active. **Tracking epic:** [duplico/gamequeer#419](https://github.com/duplico/gamequeer/issues/419).
+This document is a durable, hand-off-able snapshot of the language/toolchain-DX plan so any
+session (local, web, or a human picking up) can resume from GitHub + commits alone. The epic
+and its sub-issues are the live source of truth; this doc preserves the *rationale and the
+grounded facts* that would otherwise have to be re-derived.
+
+_AI-drafted via Claude Code at George's request, as part of the pre-DEF CON authoring push._
+
+## Goal
+
+DEF CON is ~2 weeks out. The pitch to the community has two legs:
+
+1. **"Bring your gamequeers — we'll fix performance with a quick field-firmware upgrade."**
+   This is the perf saga + `flashing/field_update.py`, which largely *exists*; it's a
+   package-and-release task, not part of this sprint's build.
+2. **"We have a dramatically improved game-author experience — you've got a week to write
+   something and we'll flash it onto carts for you."** This sprint is leg 2: ship enough
+   author-facing DX in ~1 week that an outside author can write a game in the following week.
+
+## Ranking function (drives every prioritization call)
+
+- **Favor social games and expressive-while-idle ("lanyard") games; disfavor heads-down
+  button-mashing.** Make the favored modes the *easy* path — carrot, not stick. Heads-down
+  stays possible but unsugared. This is a thumb on the scale + a spotlight, **not a gate**: a
+  rising tide that also lifts heads-down is a pure win. (The formatter/linter, PRNG, etc. are
+  mode-agnostic universal wins and rank on their own merits.)
+- **Frozen VM.** Everything desugars to today's bytecode / frame format unless a *critical*
+  bug forces a change. The badge VM interpreter does not move.
+- **The brakes make us faster.** Formatter + linter + codemods are a *front-loaded
+  accelerant*, not overhead: they speed up the sprint's own remaining work and carry the
+  existing game corpus forward instead of leaving it behind.
+
+## The three concurrent thrusts (→ sub-issues of #419)
+
+1. **Layout convention — do first** (#420): game-as-directory (`<name>/<name>.gq` entry),
+   `game{}`-anywhere grammar relaxation (exactly-one, anywhere), game-dir-relative asset
+   resolution, `gqc new` emits it. It's the structural half of multi-file (#401) and it's
+   what's actively hurting in-flight games.
+2. **Foundation, front-loaded — the brakes** (#424): CST/provenance-preserving parse →
+   formatter (`gqc fmt`) → linter (`gqc lint`) + modernization codemods. Engine lives in gqc
+   (authoritative AST), surfaced in the editor via the hybrid path (#409). Build the CST for
+   the game-as-directory structure so multi-file's merge and the linter's whole-program
+   analysis aren't reworked later. Also here: conformance gate (#405) + closing live
+   gqc↔Langium divergences (#406, #407, and now `fw_version`/#411).
+3. **Language features, in parallel — structure-independent:** social layer/cohorts (#423,
+   the headline), constants + enums (#421), PRNG + math intrinsics (#422); plus onboarding
+   (docs / examples / `gqc new`). Related: range-stages #399, unary #400, ergonomics #402.
+
+## Parked (deferred)
+
+Firmware-side favored modes — **system ambient display** and **badge-global identity store**
+(`qc2024`) — deferred. The "launch an ambient app and leave it running" pattern (à la
+`glowdeck`) delivers the lanyard experience app-side without them. Working handles are landing
+soon, which softens this. App-side ambient/flair sugar is a **stretch** goal for this sprint.
+
+## Decisions on the record
+
+- **#409:** lean **hybrid LSP** — Langium = syntactic layer (coloring, cheap completion), gqc
+  = authoritative semantics (diagnostics/lints) — plus **gqc-in-WASM** as one artifact that
+  powers editor diagnostics + browser compile + web-play (#404). Do *not* reimplement lint
+  semantics in Langium.
+- **Variants** (queersafe vs queersafe-lite) are solved by the **`abstract` primitive**
+  (declare slots in a base, fill them per-variant) — same primitive as stage
+  inheritance/templates. Multi-file concat handles *splitting*; `abstract` handles
+  *overriding*. Keep them distinct.
+- **Cue language:** effect-primitives (`pulse`/`strobe`/`chase`/`cycle`) desugar to a
+  keyframe+easing core; single-timeline + overlay modifiers before layered tracks.
+- **Shared asset store** (#403) = the console design system; search-path resolution (game dir
+  → blessed `std/console`), version-pinned per game.
+
+## Grounded facts worth not re-deriving (from investigations this planning cycle)
+
+- **No runtime pointer math / computed jump in the VM.** Every memory operand is a
+  compile-time-baked pointer (`bytecode.c`); `GOTO` targets are baked. ⇒ all collections are
+  **compile-time fixed families** (constant/foldable indices, unrolled); a *runtime*-selected
+  index must desugar to a compare-chain. The **one** runtime-indexed structure is the
+  badges-seen bitfield via `QCGET`/`QCSET`/`QCCLR` (`badge_get`/`set`/`count`).
+- **Compile-time index arithmetic is fine** (relative nav, wrap/clamp) as long as inputs are
+  statically known — and "the current stage" is a *lexical* fact, so `help[$i+1]`-style
+  navigation folds to concrete targets.
+- **LED cue desugar target (frozen):** `gq_ledcue_frame_t` = `uint16 duration` (10ms ticks,
+  compiler floors to multiples of 4 → 40ms grid) + 1 `transition_smooth` bit + `rgbcolor8 leds[5]`.
+  `smooth` = **VM-native per-channel linear tween** to the next frame; non-linear easing must
+  be **baked** into ≤ **50 frames/cue** (`GQ_CUE_MAX_FRAMES`; VM silently truncates beyond —
+  compiler must self-limit). Loop/bgcue are set by *how a cue is invoked*, not encodable in
+  `.gqcue`: foreground cues are one-shot, only a stage's background cue loops. A non-looping
+  `smooth` final frame fades to **black** (#353) — emit terminal `none` to hold.
+- **Stage-transition-from-`enter` regime = B+C:** a `gostage` in an `enter` handler consumes
+  **one main-loop tick per hop AND flushes the passed-through stage's background** (iterative,
+  not recursive; no stack-blow risk). ⇒ the auto-advance "dynamic stage family" trick is only
+  valid as *visible staged iteration*, never as invisible random-access indexing.
+- **Identity/persistence layers:** badge-global identity is an 8-byte FRAM `t_badge_id_record`
+  (numeric id only). `GQS_PLAYER_HANDLE` is a **RAM builtin** (`gq_builtin_strs[]`) with no
+  confirmed badge-global persistent backing → **system/badge-global flair is firmware
+  greenfield** (`qc2024`), hence parked. Per-game `persistent {}` lives in the per-cart SAVE
+  region (CRC16'd). The seen-bitfield is persistent.
+
+## Current state
+
+- Branch `claude/language-features-np8ywf` reset to latest `origin/default`.
+- Landed in gqc on `default` (post-audit): `#385` const-fold, `#386` inline-`str()`-concat,
+  `#387` `badge_count()`, `#411` `fw_version()`+`GQI_FW_VERSION`. The latter three are **live
+  Langium divergences** (in gqc, not the editor grammar) — `#406`/`#407` open, `fw_version` to
+  be folded in.
+- Foundation issues `#405`–`#409` open, unworked.
+
+## How to resume
+
+1. Read epic **#419** and its five sub-issues (#420 layout, #421 constants, #422 PRNG/math,
+   #423 social, #424 substrate).
+2. Each feature is being built by a `gqc-developer` agent in its own worktree → discrete PR
+   referencing its issue. Check open PRs on `duplico/gamequeer`.
+3. Integration note: the feature PRs each touch `gqc/src/gqc/grammar.py` — expect to rebase/
+   merge them sequentially. The CST/substrate work (#424) is intentionally sequenced
+   deliberately (not in the parallel spray) because everything rebases onto it.
+4. Per-feature discipline (#408): each language feature lands in gqc + a fixture + a Langium
+   grammar update (conformance batch #405).

--- a/gqc/docs/authoring-and-perf-carts.md
+++ b/gqc/docs/authoring-and-perf-carts.md
@@ -38,6 +38,34 @@ int  score   = 0;      // '=' for ints
 str  name    := "ME";  // ':=' for strings
 ```
 
+### Named constants and enums
+
+`const NAME = <int-expr>;` and `enum Name { A, B, C }` (gamequeer#421) are
+compile-time-only sugar for magic numbers — every reference is substituted
+with a literal int at parse time (reusing the same constant folding a
+literal-only expression gets, so `const MAX_HP = 20 + 1;` never emits a
+runtime add), so there's no register/opcode cost and no on-cart trace of
+the name at all:
+
+```
+const MAX_HP = 21;
+enum Difficulty { Easy, Medium, Hard }   // auto-numbered 0, 1, 2
+
+stage start {
+    event enter {
+        hp = MAX_HP;
+        if (difficulty == Difficulty.Hard) { hp = hp - 5; }
+    }
+}
+```
+
+**Declare before use.** Unlike variables/stages/animations (which resolve
+forward references at link time), a `const`/`enum` has no runtime
+representation to stay "unresolved" as — it must already be a literal by
+the time its use is parsed, so it has to appear earlier in the file than
+any reference to it. A single flat, file-global namespace covers both
+forms; an enum member is referenced as `Name.Member`.
+
 ### Stage options
 
 - `bganim <anim>;` — background animation for the stage.

--- a/gqc/docs/authoring-and-perf-carts.md
+++ b/gqc/docs/authoring-and-perf-carts.md
@@ -60,7 +60,10 @@ with `continue` / `break`, `badge_set`/`badge_clear`, and assignments
 `badge_get` is not a statement but a unary operator usable inside int
 expressions (e.g. `x = badge_get(5) + 1;`); `badge_count()` (nullary,
 parens mandatory) is a popcount over the whole badges-seen bitfield, e.g.
-`if (badge_count() >= 5) { ... }`.
+`if (badge_count() >= 5) { ... }`. `random(lo, hi)`, `min(a, b)`, `max(a,
+b)`, `clamp(x, lo, hi)`, and `abs(x)` (gamequeer#422) are also int-expression
+intrinsics, each taking one or more full `int_expression` arguments -- see
+"Randomness" below for `random()`'s details.
 
 **`badge_count()` is heavy -- a ~9-op runtime loop over all 320 badge
 slots, not an O(1) lookup.** Call it once (e.g. on a stage's `enter` event)
@@ -97,8 +100,41 @@ GQS_LABEL2 := "score=" + score_str;
 
 ### Randomness
 
-There is no RNG builtin. Build one from two pieces: an entropy source sampled
-at a human input event, and a deterministic generator.
+**`random(lo, hi)`** (gamequeer#422) returns a pseudo-random int in the
+*inclusive* range `[lo, hi]` (both full `int_expression`s, so e.g.
+`random(1, max_hp)` is valid):
+
+```
+roll = random(1, 6);          // 1..6 inclusive, like a d6
+dmg = random(low_dmg, high_dmg);
+```
+
+It's sugar for exactly the hand-rolled Park-Miller "minimal standard" LCG
+the game corpus already used before this existed (see e.g.
+`gq-games/games/donsol.gq`'s card-shuffle `lcg`) -- seeded from
+`GQI_PLAYER_ID` and a hidden per-call counter, advanced one Schrage-method
+step on every call. No setup required: the first call anywhere in a game
+lazily creates its hidden state; a game that never calls `random()` pays
+nothing for it. See `IntExpression._emit_random` (`gqc/src/gqc/datamodel.py`)
+for the full derivation.
+
+Also available: `min(a, b)`, `max(a, b)`, `clamp(x, lo, hi)` (`=
+min(max(x, lo), hi)`), and `abs(x)` -- all full `int_expression` arguments,
+all fold to a single literal at compile time when every argument is one
+(unlike `random()`, which never folds -- it reads live state).
+
+**Hand-rolling your own generator is no longer necessary for the common
+case**, but the recipe below is kept for reference (e.g. driving a full
+shuffle from one manually-managed seed, or matching a specific published
+LCG for cross-checking against another implementation). Note it predates
+`random()` and uses a *different* multiplier (16807, the original 1969
+Lehmer/Park-Miller constant) than `random()`'s own (48271, the 1993 revised
+"minimal standard" constant matching donsol.gq) -- the two aren't
+interchangeable mid-sequence, but both are valid, full-period generators on
+their own terms.
+
+Build one from two pieces: an entropy source sampled at a human input event,
+and a deterministic generator.
 
 **Entropy**: run a self-re-arming counter while waiting for the player, and
 sample it the moment they act:
@@ -538,6 +574,19 @@ for the full in-system procedure.
   bare C `/` and `%` with no zero check — a zero divisor is undefined
   behavior/a trap on both the emulator and the badge. Guard any divisor that
   can be zero with an `if` before dividing.
+- **`random(lo, hi)`/`clamp(x, lo, hi)` with `hi < lo` is unguarded** — same
+  "author's responsibility, not gqc's" contract as the zero-divisor case
+  above. `random()` maps into the range via `% (hi - lo + 1)`, an
+  unguarded runtime divide if `hi - lo + 1 <= 0`; `clamp()` still compiles
+  and runs (it's `min(max(x, lo), hi)`, no division), just returns
+  whatever that composition works out to for an inverted range, not a
+  "clamp failed" signal.
+- **`random()`/`min()`/`max()`/`clamp()` each briefly hold 2-3 of gqc's 4
+  int registers** while evaluating (see `IntExpression._emit_random`/
+  `_emit_minmax` in `datamodel.py`) — same register-pressure caveat as
+  `badge_count()` above; combining two or more of these (or nesting them
+  inside an already register-heavy expression) can hit `No free registers
+  available`.
 - **RLE4 is unreachable** via the public pipeline (commented out in `Frame`).
 - Encoding is decided **per frame**, not per animation — a mixed-content
   animation can contain both RLE7 and UNCOMPRESSED frames.

--- a/gqc/docs/authoring-and-perf-carts.md
+++ b/gqc/docs/authoring-and-perf-carts.md
@@ -137,27 +137,40 @@ roll = random(1, 6);          // 1..6 inclusive, like a d6
 dmg = random(low_dmg, high_dmg);
 ```
 
-It's sugar for exactly the hand-rolled Park-Miller "minimal standard" LCG
-the game corpus already used before this existed (see e.g.
-`gq-games/games/donsol.gq`'s card-shuffle `lcg`) -- seeded from
-`GQI_PLAYER_ID` and a hidden per-call counter, advanced one Schrage-method
-step on every call. No setup required: the first call anywhere in a game
-lazily creates its hidden state; a game that never calls `random()` pays
-nothing for it. See `IntExpression._emit_random` (`gqc/src/gqc/datamodel.py`)
-for the full derivation.
+Its *multiplicative core* is the same Park-Miller "minimal standard" LCG
+the game corpus already hand-rolled before this existed (see e.g.
+`gq-games/games/donsol.gq`'s card-shuffle `lcg`), advanced one Schrage-method
+step on every call. Its *seeding* is NOT the same as donsol.gq's: the state
+is perturbed on every call with `GQI_PLAYER_ID` and a hidden counter that
+increments once per `random()` *call* (zero at boot) -- not donsol.gq's own
+`ctr`, which is sampled from a free-running timer counter for real
+wall-clock entropy. That means **the first `random()` call after a fresh
+cart boot is fully determined by the badge's `GQI_PLAYER_ID`** and repeats
+identically on every reboot of the same badge; only later calls within the
+same boot session diverge from each other. No setup required either way:
+the first call anywhere in a game lazily creates the hidden state; a game
+that never calls `random()` pays nothing for it. See
+`IntExpression._emit_random` (`gqc/src/gqc/datamodel.py`) for the full
+derivation.
 
 Also available: `min(a, b)`, `max(a, b)`, `clamp(x, lo, hi)` (`=
 min(max(x, lo), hi)`), and `abs(x)` -- all full `int_expression` arguments,
 all fold to a single literal at compile time when every argument is one
 (unlike `random()`, which never folds -- it reads live state).
 
-**Hand-rolling your own generator is no longer necessary for the common
-case**, but the recipe below is kept for reference (e.g. driving a full
-shuffle from one manually-managed seed, or matching a specific published
-LCG for cross-checking against another implementation). Note it predates
-`random()` and uses a *different* multiplier (16807, the original 1969
-Lehmer/Park-Miller constant) than `random()`'s own (48271, the 1993 revised
-"minimal standard" constant matching donsol.gq) -- the two aren't
+**If a game needs its first draw to actually vary from boot to boot**
+(e.g. a card shuffle that shouldn't replay identically every time the same
+badge boots the cart), `random()` alone doesn't provide that -- hand-roll
+real entropy the same way donsol.gq does, with the recipe below: arm a
+`timer` event on a menu/title screen so a counter free-runs while the
+player is looking at the screen, and salt an int variable with it (or feed
+it straight into your own LCG state) before relying on any random draw.
+The recipe is also useful for driving a full shuffle from one
+manually-managed seed, or matching a specific published LCG for
+cross-checking against another implementation. Note it predates `random()`
+and uses a *different* multiplier (16807, the original 1969 Lehmer/
+Park-Miller constant) than `random()`'s own (48271, the 1993 revised
+"minimal standard" constant, also used by donsol.gq) -- the two aren't
 interchangeable mid-sequence, but both are valid, full-period generators on
 their own terms.
 

--- a/gqc/src/gqc/datamodel.py
+++ b/gqc/src/gqc/datamodel.py
@@ -1398,6 +1398,17 @@ def fold_constant_int_expression(node):
 # constant-only pre-pass to lift this restriction; that's left as a
 # possible future enhancement if declare-before-use ever proves too
 # restrictive in practice.
+#
+# A `const`/`enum` name used before its own declaration is diagnosed, not
+# silently miscompiled: `parser.parse_int_operand`'s identifier branch
+# can't tell at parse time whether an as-yet-undefined name is an ordinary
+# (forward-reference-tolerant) variable or a not-yet-declared const/enum
+# member, so it records every such fallback reference in
+# `Constant.pending_int_refs`; once the whole file has been parsed (and
+# `const_table` therefore holds every const/enum name the file will ever
+# define), `parser.parse` cross-checks that list and rejects any entry that
+# turns out to name a const/enum member after all -- see
+# `parser.check_pending_int_refs`.
 
 
 class Constant:
@@ -1409,9 +1420,23 @@ class Constant:
     grammar's bare `identifier` token can't contain a `.`, so one flat
     dict safely serves both forms and gives them a single shared
     duplicate-name check.
+
+    `pending_int_refs` is a *separate* table, for a separate purpose: every
+    identifier `parser.parse_int_operand` couldn't resolve against
+    `const_table` at the point it was parsed (so fell through to treating
+    it as an ordinary variable reference), recorded as `(name, instring,
+    loc)`. Declare-before-use for const/enum (see the module-level comment
+    above this class) means that fallback is *correct* for a genuine
+    variable, but *wrong* for a const/enum referenced ahead of its own
+    declaration -- which this file can't yet tell apart at that point in
+    the parse, since the name might still get defined later. Once the
+    whole file is parsed, `parser.check_pending_int_refs` re-checks every
+    entry here against the now-complete `const_table` and rejects any that
+    do turn out to name a const/enum member.
     """
 
     const_table: dict[str, int] = {}
+    pending_int_refs: list = []
 
     @classmethod
     def define(cls, name: str, value: int) -> None:
@@ -1741,33 +1766,49 @@ class IntExpression:
         self.free_register(cmp_reg)
 
     def _emit_random(self, lo, hi) -> GqcIntOperand:
-        """Lower a `random(lo, hi)` leaf (gamequeer#422) to the exact
-        Park-Miller "minimal standard" LCG (multiplier
-        `structs.GQ_RANDOM_LCG_MULTIPLIER`, modulus
-        `structs.GQ_RANDOM_LCG_MODULUS` = 2**31 - 1) the game corpus already
-        hand-rolls at the source level -- see e.g. gq-games/games/donsol.gq's
-        card-shuffle `lcg` -- advanced via Schrage's method so the
-        multiply-by-48271 step never has to leave `t_gq_int`'s signed-32-bit
-        range. FROZEN VM CONTRACT: no dedicated opcode, no wider int type --
-        every step below is an existing `CommandArithmetic`/`CommandIf` op.
+        """Lower a `random(lo, hi)` leaf (gamequeer#422) to the Park-Miller
+        "minimal standard" LCG (multiplier `structs.GQ_RANDOM_LCG_MULTIPLIER`,
+        modulus `structs.GQ_RANDOM_LCG_MODULUS` = 2**31 - 1), advanced via
+        Schrage's method so the multiply-by-48271 step never has to leave
+        `t_gq_int`'s signed-32-bit range. FROZEN VM CONTRACT: no dedicated
+        opcode, no wider int type -- every step below is an existing
+        `CommandArithmetic`/`CommandIf` op.
 
-        Seed convention: `structs.GQ_RANDOM_STATE_VAR` is the persisted LCG
-        state, carried across *every* `random()` call for the life of the
-        running cart (it's a volatile/heap variable, zero-initialized at
-        boot like any other -- see `linker.create_random_state_variables`).
-        Every call perturbs it with `GQI_PLAYER_ID * GQ_RANDOM_SEED_MULTIPLIER`
-        plus `structs.GQ_RANDOM_CTR_VAR`, a counter incremented on every call
-        -- donsol.gq's own seeding formula (`lcg = GQI_PLAYER_ID * 7919; lcg
-        = lcg + ctr; ...`), applied fresh on every call instead of once per
-        "run": two `random()` calls made back-to-back (or a fresh cart boot,
-        which resets the state back to 0) still diverge from each other,
-        rather than both landing on the same first draw. The perturbation
-        folds into the *previous* call's already-well-mixed state rather
-        than replacing it outright, so the full multiplicative recurrence's
-        statistical properties carry forward between calls; the seed
-        formula alone (without a continuously-advancing state) would just
-        be an arithmetic progression in the counter -- not what "the same
-        LCG donsol hand-rolls" means here.
+        The *multiplicative core* (this same modulus/multiplier, advanced
+        one Schrage step per draw) is the recurrence the game corpus already
+        hand-rolls at the source level -- see e.g. gq-games/games/donsol.gq's
+        card-shuffle `lcg`. The *seeding scheme* is deliberately NOT the
+        same, and callers should not assume it is:
+
+        `structs.GQ_RANDOM_STATE_VAR` is the persisted LCG state, carried
+        across *every* `random()` call for the life of the running cart
+        (it's a volatile/heap variable, zero-initialized at boot like any
+        other -- see `linker.create_random_state_variables`). Every call
+        perturbs it with `GQI_PLAYER_ID * GQ_RANDOM_SEED_MULTIPLIER` plus
+        `structs.GQ_RANDOM_CTR_VAR`, a counter incremented once per
+        `random()` *call* (also zero-initialized at boot) -- NOT donsol.gq's
+        `ctr`, which is a free-running counter driven by a re-armed `timer`
+        event while the player sits on a menu, i.e. real wall-clock entropy
+        that varies with how long the player waited before triggering the
+        first draw. `GQ_RANDOM_CTR_VAR` has no such source: it is 0 at boot
+        and only ever advances when `random()` itself is called, so the
+        *first* `random()` call after a fresh boot is `state = GQI_PLAYER_ID
+        * 7919 + 1` -- a value fully determined by the cart's badge ID,
+        identical and reproducible on every reboot of the same badge. (The
+        perturbation still folds into the *previous* call's already-mixed
+        state rather than replacing it outright, so calls made back-to-back
+        within the same boot session do diverge from each other and from
+        the first draw -- it's only the very first draw per boot that has no
+        real entropy behind it.)
+
+        Authors who need a genuinely per-boot-unpredictable first draw (e.g.
+        a card shuffle that shouldn't replay identically every time the same
+        badge boots the cart) need to hand-roll real entropy the same way
+        donsol.gq does: arm a `timer` event on a menu/title screen, let it
+        free-run while the player is looking at the screen, and salt an int
+        variable with that counter (via ordinary int-expression ops) before
+        the first `random()` call -- `random()` alone does not do this for
+        you.
 
         Maps the result into the caller's *inclusive* `[lo, hi]` range via
         `state % (hi - lo + 1) + lo`. Like every other gqc runtime `/`/`%`

--- a/gqc/src/gqc/datamodel.py
+++ b/gqc/src/gqc/datamodel.py
@@ -47,7 +47,24 @@ GqcBadgeCountOperand = namedtuple('GqcBadgeCountOperand', [])
 class Game:
     link_table = dict() # OrderedDict not needed to remember order since Python 3.7
     game_name : str = None
+    # The directory containing the game's entry `.gq` file (gamequeer#420's
+    # game-as-directory convention). Set by gqc.py's `compile` command (and
+    # by tests that drive the parser directly) before parsing, so
+    # animations{}/lightcues{} sources -- and Game.__init__ below, via the
+    # game{}-anywhere relaxation -- never have to assume anything about
+    # *when* the game{} block itself is parsed relative to those sections.
+    # Defaults to the CWD, matching gqc's historical CWD-relative asset
+    # resolution for the common case where the entry file lives at the top
+    # of the invocation directory.
+    game_dir : pathlib.Path = pathlib.Path()
     game = None
+
+    # Set (regardless of whether a Game instance exists yet) the first time
+    # any stage's event code calls fw_version() (gamequeer#411), so the
+    # game{}-anywhere relaxation (gamequeer#420) can't lose the signal to a
+    # fw_version() call that's parsed *before* the game{} block itself --
+    # see parse_fw_version_operand and Game.__init__ below.
+    needs_fw_probe_seen = False
 
     def __init__(self, id : int, title : str, author : str, starting_stage : str = 'start'):
         self.addr = 0x00000000 # Set at link time
@@ -66,7 +83,10 @@ class Game:
         # only synthesizes the probe stage -- and its firmware pays for the
         # probe's BGDONE/TIMER race -- when this is True, so a game that
         # never calls fw_version() has zero footprint from this feature.
-        self.needs_fw_probe = False
+        # Seeded from needs_fw_probe_seen rather than starting False: since
+        # gamequeer#420, a fw_version() call may already have been parsed
+        # (and recorded there) before this game{} block itself is reached.
+        self.needs_fw_probe = Game.needs_fw_probe_seen
 
         if Game.game is not None:
             raise ValueError("Game already defined")
@@ -76,11 +96,21 @@ class Game:
         self.title = title
         self.author = author
 
+        # gamequeer#420: game{} may now be parsed after some/all of a
+        # game's stages (it no longer has to be the first top-level
+        # section), so a stage matching starting_stage may already be
+        # sitting in Stage.stage_table by the time we get here -- add_stage()
+        # only runs this same check for a stage parsed *after* this point.
+        for stage in Stage.stage_table.values():
+            if stage.name == self.starting_stage_name:
+                self.starting_stage = stage
+                break
+
     def add_stage(self, stage):
         self.stages.append(stage)
         if stage.name == self.starting_stage_name:
             self.starting_stage = stage
-    
+
     def __repr__(self) -> str:
         return f"Game({self.id}, {repr(self.title)}, {repr(self.author)}, crc_ptr={self.persistent_crc16_ptr:#0{10}x})"
     
@@ -181,7 +211,13 @@ class Stage:
 
         self.resolve()
 
-        Game.game.add_stage(self)
+        # gamequeer#420: game{} may not have been parsed yet (it's no
+        # longer required to be the first top-level section) -- in that
+        # case Game.__init__ itself scans Stage.stage_table for a
+        # starting_stage match once it *is* parsed, so there's nothing to
+        # register here yet.
+        if Game.game is not None:
+            Game.game.add_stage(self)
 
     def resolve(self) -> bool:
         # Don't bother trying to resolve symbols if we've already done so.
@@ -490,7 +526,12 @@ class Animation:
             if self.height:
                 make_animation_kwargs['height'] = self.height
 
-            self.src_path = pathlib.Path() / 'assets' / 'animations' / source
+            # gamequeer#420: resolved relative to the game's own directory
+            # (Game.game_dir), not the process CWD -- an absolute `source`
+            # still bypasses this entirely (pathlib truncates a `/`-joined
+            # absolute right-hand side), which linker.py's fw_version()
+            # probe-frame synthesis relies on.
+            self.src_path = Game.game_dir / 'assets' / 'animations' / source
             self.dst_path = pathlib.Path() / 'build' / 'assets' / 'animations' / Game.game_name / name
             digest_path = self.dst_path / '.digest'
 

--- a/gqc/src/gqc/datamodel.py
+++ b/gqc/src/gqc/datamodel.py
@@ -44,6 +44,45 @@ GqcStrCastOperand = namedtuple('GqcStrCastOperand', 'int_expr')
 # same role `GqcStrCastOperand` plays for an inline `str(x)` cast.
 GqcBadgeCountOperand = namedtuple('GqcBadgeCountOperand', [])
 
+# The social vocabulary (gamequeer#423, DEF CON sprint epic gamequeer#419):
+# `have_met(id)`, `in_cohort(NAME, id)`, and `count_seen(NAME)` (the
+# one-argument overload of `count_seen`; the bare `count_seen()` form
+# reuses `GqcBadgeCountOperand` directly -- see `parser.parse_count_seen_operand`).
+# FROZEN VM CONTRACT: all three desugar entirely to *existing* opcodes --
+# `badge_get` (`QCGET`), the comparison/logical ops, and the same
+# loop-over-`badge_get` shape `badge_count()` already uses -- never a new
+# opcode or register. Each is a marker `parser.py`'s own parse action
+# returns for `parse_int_operand`/`parse_int_expression`/
+# `IntExpression.get_result_symbol`/`fold_constant_int_expression` to
+# recognize and lower, the same role `GqcBadgeCountOperand` already plays
+# for `badge_count()`.
+#
+# `have_met(id)` is a bare rename of `badge_get(id)` -- `id_operand` is
+# whatever `int_expression` already reduced the argument to (a
+# `GqcIntOperand` or `IntExpression`); `IntExpression.get_result_symbol`
+# lowers it by delegating straight to the existing unary-`badge_get`
+# codegen path (see the `GqcHaveMetOperand` branch there).
+GqcHaveMetOperand = namedtuple('GqcHaveMetOperand', 'id_operand')
+
+# `in_cohort(NAME, id)` -- `NAME` is resolved against `Cohort.cohort_table`
+# at parse time (`parser.parse_in_cohort_operand`); `lo`/`hi` are that
+# cohort's own already-validated bounds (plain `int`s, not `GqcIntOperand`s
+# -- there's no register/variable to reference, just two compile-time
+# constants), so this lowers to a bare `(id_operand >= lo) && (id_operand
+# <= hi)` range compare over the *existing* `GE`/`LE`/`AND` opcodes -- see
+# the `GqcInCohortOperand` branches of `fold_constant_int_expression` (this
+# one folds if `id_operand` does) and `IntExpression.get_result_symbol`.
+GqcInCohortOperand = namedtuple('GqcInCohortOperand', 'id_operand lo hi')
+
+# `count_seen(NAME)` -- like `GqcInCohortOperand`, `lo`/`hi` are `NAME`'s
+# own resolved `Cohort` bounds. Lowers to a `badge_get` popcount loop
+# bounded to `[lo, hi]` instead of `badge_count()`'s full `[0,
+# BADGES_ALLOWED)` sweep -- see `IntExpression._emit_count_seen_range`.
+# Reads live badge state, not a constant, so -- like `GqcBadgeCountOperand`
+# -- this never folds even when `lo`/`hi` are themselves compile-time
+# constants (they always are).
+GqcCountSeenRangeOperand = namedtuple('GqcCountSeenRangeOperand', 'lo hi')
+
 class Game:
     link_table = dict() # OrderedDict not needed to remember order since Python 3.7
     game_name : str = None
@@ -829,6 +868,48 @@ class Menu:
         self.addr = structs.gq_ptr_apply_ns(namespace, addr)
         Menu.link_table[self.addr] = self
 
+class Cohort:
+    """A `cohort NAME = <lo>..<hi>;` declaration (gamequeer#423, DEF CON
+    sprint epic gamequeer#419): a named, inclusive player-ID range, resolved
+    entirely at compile time (`cohort_table` is a compiler-only symbol
+    table, consulted by `parser.parse_in_cohort_operand`/
+    `parse_count_seen_operand`). Unlike `Menu`/`LightCue`/`Animation`, a
+    cohort has no on-cart footprint of its own -- it never appears in the
+    compiled `.gqgame` at all, only as the already-resolved `lo`/`hi`
+    literals baked into the range-compare/bounded-popcount codegen its
+    references desugar to (see `GqcInCohortOperand`/
+    `GqcCountSeenRangeOperand` in this module). No `addr`, `set_addr`, or
+    `to_bytes` -- there's nothing to link or serialize.
+
+    `lo`/`hi` are bounded to `[0, BADGES_ALLOWED)` -- the same bound the
+    badges-seen bitfield itself uses (`structs.BADGES_ALLOWED`) -- not just
+    because `count_seen(NAME)` walks that bitfield directly, but so a
+    cohort declared partly or wholly outside it doesn't silently behave as
+    "always empty" for that usage instead of failing to compile.
+    """
+
+    cohort_table = dict()
+
+    def __init__(self, name: str, lo: int, hi: int):
+        if name in Cohort.cohort_table:
+            raise ValueError(f"Cohort {name} already defined")
+        if lo > hi:
+            raise ValueError(f"Cohort {name} has an empty/invalid range {lo}..{hi} (lo must be <= hi)")
+        if lo < 0 or hi >= structs.BADGES_ALLOWED:
+            raise ValueError(
+                f"Cohort {name} range {lo}..{hi} is out of bounds for the badges-seen "
+                f"bitfield (valid player IDs are 0..{structs.BADGES_ALLOWED - 1})"
+            )
+
+        self.name = name
+        self.lo = lo
+        self.hi = hi
+
+        Cohort.cohort_table[name] = self
+
+    def __repr__(self) -> str:
+        return f"Cohort({self.name}, {self.lo}..{self.hi})"
+
 class LightCue:
     link_table = dict() # OrderedDict not needed to remember order since Python 3.7
     cue_table = dict()
@@ -1008,10 +1089,12 @@ def fold_constant_int_expression(node):
     from the VM's actual runtime behavior:
       - any operand references a variable or a register, rather than being
         a literal;
-      - the operator is `badge_get`, or the node is a `badge_count()` call
-        -- both read live badge state, not a constant, regardless of
-        whether `badge_get`'s own operand is a literal (`badge_count()`
-        never has one);
+      - the operator is `badge_get`, or the node is a `badge_count()`,
+        `have_met(id)`, or `count_seen(NAME)` call -- all read live badge
+        state, not a constant, regardless of whether their own operand (if
+        any) is a literal (`in_cohort(NAME, id)`, gamequeer#423, is the one
+        exception: it's a pure range compare with no badge state involved,
+        so it folds whenever `id` does);
       - a `/` or `%` whose literal divisor is 0 -- the VM leaves this
         unguarded at runtime (see `run_arithmetic`), so folding it would
         turn a runtime behavior into either a compile-time crash or a
@@ -1051,6 +1134,29 @@ def fold_constant_int_expression(node):
         # `len() == 0`), but that's incidental; this is the intentional,
         # explicit no-fold.
         return None
+
+    if isinstance(node, GqcHaveMetOperand):
+        # have_met(id) is a bare rename of badge_get(id) (gamequeer#423) --
+        # reads live badge state, not a constant, regardless of whether
+        # `id_operand` itself is a literal. Same reasoning as badge_get
+        # below.
+        return None
+
+    if isinstance(node, GqcCountSeenRangeOperand):
+        # count_seen(NAME) reads live badge state the same way badge_count()
+        # does, just bounded to NAME's own range (gamequeer#423) -- never a
+        # constant, even though `lo`/`hi` themselves always are.
+        return None
+
+    if isinstance(node, GqcInCohortOperand):
+        # in_cohort(NAME, id) is a pure `(id >= lo) && (id <= hi)` range
+        # compare (gamequeer#423) -- unlike badge_get/badge_count/
+        # count_seen, it never touches live badge state, so it folds
+        # whenever `id_operand` itself does.
+        id_value = fold_constant_int_expression(node.id_operand)
+        if id_value is None:
+            return None
+        return int(node.lo <= id_value <= node.hi)
 
     # The remaining shape is a raw `[operand, op, operand]` / `[op, operand]`
     # token group -- a plain `list` when built by this module's own
@@ -1195,16 +1301,49 @@ class IntExpression:
             # call subexpr[0] bare, not wrapped in a list) -- gamequeer#387.
             return self._emit_badge_count()
 
+        if isinstance(subexpr, GqcHaveMetOperand):
+            # have_met(id) (gamequeer#423) is a bare rename of badge_get(id)
+            # -- delegate straight to the existing unary-badge_get codegen
+            # path by handing it the exact same ['badge_get', operand] shape
+            # infix_notation itself would produce for a literal `badge_get`
+            # invocation, rather than duplicating that branch's logic here.
+            return self.get_result_symbol(['badge_get', subexpr.id_operand])
+
+        if isinstance(subexpr, GqcInCohortOperand):
+            # in_cohort(NAME, id) (gamequeer#423) is a bare `(id >= lo) &&
+            # (id <= hi)` range compare -- delegate to the ordinary binary-op
+            # branches below via the same raw [operand, op, operand] shape a
+            # hand-written `id >= lo && id <= hi` would produce, reusing the
+            # existing GE/LE/AND opcodes instead of a dedicated range-check
+            # op. `subexpr.id_operand` is referenced twice (once per side of
+            # the `&&`); if it's an already-built IntExpression, the
+            # IntExpression-unwrap branch above runs once per reference,
+            # safely re-deriving it under this expression's own register
+            # pool each time (see unregister_orphaned_commands's docstring) at
+            # the cost of evaluating it twice at runtime -- acceptable for a
+            # side-effect-free int expression, the same tradeoff
+            # badge_count() used twice in one expression already accepts.
+            return self.get_result_symbol([
+                [subexpr.id_operand, '>=', GqcIntOperand(is_literal=True, value=subexpr.lo)],
+                '&&',
+                [subexpr.id_operand, '<=', GqcIntOperand(is_literal=True, value=subexpr.hi)],
+            ])
+
+        if isinstance(subexpr, GqcCountSeenRangeOperand):
+            # count_seen(NAME) (gamequeer#423) -- a badge_count()-style
+            # popcount loop bounded to NAME's own [lo, hi] range.
+            return self._emit_count_seen_range(subexpr.lo, subexpr.hi)
+
         if isinstance(subexpr, GqcIntOperand):
             return subexpr
         elif len(subexpr) == 1:
-            # subexpr[0] may itself be a bare GqcBadgeCountOperand -- e.g.
-            # the sole atom of "x = badge_count();", which
-            # parser.parse_int_expression wraps as
-            # IntExpression([GqcBadgeCountOperand()], ...). Recurse instead
-            # of handing it back unresolved; every other len-1 shape here is
-            # already a GqcIntOperand (or an IntExpression to unwrap), so
-            # this recursion is a no-op passthrough for them.
+            # subexpr[0] may itself be a bare GqcBadgeCountOperand (or one of
+            # the gamequeer#423 markers above) -- e.g. the sole atom of
+            # "x = badge_count();", which parser.parse_int_expression wraps
+            # as IntExpression([GqcBadgeCountOperand()], ...). Recurse
+            # instead of handing it back unresolved; every other len-1 shape
+            # here is already a GqcIntOperand (or an IntExpression to
+            # unwrap), so this recursion is a no-op passthrough for them.
             return self.get_result_symbol(subexpr[0])
         elif len(subexpr) > 3:
             raise ValueError(f"Invalid subexpression length {len(subexpr)}: should be [operand, operator, operand] or [operator operand]")
@@ -1333,6 +1472,80 @@ class IntExpression:
         # built; acc is this method's result and stays allocated, exactly
         # like a unary op's freshly-allocated destination register does at
         # this same point in the len(subexpr) == 2 branch above.
+        self.free_register(bit_reg)
+        self.free_register(idx_reg)
+
+        return acc_operand
+
+    def _emit_count_seen_range(self, lo: int, hi: int) -> GqcIntOperand:
+        """Lower a `count_seen(NAME)` leaf (gamequeer#423) to a runtime
+        popcount loop over `badge_get`, bounded to the inclusive `[lo, hi]`
+        range instead of `_emit_badge_count`'s full `[0, BADGES_ALLOWED)`
+        sweep -- `lo`/`hi` are `NAME`'s own `Cohort`-validated bounds, so
+        `0 <= lo <= hi < BADGES_ALLOWED` always holds here.
+
+        Same "count the loop variable down to a bare truthiness check"
+        strategy as `_emit_badge_count`, generalized with a compile-time
+        constant `lo` offset: `idx` counts down from `hi - lo + 1` (the
+        range's own size) to 0 -- so the loop-continue test is still just
+        `idx`'s own truthiness, no extra comparison register -- while the
+        actual badge id passed to `badge_get` is computed into `bit_reg` as
+        `idx + lo` before the `QCGET` overwrites it with the read result
+        (`QCGET`'s own dst/src *may* be the same register: the VM's
+        `run_arithmetic` always reads `arg2` into a local before writing
+        `arg1`, so this self-referential form is safe -- see
+        `gamequeer/src/bytecode.c`). When `lo == 0` (e.g. a cohort starting
+        at badge id 0) the `idx + lo` computation is skipped entirely --
+        `idx` is already the badge id -- keeping that case's bytecode
+        identical in shape to `_emit_badge_count`'s own loop body.
+
+        Register cost: identical to `_emit_badge_count` -- 3 of gqc's 4
+        `GQ_REGISTERS_INT` (accumulator, counter, per-iteration scratch),
+        not 4, despite computing both a "how many left" counter and a
+        separate "which badge id" value -- the `idx + lo` computation
+        reuses the same scratch register `QCGET`'s result lands in rather
+        than allocating a dedicated one. Only the accumulator survives past
+        this method, same as `_emit_badge_count`.
+        """
+        from .commands import CommandSetInt, CommandArithmetic, CommandIf, CommandGoto, CommandLoop
+
+        acc_reg = self.alloc_register()
+        idx_reg = self.alloc_register()
+        acc_operand = GqcIntOperand(is_literal=False, value=acc_reg)
+        idx_operand = GqcIntOperand(is_literal=False, value=idx_reg)
+
+        self.commands.append(CommandSetInt(self.instring, self.loc, acc_reg, GqcIntOperand(is_literal=True, value=0)))
+        self.commands.append(CommandSetInt(self.instring, self.loc, idx_reg, GqcIntOperand(is_literal=True, value=hi - lo + 1)))
+
+        bit_reg = self.alloc_register()
+        bit_operand = GqcIntOperand(is_literal=False, value=bit_reg)
+
+        # while (idx) { idx -= 1; bit = idx [+ lo]; bit = badge_get(bit); acc += bit; }
+        decrement_and_accumulate = [
+            CommandArithmetic(structs.OpCode.SUBBY, self.instring, self.loc, idx_operand, GqcIntOperand(is_literal=True, value=1)),
+        ]
+        if lo == 0:
+            decrement_and_accumulate.append(
+                CommandArithmetic(structs.OpCode.QCGET, self.instring, self.loc, bit_operand, idx_operand)
+            )
+        else:
+            decrement_and_accumulate += [
+                CommandSetInt(self.instring, self.loc, bit_reg, idx_operand),
+                CommandArithmetic(structs.OpCode.ADDBY, self.instring, self.loc, bit_operand, GqcIntOperand(is_literal=True, value=lo)),
+                CommandArithmetic(structs.OpCode.QCGET, self.instring, self.loc, bit_operand, bit_operand),
+            ]
+        decrement_and_accumulate.append(
+            CommandArithmetic(structs.OpCode.ADDBY, self.instring, self.loc, acc_operand, bit_operand)
+        )
+        guarded_body = [
+            CommandIf(
+                self.instring, self.loc, idx_operand,
+                decrement_and_accumulate,
+                [CommandGoto(self.instring, self.loc, form='break')],
+            )
+        ]
+        self.commands.append(CommandLoop(self.instring, self.loc, guarded_body))
+
         self.free_register(bit_reg)
         self.free_register(idx_reg)
 

--- a/gqc/src/gqc/datamodel.py
+++ b/gqc/src/gqc/datamodel.py
@@ -1157,6 +1157,95 @@ def fold_constant_int_expression(node):
 
     return result if _fits_t_gq_int(result) else None
 
+# --- named compile-time constants and enums (gamequeer#421) ------------------
+# `const NAME = <int-expression>;` and `enum Name { A, B, C }` are pure
+# compile-time sugar: every reference gqc emits is *already* the literal
+# int value substituted in at parse time (see parser.parse_int_operand and
+# parser.parse_enum_member_operand, below), by construction the exact same
+# GqcIntOperand shape a bare int literal produces -- so there is nothing
+# new for the linker or the VM to do with them (FROZEN VM CONTRACT: no new
+# opcode, register, or on-cart format change).
+#
+# Scoping (the "keep it simple" decision gamequeer#421 asks for): a single
+# flat, file-global namespace, resolved eagerly in source order -- a
+# `const`/`enum` must be declared *before* its first use, like a `#define`
+# in a single-pass C preprocessor. This is a deliberate departure from
+# ordinary variable/stage/animation references, which *are*
+# forward-reference-tolerant (see linker.py's multi-pass resolve sweep):
+# those all keep a name unresolved until link time, but a constant has no
+# runtime representation to stay unresolved *as* -- it has to already be a
+# literal by the time its use is parsed. gqc does not run a separate
+# constant-only pre-pass to lift this restriction; that's left as a
+# possible future enhancement if declare-before-use ever proves too
+# restrictive in practice.
+
+
+class Constant:
+    """A named compile-time integer constant (`const NAME = <int-expr>;`).
+
+    `const_table` is also where `Enum` registers each of its members, under
+    the composite key `"EnumName.Member"` (see `Enum.define`, below) --
+    that key can never collide with a plain `const` name because the
+    grammar's bare `identifier` token can't contain a `.`, so one flat
+    dict safely serves both forms and gives them a single shared
+    duplicate-name check.
+    """
+
+    const_table: dict[str, int] = {}
+
+    @classmethod
+    def define(cls, name: str, value: int) -> None:
+        if name in cls.const_table:
+            raise ValueError(f"Duplicate definition of constant {name}")
+        if not _fits_t_gq_int(value):
+            raise ValueError(
+                f"Constant {name} value {value} is out of range for a "
+                "32-bit int (t_gq_int)"
+            )
+        cls.const_table[name] = value
+
+
+class Enum:
+    """`enum Name { A, B, C }`: a named group of compile-time int constants,
+    auto-numbered from 0 in declaration order, referenced as `Name.Member`.
+
+    An enum is just sugar for a block of `const`s that share a name prefix
+    and get their values auto-assigned -- each member is registered into
+    `Constant.const_table` (under `"Name.Member"`) exactly as if the user
+    had written `const Name.Member = <index>;` themselves, so lookup,
+    duplicate-name rejection, and range-checking all reuse Constant's own
+    machinery rather than duplicating it.
+    """
+
+    enum_table: dict[str, list[str]] = {}
+
+    @classmethod
+    def define(cls, name: str, members: list[str]) -> None:
+        if name in cls.enum_table:
+            raise ValueError(f"Duplicate definition of enum {name}")
+
+        seen = set()
+        for member in members:
+            if member in seen:
+                raise ValueError(f"Duplicate member {member} in enum {name}")
+            seen.add(member)
+
+        cls.enum_table[name] = list(members)
+        for index, member in enumerate(members):
+            # Can't collide with Constant.define's own duplicate check
+            # (distinct enum names give distinct composite keys), so the
+            # only way this raises is the _fits_t_gq_int range check --
+            # unreachable in practice (it would take over 2**31 members).
+            Constant.define(f"{name}.{member}", index)
+
+    @classmethod
+    def get_member_value(cls, enum_name: str, member_name: str) -> int:
+        if enum_name not in cls.enum_table:
+            raise ValueError(f"Unknown enum {enum_name}")
+        if member_name not in cls.enum_table[enum_name]:
+            raise ValueError(f"Unknown member {member_name} of enum {enum_name}")
+        return Constant.const_table[f"{enum_name}.{member_name}"]
+
 class IntExpression:
     def __init__(self, expression_toks : list[GqcIntOperand], instring, loc):
         self.expression_toks = expression_toks

--- a/gqc/src/gqc/datamodel.py
+++ b/gqc/src/gqc/datamodel.py
@@ -44,6 +44,22 @@ GqcStrCastOperand = namedtuple('GqcStrCastOperand', 'int_expr')
 # same role `GqcStrCastOperand` plays for an inline `str(x)` cast.
 GqcBadgeCountOperand = namedtuple('GqcBadgeCountOperand', [])
 
+# random(lo, hi), min(a, b), max(a, b), clamp(x, lo, hi), abs(x) --
+# gamequeer#422's math intrinsics. Same role as `GqcBadgeCountOperand`
+# above: each carries its own (already-parsed, i.e. each field is itself a
+# `GqcIntOperand` or `IntExpression`) argument sub-expressions, but -- like
+# `badge_count()` -- can never be handed back as-is as a subexpression's
+# result; `parser.parse_random_operand`/`parse_min_operand`/
+# `parse_max_operand`/`parse_clamp_operand`/`parse_abs_operand` build these,
+# and `IntExpression.get_result_symbol` (`_emit_random`/`_emit_minmax`/
+# `_emit_clamp`/`_emit_abs`) lowers them to real arithmetic/compare ops.
+# `want_max` lets min() and max() share one marker/one lowering method
+# (`_emit_minmax`) since they're identical but for that one comparison sense.
+GqcRandomOperand = namedtuple('GqcRandomOperand', 'lo hi')
+GqcMinMaxOperand = namedtuple('GqcMinMaxOperand', 'a b want_max')
+GqcClampOperand = namedtuple('GqcClampOperand', 'x lo hi')
+GqcAbsOperand = namedtuple('GqcAbsOperand', 'x')
+
 class Game:
     link_table = dict() # OrderedDict not needed to remember order since Python 3.7
     game_name : str = None
@@ -67,6 +83,18 @@ class Game:
         # probe's BGDONE/TIMER race -- when this is True, so a game that
         # never calls fw_version() has zero footprint from this feature.
         self.needs_fw_probe = False
+
+        # Set by parser.parse_random_operand the first time a game calls
+        # random() (gamequeer#422). linker.create_random_state_variables
+        # only creates the hidden LCG state/counter variables when this is
+        # True, so a game that never calls random() has zero footprint from
+        # this feature. Deferred until after parsing completes (same reason
+        # as needs_fw_probe/inject_fw_version_probe above): creating those
+        # variables eagerly, the first time random() is *parsed*, could run
+        # ahead of a `volatile { ... }` section appearing later in the same
+        # source file and falsely trip its one-declaration-per-game check
+        # (parser.parse_variable_definition_storageclass).
+        self.needs_random = False
 
         if Game.game is not None:
             raise ValueError("Game already defined")
@@ -1065,6 +1093,51 @@ def fold_constant_int_expression(node):
         # explicit no-fold.
         return None
 
+    if isinstance(node, GqcRandomOperand):
+        # random() reads (and mutates) live LCG state seeded from
+        # GQI_PLAYER_ID and a per-call counter, not a constant -- same
+        # no-fold reasoning as badge_get/badge_count() above (gamequeer#422).
+        # Explicit rather than left to duck-typing: `GqcRandomOperand` has 2
+        # fields, the same length `node_len` a couple of lines down treats
+        # as a valid `[operand, op, operand]` shape's arity minus one --
+        # relying on that coincidence to decline would be fragile.
+        return None
+
+    if isinstance(node, GqcAbsOperand):
+        # abs(x) (gamequeer#422): folds when its argument does, same as any
+        # other unary op. Declines (like the shift-amount/overflow guards
+        # below) when the result wouldn't fit t_gq_int -- e.g. abs(INT32_MIN)
+        # is 2**31, one past T_GQ_INT_MAX.
+        value = fold_constant_int_expression(node.x)
+        if value is None:
+            return None
+        result = abs(value)
+        return result if _fits_t_gq_int(result) else None
+
+    if isinstance(node, GqcMinMaxOperand):
+        # min(a, b)/max(a, b) (gamequeer#422): fold when both arguments do.
+        # Always representable -- the result is exactly one of the two
+        # already-representable inputs, never a new computed value.
+        left = fold_constant_int_expression(node.a)
+        right = fold_constant_int_expression(node.b)
+        if left is None or right is None:
+            return None
+        return max(left, right) if node.want_max else min(left, right)
+
+    if isinstance(node, GqcClampOperand):
+        # clamp(x, lo, hi) (gamequeer#422): fold when all three arguments
+        # do, via the exact same min(max(x, lo), hi) composition
+        # `IntExpression._emit_clamp` lowers to at runtime -- so a folded
+        # result can never diverge from what the unfolded bytecode would
+        # have computed for lo > hi (an out-of-contract but not rejected
+        # input; see _emit_clamp's docstring).
+        x = fold_constant_int_expression(node.x)
+        lo = fold_constant_int_expression(node.lo)
+        hi = fold_constant_int_expression(node.hi)
+        if x is None or lo is None or hi is None:
+            return None
+        return min(max(x, lo), hi)
+
     # The remaining shape is a raw `[operand, op, operand]` / `[op, operand]`
     # token group -- a plain `list` when built by this module's own
     # left-fold recursion (parser.parse_int_expression), or a pyparsing
@@ -1208,16 +1281,36 @@ class IntExpression:
             # call subexpr[0] bare, not wrapped in a list) -- gamequeer#387.
             return self._emit_badge_count()
 
+        # random()/min()/max()/clamp()/abs() (gamequeer#422) leaves reached
+        # directly, same "one operand of a binary op hands this bare"
+        # reasoning as badge_count() above. These checks have to come before
+        # the generic length-based dispatch below: each marker's own field
+        # count (2 for GqcRandomOperand, 3 for GqcMinMaxOperand/
+        # GqcClampOperand, 1 for GqcAbsOperand) would otherwise coincide with
+        # a real `[operand, operator, operand]`/`[operator, operand]`/bare-
+        # atom shape and get silently (and wrongly) unpacked as one.
+        if isinstance(subexpr, GqcRandomOperand):
+            return self._emit_random(subexpr.lo, subexpr.hi)
+
+        if isinstance(subexpr, GqcMinMaxOperand):
+            return self._emit_minmax(subexpr.a, subexpr.b, subexpr.want_max)
+
+        if isinstance(subexpr, GqcClampOperand):
+            return self._emit_clamp(subexpr.x, subexpr.lo, subexpr.hi)
+
+        if isinstance(subexpr, GqcAbsOperand):
+            return self._emit_abs(subexpr.x)
+
         if isinstance(subexpr, GqcIntOperand):
             return subexpr
         elif len(subexpr) == 1:
-            # subexpr[0] may itself be a bare GqcBadgeCountOperand -- e.g.
-            # the sole atom of "x = badge_count();", which
-            # parser.parse_int_expression wraps as
-            # IntExpression([GqcBadgeCountOperand()], ...). Recurse instead
-            # of handing it back unresolved; every other len-1 shape here is
-            # already a GqcIntOperand (or an IntExpression to unwrap), so
-            # this recursion is a no-op passthrough for them.
+            # subexpr[0] may itself be a bare GqcBadgeCountOperand (or one
+            # of the gamequeer#422 markers above) -- e.g. the sole atom of
+            # "x = badge_count();", which parser.parse_int_expression wraps
+            # as IntExpression([GqcBadgeCountOperand()], ...). Recurse
+            # instead of handing it back unresolved; every other len-1 shape
+            # here is already a GqcIntOperand (or an IntExpression to
+            # unwrap), so this recursion is a no-op passthrough for them.
             return self.get_result_symbol(subexpr[0])
         elif len(subexpr) > 3:
             raise ValueError(f"Invalid subexpression length {len(subexpr)}: should be [operand, operator, operand] or [operator operand]")
@@ -1350,6 +1443,230 @@ class IntExpression:
         self.free_register(idx_reg)
 
         return acc_operand
+
+    def _emit_negate_if_negative(self, operand : GqcIntOperand):
+        """Emit `if (operand < 0) { operand = -operand; }` in place, i.e.
+        the abs()-by-comparison idiom the game corpus already hand-rolls
+        (e.g. donsol.gq's `if (lcg < 0) { lcg = -lcg; }` seed
+        normalization) -- shared by `_emit_random` and `_emit_abs`
+        (gamequeer#422).
+
+        `operand` may be any writable variable or register (its own
+        register, if it's one, is untouched by this method -- the caller
+        keeps owning it). A `<` comparison can't test `operand < 0` in
+        place without clobbering `operand` itself (every `CommandArithmetic`
+        op, comparisons included, overwrites its own destination), so this
+        allocates one scratch register for the comparison snapshot/result,
+        freed again before returning.
+        """
+        from .commands import CommandSetInt, CommandArithmetic, CommandIf
+
+        cmp_reg = self.alloc_register()
+        cmp_operand = GqcIntOperand(is_literal=False, value=cmp_reg)
+        self.commands.append(CommandSetInt(self.instring, self.loc, cmp_reg, operand))
+        self.commands.append(CommandArithmetic(structs.OpCode.LT, self.instring, self.loc, cmp_operand, GqcIntOperand(is_literal=True, value=0)))
+        self.commands.append(CommandIf(
+            self.instring, self.loc, cmp_operand,
+            [CommandArithmetic(structs.OpCode.NEG, self.instring, self.loc, operand, operand)],
+        ))
+        self.free_register(cmp_reg)
+
+    def _emit_random(self, lo, hi) -> GqcIntOperand:
+        """Lower a `random(lo, hi)` leaf (gamequeer#422) to the exact
+        Park-Miller "minimal standard" LCG (multiplier
+        `structs.GQ_RANDOM_LCG_MULTIPLIER`, modulus
+        `structs.GQ_RANDOM_LCG_MODULUS` = 2**31 - 1) the game corpus already
+        hand-rolls at the source level -- see e.g. gq-games/games/donsol.gq's
+        card-shuffle `lcg` -- advanced via Schrage's method so the
+        multiply-by-48271 step never has to leave `t_gq_int`'s signed-32-bit
+        range. FROZEN VM CONTRACT: no dedicated opcode, no wider int type --
+        every step below is an existing `CommandArithmetic`/`CommandIf` op.
+
+        Seed convention: `structs.GQ_RANDOM_STATE_VAR` is the persisted LCG
+        state, carried across *every* `random()` call for the life of the
+        running cart (it's a volatile/heap variable, zero-initialized at
+        boot like any other -- see `linker.create_random_state_variables`).
+        Every call perturbs it with `GQI_PLAYER_ID * GQ_RANDOM_SEED_MULTIPLIER`
+        plus `structs.GQ_RANDOM_CTR_VAR`, a counter incremented on every call
+        -- donsol.gq's own seeding formula (`lcg = GQI_PLAYER_ID * 7919; lcg
+        = lcg + ctr; ...`), applied fresh on every call instead of once per
+        "run": two `random()` calls made back-to-back (or a fresh cart boot,
+        which resets the state back to 0) still diverge from each other,
+        rather than both landing on the same first draw. The perturbation
+        folds into the *previous* call's already-well-mixed state rather
+        than replacing it outright, so the full multiplicative recurrence's
+        statistical properties carry forward between calls; the seed
+        formula alone (without a continuously-advancing state) would just
+        be an arithmetic progression in the counter -- not what "the same
+        LCG donsol hand-rolls" means here.
+
+        Maps the result into the caller's *inclusive* `[lo, hi]` range via
+        `state % (hi - lo + 1) + lo`. Like every other gqc runtime `/`/`%`
+        (see `fold_constant_int_expression`'s zero-divisor case), `hi < lo`
+        (a non-positive range) is left undefined -- the author's
+        responsibility, not something gqc validates.
+
+        Register cost: up to 3 concurrently (one surviving the whole
+        method for `lo` if it's a non-literal sub-expression, one for the
+        `range = hi - lo + 1` accumulator, one scratch reused across the
+        seed-perturbation and Schrage-advance steps) -- plus whatever `lo`/
+        `hi` themselves need to resolve to a register. Same pre-existing
+        4-register-file limit `badge_count()` (gamequeer#387) and deep
+        arithmetic nesting already share.
+        """
+        from .commands import CommandSetInt, CommandArithmetic, CommandIf
+
+        state_operand = GqcIntOperand(is_literal=False, value=structs.GQ_RANDOM_STATE_VAR)
+        ctr_operand = GqcIntOperand(is_literal=False, value=structs.GQ_RANDOM_CTR_VAR)
+
+        lo_operand = self.get_result_symbol(lo)
+        hi_operand = self.get_result_symbol(hi)
+
+        # range = hi - lo + 1 (the caller's inclusive span). Computed into
+        #  its own register now, before hi_operand's register (if any) gets
+        #  freed below, and before lo_operand is needed again at the very
+        #  end -- both survive independently of the seed-perturbation/
+        #  Schrage-advance scratch work in between.
+        range_reg = self.alloc_register()
+        range_operand = GqcIntOperand(is_literal=False, value=range_reg)
+        self.commands.append(CommandSetInt(self.instring, self.loc, range_reg, hi_operand))
+        if not hi_operand.is_literal and hi_operand.value in structs.GQ_REGISTERS_INT:
+            self.free_register(hi_operand.value)
+        self.commands.append(CommandArithmetic(structs.OpCode.SUBBY, self.instring, self.loc, range_operand, lo_operand))
+        self.commands.append(CommandArithmetic(structs.OpCode.ADDBY, self.instring, self.loc, range_operand, GqcIntOperand(is_literal=True, value=1)))
+
+        # ctr += 1; state += GQI_PLAYER_ID * GQ_RANDOM_SEED_MULTIPLIER + ctr
+        #  -- the per-call seed perturbation (see docstring above).
+        self.commands.append(CommandArithmetic(structs.OpCode.ADDBY, self.instring, self.loc, ctr_operand, GqcIntOperand(is_literal=True, value=1)))
+        seed_reg = self.alloc_register()
+        seed_operand = GqcIntOperand(is_literal=False, value=seed_reg)
+        self.commands.append(CommandSetInt(self.instring, self.loc, seed_reg, GqcIntOperand(is_literal=False, value='GQI_PLAYER_ID')))
+        self.commands.append(CommandArithmetic(structs.OpCode.MULBY, self.instring, self.loc, seed_operand, GqcIntOperand(is_literal=True, value=structs.GQ_RANDOM_SEED_MULTIPLIER)))
+        self.commands.append(CommandArithmetic(structs.OpCode.ADDBY, self.instring, self.loc, seed_operand, ctr_operand))
+        self.commands.append(CommandArithmetic(structs.OpCode.ADDBY, self.instring, self.loc, state_operand, seed_operand))
+
+        # if (state < 0) { state = -state; }
+        self._emit_negate_if_negative(state_operand)
+
+        # state = state % (GQ_RANDOM_LCG_MODULUS - 1) + 1 -- normalize into
+        #  [1, modulus - 1], the valid nonzero-seed domain for the
+        #  multiplicative step below.
+        self.commands.append(CommandArithmetic(structs.OpCode.MODBY, self.instring, self.loc, state_operand, GqcIntOperand(is_literal=True, value=structs.GQ_RANDOM_LCG_MODULUS - 1)))
+        self.commands.append(CommandArithmetic(structs.OpCode.ADDBY, self.instring, self.loc, state_operand, GqcIntOperand(is_literal=True, value=1)))
+
+        # One step of Schrage's method for state = (multiplier * state) mod
+        #  modulus -- avoids the 32-bit signed overflow a direct
+        #  `multiplier * state` would hit for state values near the top of
+        #  its range. seed_reg is reused here as pure scratch; its
+        #  perturbation-term value from above is no longer needed.
+        self.commands.append(CommandSetInt(self.instring, self.loc, seed_reg, state_operand))
+        self.commands.append(CommandArithmetic(structs.OpCode.DIVBY, self.instring, self.loc, seed_operand, GqcIntOperand(is_literal=True, value=structs.GQ_RANDOM_LCG_Q)))
+        self.commands.append(CommandArithmetic(structs.OpCode.MODBY, self.instring, self.loc, state_operand, GqcIntOperand(is_literal=True, value=structs.GQ_RANDOM_LCG_Q)))
+        self.commands.append(CommandArithmetic(structs.OpCode.MULBY, self.instring, self.loc, state_operand, GqcIntOperand(is_literal=True, value=structs.GQ_RANDOM_LCG_MULTIPLIER)))
+        self.commands.append(CommandArithmetic(structs.OpCode.MULBY, self.instring, self.loc, seed_operand, GqcIntOperand(is_literal=True, value=structs.GQ_RANDOM_LCG_R)))
+        self.commands.append(CommandArithmetic(structs.OpCode.SUBBY, self.instring, self.loc, state_operand, seed_operand))
+
+        # if (state <= 0) { state = state + GQ_RANDOM_LCG_MODULUS; }
+        self.commands.append(CommandSetInt(self.instring, self.loc, seed_reg, state_operand))
+        self.commands.append(CommandArithmetic(structs.OpCode.LE, self.instring, self.loc, seed_operand, GqcIntOperand(is_literal=True, value=0)))
+        self.commands.append(CommandIf(
+            self.instring, self.loc, seed_operand,
+            [CommandArithmetic(structs.OpCode.ADDBY, self.instring, self.loc, state_operand, GqcIntOperand(is_literal=True, value=structs.GQ_RANDOM_LCG_MODULUS))],
+        ))
+        self.free_register(seed_reg)
+
+        # Map the now-uniform [1, modulus - 1] state into the caller's
+        #  inclusive [lo, hi] range, into a fresh result register -- NOT
+        #  back into state_operand itself, which must keep carrying its
+        #  full-quality Schrage output forward into the *next* random()
+        #  call, not the (likely much smaller, range-biased) mapped result.
+        result_reg = self.alloc_register()
+        result_operand = GqcIntOperand(is_literal=False, value=result_reg)
+        self.commands.append(CommandSetInt(self.instring, self.loc, result_reg, state_operand))
+        self.commands.append(CommandArithmetic(structs.OpCode.MODBY, self.instring, self.loc, result_operand, range_operand))
+        self.free_register(range_reg)
+        self.commands.append(CommandArithmetic(structs.OpCode.ADDBY, self.instring, self.loc, result_operand, lo_operand))
+        if not lo_operand.is_literal and lo_operand.value in structs.GQ_REGISTERS_INT:
+            self.free_register(lo_operand.value)
+
+        return result_operand
+
+    def _emit_minmax(self, a, b, want_max : bool) -> GqcIntOperand:
+        """Lower a `min(a, b)`/`max(a, b)` leaf (gamequeer#422) to a
+        compare-and-conditionally-overwrite: `result = a; if (want_max ?
+        b > result : b < result) { result = b; }` -- existing
+        `CommandArithmetic`/`CommandIf` ops only, no dedicated opcode.
+        Shared by both `min()` and `max()` (`_emit_random`'s dispatch in
+        `get_result_symbol` picks `want_max` from `GqcMinMaxOperand`), since
+        they're identical but for that one comparison sense.
+        """
+        from .commands import CommandSetInt, CommandArithmetic, CommandIf
+
+        # a/b are whatever int_expression's own parse action already
+        # produced for random()/min()/max()/clamp()'s arguments -- a
+        # GqcIntOperand *or* an independently-register-allocated
+        # IntExpression (e.g. the "a + 1" in "min(a + 1, b)"). Reduce each
+        # through get_result_symbol (like every other binary op's own
+        # operands) to fold it under *this* expression's shared register
+        # pool, rather than embedding its own separate expression section --
+        # see IntExpression.get_result_symbol's IntExpression-unwrap branch.
+        a = self.get_result_symbol(a)
+        b = self.get_result_symbol(b)
+
+        result_reg = self.alloc_register()
+        result_operand = GqcIntOperand(is_literal=False, value=result_reg)
+        self.commands.append(CommandSetInt(self.instring, self.loc, result_reg, a))
+        if not a.is_literal and a.value in structs.GQ_REGISTERS_INT:
+            self.free_register(a.value)
+
+        cmp_reg = self.alloc_register()
+        cmp_operand = GqcIntOperand(is_literal=False, value=cmp_reg)
+        self.commands.append(CommandSetInt(self.instring, self.loc, cmp_reg, b))
+        compare_op = structs.OpCode.GT if want_max else structs.OpCode.LT
+        self.commands.append(CommandArithmetic(compare_op, self.instring, self.loc, cmp_operand, result_operand))
+        self.commands.append(CommandIf(
+            self.instring, self.loc, cmp_operand,
+            [CommandSetInt(self.instring, self.loc, result_reg, b)],
+        ))
+        self.free_register(cmp_reg)
+        if not b.is_literal and b.value in structs.GQ_REGISTERS_INT:
+            self.free_register(b.value)
+
+        return result_operand
+
+    def _emit_clamp(self, x, lo, hi) -> GqcIntOperand:
+        """Lower a `clamp(x, lo, hi)` leaf (gamequeer#422) as
+        `min(max(x, lo), hi)`, composed directly from `_emit_minmax` --
+        matches `fold_constant_int_expression`'s `GqcClampOperand` folding,
+        which computes the same composition in Python, so a folded result
+        can never diverge from the unfolded bytecode's.
+
+        `hi < lo` (an empty/inverted range) is left undefined, same as
+        `_emit_random`'s `hi < lo` case -- the author's responsibility.
+        """
+        floored = self._emit_minmax(x, lo, want_max=True)
+        return self._emit_minmax(floored, hi, want_max=False)
+
+    def _emit_abs(self, x) -> GqcIntOperand:
+        """Lower an `abs(x)` leaf (gamequeer#422) as `result = x; if
+        (result < 0) { result = -result; }`, via the shared
+        `_emit_negate_if_negative` helper (also used by `_emit_random`'s
+        seed normalization) -- an existing `CommandArithmetic`/`CommandIf`
+        idiom, not a dedicated opcode.
+        """
+        from .commands import CommandSetInt
+
+        x = self.get_result_symbol(x)  # see _emit_minmax's a/b reduction comment
+
+        result_reg = self.alloc_register()
+        result_operand = GqcIntOperand(is_literal=False, value=result_reg)
+        self.commands.append(CommandSetInt(self.instring, self.loc, result_reg, x))
+        if not x.is_literal and x.value in structs.GQ_REGISTERS_INT:
+            self.free_register(x.value)
+
+        self._emit_negate_if_negative(result_operand)
+
+        return result_operand
 
     def resolve(self):
         if self.resolved:

--- a/gqc/src/gqc/datamodel.py
+++ b/gqc/src/gqc/datamodel.py
@@ -121,6 +121,12 @@ class Game:
     # see parse_fw_version_operand and Game.__init__ below.
     needs_fw_probe_seen = False
 
+    # Same hazard, same fix, for random() (gamequeer#422): set the first
+    # time any stage's event code calls random(), regardless of whether a
+    # Game instance exists yet -- see parse_random_operand and
+    # Game.__init__ below.
+    needs_random_seen = False
+
     def __init__(self, id : int, title : str, author : str, starting_stage : str = 'start'):
         self.addr = 0x00000000 # Set at link time
         self.stages = []
@@ -153,7 +159,12 @@ class Game:
         # ahead of a `volatile { ... }` section appearing later in the same
         # source file and falsely trip its one-declaration-per-game check
         # (parser.parse_variable_definition_storageclass).
-        self.needs_random = False
+        #
+        # Seeded from needs_random_seen rather than starting False, for the
+        # same gamequeer#420 reason as needs_fw_probe above: a random() call
+        # may already have been parsed (and recorded there) before this
+        # game{} block itself is reached.
+        self.needs_random = Game.needs_random_seen
 
         if Game.game is not None:
             raise ValueError("Game already defined")

--- a/gqc/src/gqc/gqc.py
+++ b/gqc/src/gqc/gqc.py
@@ -40,6 +40,13 @@ def mkcue(out_path : pathlib.Path, src_path : pathlib.Path):
 @click.argument('input', type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True, path_type=pathlib.Path), required=True)
 def compile(input : pathlib.Path, no_mem_map : bool, out_dir : pathlib.Path):
     Game.game_name = input.stem
+    # gamequeer#420: animations{}/lightcues{} asset sources resolve relative
+    # to the game's own directory (the entry file's parent), not the
+    # process CWD -- see Animation.src_path/parse_lightcue_definition_section.
+    # This is what makes `gqc compile some/other/dir/foo.gq` work correctly
+    # from outside that directory, and is a no-op for the common case where
+    # the entry file is already at the top of the invocation directory.
+    Game.game_dir = input.parent
 
     # output_path is the directory where the output of the project will be placed
     if out_dir is None:
@@ -82,6 +89,65 @@ def compile(input : pathlib.Path, no_mem_map : bool, out_dir : pathlib.Path):
     output_code = linker.generate_code(parsed, symbol_table)
     with open(out_dir / f'{Game.game_name}.gqgame', 'wb') as out_file:
         out_file.write(output_code)
+
+# gamequeer#420: the game-as-directory layout convention -- a game is a
+# directory whose entry file is `<dirname>/<dirname>.gq`, with its own
+# `assets/animations/`/`assets/lighting/` subdirectories that
+# animations{}/lightcues{} sources resolve against (see
+# Animation.src_path / parser.parse_lightcue_definition_section), instead
+# of a shared top-level `assets/` root. `new` scaffolds exactly that shape
+# so a freshly-created game is born correctly-structured.
+GAME_SKEL = """\
+game {
+    // TODO: pick a real cart id (unique per physical cartridge).
+    id = 0;
+    title := "GQC_NEW_TITLE";
+    author := "Your Name";
+    starting_stage = start;
+}
+
+stage start {
+    event enter {
+    }
+}
+"""
+
+@gqc_cli.command()
+@click.argument('name', type=str, required=True)
+@click.option('--out-dir', '-o', type=click.Path(file_okay=False, dir_okay=True, writable=True, path_type=pathlib.Path), default=None)
+@click.option('--force', '-f', is_flag=True)
+def new(name : str, out_dir : pathlib.Path, force : bool):
+    """Scaffold a new game directory NAME in the game-as-directory layout
+    (gamequeer#420): NAME/NAME.gq (a starter game{} block and a placeholder
+    `start` stage) plus NAME/assets/animations/ and NAME/assets/lighting/.
+
+    NAME's own directory is created under --out-dir (default: the current
+    directory)."""
+    base_dir = (out_dir if out_dir is not None else pathlib.Path.cwd()) / name
+    entry_path = base_dir / f'{name}.gq'
+
+    directory_tree = [
+        'assets/animations',
+        'assets/lighting',
+    ]
+
+    # Check to see if the game directory or entry file already exist
+    if base_dir.exists() and not force:
+        click.echo(f"Directory {base_dir} already exists; aborting.")
+        return
+    if entry_path.exists() and not force:
+        click.echo(f"File {entry_path} already exists; aborting.")
+        return
+
+    # Create the directory tree
+    for dir in directory_tree:
+        (base_dir / dir).mkdir(parents=True, exist_ok=True)
+
+    # Drop the starter entry file, unless one's already there and --force
+    # wasn't passed (checked above).
+    entry_path.write_text(GAME_SKEL.replace('GQC_NEW_TITLE', name))
+
+    click.echo(f"Created new game {name!r} at {base_dir}")
 
 @gqc_cli.command()
 @click.argument('base_dir', type=click.Path(file_okay=False, dir_okay=True, writable=True, path_type=pathlib.Path))

--- a/gqc/src/gqc/gqc.py
+++ b/gqc/src/gqc/gqc.py
@@ -68,6 +68,12 @@ def compile(input : pathlib.Path, no_mem_map : bool, out_dir : pathlib.Path):
     if Game.game.needs_fw_probe:
         linker.inject_fw_version_probe()
 
+    # Same zero-footprint-when-unused convention for random() (gamequeer#422):
+    # only create its hidden LCG state/counter variables if the game
+    # actually calls random() somewhere.
+    if Game.game.needs_random:
+        linker.create_random_state_variables()
+
     # Place symbols into the symbol table
     mem_map_path = out_dir / 'map.txt'
     cmd_asm_path = out_dir / 'cmds.gqasm'

--- a/gqc/src/gqc/grammar.py
+++ b/gqc/src/gqc/grammar.py
@@ -7,13 +7,20 @@ from .parser import parse_menu_definition, parse_bound_menu, parse_play
 from .parser import parse_int_expression, parse_int_operand, parse_str_literal, parse_if
 from .parser import parse_str_expression, parse_string_cast_operand
 from .parser import parse_badge_count_operand
+from .parser import parse_cohort_definition, parse_have_met_operand, parse_in_cohort_operand, parse_count_seen_operand
 
 """
 Grammar for GQC language
 ========================
 
 program = game_definition_section declaration_section*
-declaration_section = var_definition_section | animation_definition_section | lightcue_definition_section | menu_definition_section | stage_definition_section
+declaration_section = var_definition_section | animation_definition_section | lightcue_definition_section | menu_definition_section | cohort_definition_section | stage_definition_section
+
+# cohort NAME = <lo>..<hi>; -- a declared, inclusive player-ID range,
+# resolved entirely at compile time (gamequeer#423, DEF CON sprint epic
+# gamequeer#419). No on-cart footprint; NAME is only ever consulted by
+# in_cohort()/count_seen() below.
+cohort_definition_section = "cohort" identifier "=" integer ".." integer ";"
 
 game_definition_section = "game" "{" game_assignment* "}"
 game_id_assignment = "id" "=" integer ";"
@@ -57,7 +64,7 @@ stage_event = "event" event_type event_statement
 event_type = "input" "(" event_input_button ")" | "bgdone" | "fgdone" "(" integer ")" | "menu" | "enter" | "timer"
 event_input_button = "A" | "B" | "<-" | "->" | "-"
 event_statements = event_statement | "{" event_statement* "}"
-event_statement = play | cue | gostage | assignment_statement | if_statement | timer | continue | break | loop | badge_set | badge_clear
+event_statement = play | cue | gostage | assignment_statement | if_statement | timer | continue | break | loop | badge_set | badge_clear | seen_self
 play = "play" ("bganim" | ("fganim" | "fgmask") "(" int ")") identifier ";"
 cue = "cue" identifier ";"
 gostage = "gostage" identifier ";"
@@ -67,6 +74,11 @@ break = "break" ";"
 loop = "loop" event_statements
 badge_set = "badge_set" int_expression ";"
 badge_clear = "badge_clear" int_expression ";"
+# seen_self() (gamequeer#423) desugars to the idiom copy-pasted verbatim
+# across several games: "if (badge_get(GQI_PLAYER_ID)==0) badge_set
+# GQI_PLAYER_ID;" -- mark this badge as having seen its own player ID,
+# exactly once.
+seen_self = "seen_self" "(" ")" ";"
 
 assignment_statement = int_assignment | string_assignment
 int_assignment = identifier "=" int_expression ";"
@@ -77,7 +89,7 @@ int_assignment = identifier "=" int_expression ";"
 # including str(x) appearing inside a "+" chain (gamequeer#386).
 string_assignment = identifier ":=" ((string_cast &";") | string_expression) ";"
 
-int_operand = badge_count_call | identifier | integer
+int_operand = badge_count_call | have_met_call | in_cohort_call | count_seen_call | identifier | integer
 string_cast = 'str' '(' int_expression ')'
 string_operand = identifier | string | string_cast
 
@@ -88,6 +100,20 @@ string_operand = identifier | string | string_cast
 # badge_get it takes an empty, mandatory parameter list, not a bare operand
 # form.
 badge_count_call = "badge_count" "(" ")"
+
+# The social vocabulary (gamequeer#423, DEF CON sprint epic gamequeer#419) --
+# a first-class desugaring over the same badge_get/badge_set/badge_count
+# intrinsics above, replacing hand-rolled range-compare chains and the
+# copy-pasted seen_self idiom (see seen_self above).
+#
+# have_met(id) is a bare rename of badge_get(id).
+have_met_call = "have_met" "(" int_expression ")"
+# in_cohort(NAME, id) desugars to "(id >= NAME.lo) && (id <= NAME.hi)";
+# NAME must already be declared by a cohort_definition_section above it.
+in_cohort_call = "in_cohort" "(" identifier "," int_expression ")"
+# count_seen() (no argument) is badge_count() itself; count_seen(NAME) is a
+# badge_count()-style popcount loop bounded to NAME's own declared range.
+count_seen_call = "count_seen" "(" [identifier] ")"
 
 # Shorthand; see https://stackoverflow.com/a/23956778
 # badge_get is a right-associative unary prefix operator, e.g. badge_get(x).
@@ -172,10 +198,30 @@ def build_game_parser():
 
     menu_definition.set_parse_action(parse_menu_definition)
 
+    # Cohort declarations (gamequeer#423, DEF CON sprint epic gamequeer#419):
+    # "cohort NAME = <lo>..<hi>;" -- a named, inclusive player-ID range,
+    # resolved entirely at compile time (Cohort.cohort_table). No on-cart
+    # footprint of its own; only in_cohort()/count_seen() below ever
+    # reference it. `lo`/`hi` are bare integer literals for now (gqc has no
+    # named-constant feature yet -- see gamequeer#421); once that lands,
+    # this is the one place that would need to switch to whatever operand
+    # rule #421 introduces.
+    cohort_definition_section = pp.Group(pp.Keyword("cohort") - identifier - pp.Suppress("=") - integer - pp.Suppress("..") - integer - pp.Suppress(";")).set_name("cohort_definition_section")
+    cohort_definition_section.set_parse_action(parse_cohort_definition)
+
     ### Stage sections ###
     event_statements = pp.Forward()
-    
+
     # Assignments and expressions
+    # int_expression is declared as a Forward here, ahead of int_operand,
+    # because two of the social-vocabulary call forms below (have_met_call,
+    # in_cohort_call) take an int_expression as their own argument -- the
+    # usual definition order (int_operand, then int_expression built on top
+    # of it via infix_notation) would be circular otherwise. Assigned via
+    # `<<` once int_operand is fully built, same pattern as event_statements
+    # above.
+    int_expression = pp.Forward()
+
     # badge_count() -- a nullary popcount intrinsic over the badges-seen
     # bitfield (gamequeer#387). Keyword("badge_count"), not a bare string,
     # so it doesn't swallow a `badge_count`-prefixed identifier
@@ -187,9 +233,37 @@ def build_game_parser():
     badge_count_call = pp.Group(pp.Keyword("badge_count") - pp.Suppress("(") - pp.Suppress(")")).set_name("badge_count_call")
     badge_count_call.set_parse_action(parse_badge_count_operand)
 
-    int_operand = badge_count_call | identifier | integer
+    # The social vocabulary (gamequeer#423, DEF CON sprint epic
+    # gamequeer#419) -- same Keyword()-commits-once-matched reasoning as
+    # badge_count_call above, so each fails with a clean
+    # ParseSyntaxException on a malformed argument list rather than falling
+    # through to some other interpretation.
+    #
+    # have_met(id) is a bare rename of badge_get(id) -- see
+    # parser.parse_have_met_operand / GqcHaveMetOperand.
+    have_met_call = pp.Group(pp.Keyword("have_met") - pp.Suppress("(") - int_expression - pp.Suppress(")")).set_name("have_met_call")
+    have_met_call.set_parse_action(parse_have_met_operand)
+
+    # in_cohort(NAME, id) desugars to "(id >= NAME.lo) && (id <= NAME.hi)"
+    # -- NAME is resolved against Cohort.cohort_table at parse time, so it
+    # must already have been declared by a cohort_definition_section above
+    # this point in the source. See parser.parse_in_cohort_operand /
+    # GqcInCohortOperand.
+    in_cohort_call = pp.Group(pp.Keyword("in_cohort") - pp.Suppress("(") - identifier - pp.Suppress(",") - int_expression - pp.Suppress(")")).set_name("in_cohort_call")
+    in_cohort_call.set_parse_action(parse_in_cohort_operand)
+
+    # count_seen() -- no argument -- is badge_count() itself (same
+    # GqcBadgeCountOperand marker, see parser.parse_count_seen_operand);
+    # count_seen(NAME) is a badge_count()-style popcount loop bounded to
+    # NAME's own declared range. pp.Optional(identifier), not
+    # pp.Optional(int_expression): a cohort reference is a bare name looked
+    # up at parse time, not a value-producing expression.
+    count_seen_call = pp.Group(pp.Keyword("count_seen") - pp.Suppress("(") - pp.Optional(identifier) - pp.Suppress(")")).set_name("count_seen_call")
+    count_seen_call.set_parse_action(parse_count_seen_operand)
+
+    int_operand = badge_count_call | have_met_call | in_cohort_call | count_seen_call | identifier | integer
     int_operand.set_parse_action(parse_int_operand)
-    int_expression = pp.infix_notation(int_operand, [
+    int_expression <<= pp.infix_notation(int_operand, [
         (pp.Keyword('badge_get') | pp.one_of('! - ~'), 1, pp.opAssoc.RIGHT),
         (pp.one_of('* / %'), 2, pp.opAssoc.LEFT),
         (pp.one_of('+ -'), 2, pp.opAssoc.LEFT),
@@ -243,6 +317,11 @@ def build_game_parser():
     # Other commands
     badge_set = pp.Group(pp.Keyword("badge_set") - int_expression - pp.Suppress(";"))
     badge_clear = pp.Group(pp.Keyword("badge_clear") - int_expression - pp.Suppress(";"))
+    # seen_self() (gamequeer#423) desugars to the copy-pasted-verbatim idiom
+    # "if (badge_get(GQI_PLAYER_ID)==0) badge_set GQI_PLAYER_ID;" -- see
+    # parser.parse_seen_self. Nullary, like badge_count(): mandatory empty
+    # parens, no bare-operand form.
+    seen_self = pp.Group(pp.Keyword("seen_self") - pp.Suppress("(") - pp.Suppress(")") - pp.Suppress(";")).set_name("seen_self")
 
     play_type = pp.Group(pp.Keyword("bganim") | (pp.Keyword("fganim") | pp.Keyword("fgmask")) - pp.Suppress("(") - integer - pp.Suppress(")"))
     play = pp.Group(pp.Keyword("play") - play_type - identifier - pp.Suppress(";"))
@@ -253,7 +332,7 @@ def build_game_parser():
     gostage = pp.Group(pp.Keyword("gostage") - identifier - pp.Suppress(";"))
     timer = pp.Group(pp.Keyword("timer") - int_expression - pp.Suppress(";"))
 
-    event_statement = badge_set | badge_clear | play | cue | gostage | timer | if_statement | continue_statement | break_statement | loop_statement | assignment_statement
+    event_statement = badge_set | badge_clear | seen_self | play | cue | gostage | timer | if_statement | continue_statement | break_statement | loop_statement | assignment_statement
     event_statements << (pp.Group(event_statement | pp.Suppress("{") - pp.ZeroOrMore(event_statement) - pp.Suppress("}")))
 
     event_statement.set_parse_action(parse_command)
@@ -278,7 +357,7 @@ def build_game_parser():
     stage_definition_section.set_parse_action(parse_stage_definition)
 
     # Finish up
-    gqc_game << game_definition_section - pp.ZeroOrMore(animation_definition_section | lightcue_definition_section | var_definition_section | menu_definition_section | stage_definition_section)
+    gqc_game << game_definition_section - pp.ZeroOrMore(animation_definition_section | lightcue_definition_section | var_definition_section | menu_definition_section | cohort_definition_section | stage_definition_section)
     gqc_game.ignore(pp.cppStyleComment)
 
     return gqc_game

--- a/gqc/src/gqc/grammar.py
+++ b/gqc/src/gqc/grammar.py
@@ -45,7 +45,18 @@ game_id_assignment = "id" "=" integer ";"
 game_title_assignment = "title" ":=" string ";"
 game_author_assignment = "author" ":=" string ";"
 game_starting_stage_assignment = "starting_stage" "=" identifier ";"
-game_assignment = game_id_assignment | game_title_assignment | game_author_assignment | game_starting_stage_assignment  # one of each, in any order
+game_assignment = game_id_assignment | game_title_assignment | game_author_assignment | game_starting_stage_assignment
+# `game_assignment*` is a plain repetition of the alternation above, in any
+# order -- not pyparsing's `&` ("each") operator. Each of the four keys is
+# still required exactly once, but (like game_definition_section itself
+# being exactly-one, gamequeer#420) that cardinality can't be expressed
+# structurally by a repetition, so it's enforced semantically instead, in
+# parser.parse_game_definition: a missing or duplicated key raises a
+# GqcParseError naming that specific key, rather than pyparsing's `&`
+# producing a generic "missing one or more required elements" message that
+# can't distinguish a duplicate `id` from a missing everything-else (see
+# gamequeer#331's investigation notes) or a bare ParseSyntaxException with
+# no semantic message at all.
 
 var_definition_section = ("volatile" | "persistent") var_definitions
 var_definitions = var_definition | "{" var_definition* "}"
@@ -188,8 +199,15 @@ def build_game_parser():
     game_title_assignment = pp.Group(pp.Keyword("title") - pp.Suppress(":=") - string - pp.Suppress(";")).set_name("title")
     game_author_assignment = pp.Group(pp.Keyword("author") - pp.Suppress(":=") - string - pp.Suppress(";")).set_name("author")
     game_starting_stage_assignment = pp.Group(pp.Keyword("starting_stage") - pp.Suppress("=") - identifier - pp.Suppress(";")).set_name("starting_stage")
-    game_assignment = pp.Group(game_id_assignment & game_title_assignment & game_author_assignment & game_starting_stage_assignment)
-    game_definition_section = pp.Group(pp.Keyword("game") - pp.Suppress("{") - game_assignment - pp.Suppress("}"))
+    # A plain repetition of the alternation, any number of times in any
+    # order -- not pp.Each (`&`), which can only ever produce a generic
+    # "missing one or more required elements" ParseException that can't
+    # name which key is missing/duplicated. parser.parse_game_definition
+    # validates "exactly one of each" itself and raises a GqcParseError
+    # naming the specific offending key (gamequeer#420 cardinality
+    # follow-up).
+    game_assignment = game_id_assignment | game_title_assignment | game_author_assignment | game_starting_stage_assignment
+    game_definition_section = pp.Group(pp.Keyword("game") - pp.Suppress("{") - pp.ZeroOrMore(game_assignment) - pp.Suppress("}"))
     game_definition_section.set_parse_action(parse_game_definition)
 
     # Variable sections

--- a/gqc/src/gqc/grammar.py
+++ b/gqc/src/gqc/grammar.py
@@ -13,8 +13,16 @@ from .parser import parse_fw_version_operand
 Grammar for GQC language
 ========================
 
-program = game_definition_section declaration_section*
-declaration_section = var_definition_section | animation_definition_section | lightcue_definition_section | menu_definition_section | stage_definition_section
+program = top_level_section*
+top_level_section = game_definition_section | var_definition_section | animation_definition_section | lightcue_definition_section | menu_definition_section | stage_definition_section
+# Exactly one game_definition_section is required, but (gamequeer#420) it
+# may appear anywhere in the top-level section stream, not just first --
+# pyparsing's repetition here can't itself enforce "exactly one" (a rule
+# about *how many* times an alternative matches across the whole
+# repetition, not about any single match), so that's a semantic check
+# instead: a second one is rejected by Game.__init__ (see
+# parser.parse_game_definition), and zero is rejected by parser.parse()
+# once the top-level repetition itself has finished matching.
 
 game_definition_section = "game" "{" game_assignment* "}"
 game_id_assignment = "id" "=" integer ";"
@@ -285,7 +293,13 @@ def build_game_parser():
     stage_definition_section.set_parse_action(parse_stage_definition)
 
     # Finish up
-    gqc_game << game_definition_section - pp.ZeroOrMore(animation_definition_section | lightcue_definition_section | var_definition_section | menu_definition_section | stage_definition_section)
+    #
+    # game_definition_section is just one more alternative in the top-level
+    # repetition (gamequeer#420) -- it's no longer structurally locked to
+    # being first. "Exactly one" is enforced semantically instead: see
+    # parser.parse_game_definition (a second one) and parser.parse()
+    # (zero) -- as well as the module docstring above.
+    gqc_game << pp.ZeroOrMore(game_definition_section | animation_definition_section | lightcue_definition_section | var_definition_section | menu_definition_section | stage_definition_section)
     gqc_game.ignore(pp.cppStyleComment)
 
     return gqc_game

--- a/gqc/src/gqc/grammar.py
+++ b/gqc/src/gqc/grammar.py
@@ -8,6 +8,8 @@ from .parser import parse_int_expression, parse_int_operand, parse_str_literal, 
 from .parser import parse_str_expression, parse_string_cast_operand
 from .parser import parse_badge_count_operand
 from .parser import parse_fw_version_operand
+from .parser import parse_random_operand, parse_min_operand, parse_max_operand
+from .parser import parse_clamp_operand, parse_abs_operand
 
 """
 Grammar for GQC language
@@ -175,8 +177,16 @@ def build_game_parser():
 
     ### Stage sections ###
     event_statements = pp.Forward()
-    
+
     # Assignments and expressions
+    # int_expression is forward-declared (same idiom as event_statements
+    # above) so the gamequeer#422 intrinsics below -- random()/min()/max()/
+    # clamp(), each of which takes one or more int_expression *arguments* --
+    # can reference it before int_operand (which they're themselves part of)
+    # is assembled a few lines down. Populated via "int_expression << ..."
+    # once int_operand is complete.
+    int_expression = pp.Forward()
+
     # badge_count() -- a nullary popcount intrinsic over the badges-seen
     # bitfield (gamequeer#387). Keyword("badge_count"), not a bare string,
     # so it doesn't swallow a `badge_count`-prefixed identifier
@@ -194,9 +204,33 @@ def build_game_parser():
     fw_version_call = pp.Group(pp.Keyword("fw_version") - pp.Suppress("(") - pp.Suppress(")")).set_name("fw_version_call")
     fw_version_call.set_parse_action(parse_fw_version_operand)
 
-    int_operand = badge_count_call | fw_version_call | identifier | integer
+    # random(lo, hi)/min(a, b)/max(a, b)/clamp(x, lo, hi)/abs(x) --
+    # gamequeer#422's math intrinsics. Same Keyword-not-bare-string
+    # reasoning as badge_count_call/fw_version_call above, so e.g. a
+    # `random`- or `min`-prefixed identifier isn't swallowed; same `-`-commits-
+    # on-keyword-match reasoning too, so a wrong argument count (or a bare,
+    # parens-less form -- unlike badge_get, none of these have one) fails
+    # with a clean, source-located ParseSyntaxException. Each takes one or
+    # more full int_expression arguments (like string_cast's `str(x)`
+    # above), not just a bare operand, so e.g. `min(a + 1, b)` is valid.
+    random_call = pp.Group(pp.Suppress(pp.Keyword("random")) - pp.Suppress("(") - int_expression - pp.Suppress(",") - int_expression - pp.Suppress(")")).set_name("random_call")
+    random_call.set_parse_action(parse_random_operand)
+
+    min_call = pp.Group(pp.Suppress(pp.Keyword("min")) - pp.Suppress("(") - int_expression - pp.Suppress(",") - int_expression - pp.Suppress(")")).set_name("min_call")
+    min_call.set_parse_action(parse_min_operand)
+
+    max_call = pp.Group(pp.Suppress(pp.Keyword("max")) - pp.Suppress("(") - int_expression - pp.Suppress(",") - int_expression - pp.Suppress(")")).set_name("max_call")
+    max_call.set_parse_action(parse_max_operand)
+
+    clamp_call = pp.Group(pp.Suppress(pp.Keyword("clamp")) - pp.Suppress("(") - int_expression - pp.Suppress(",") - int_expression - pp.Suppress(",") - int_expression - pp.Suppress(")")).set_name("clamp_call")
+    clamp_call.set_parse_action(parse_clamp_operand)
+
+    abs_call = pp.Group(pp.Suppress(pp.Keyword("abs")) - pp.Suppress("(") - int_expression - pp.Suppress(")")).set_name("abs_call")
+    abs_call.set_parse_action(parse_abs_operand)
+
+    int_operand = badge_count_call | fw_version_call | random_call | min_call | max_call | clamp_call | abs_call | identifier | integer
     int_operand.set_parse_action(parse_int_operand)
-    int_expression = pp.infix_notation(int_operand, [
+    int_expression << pp.infix_notation(int_operand, [
         (pp.Keyword('badge_get') | pp.one_of('! - ~'), 1, pp.opAssoc.RIGHT),
         (pp.one_of('* / %'), 2, pp.opAssoc.LEFT),
         (pp.one_of('+ -'), 2, pp.opAssoc.LEFT),

--- a/gqc/src/gqc/grammar.py
+++ b/gqc/src/gqc/grammar.py
@@ -251,10 +251,10 @@ def build_game_parser():
     # "cohort NAME = <lo>..<hi>;" -- a named, inclusive player-ID range,
     # resolved entirely at compile time (Cohort.cohort_table). No on-cart
     # footprint of its own; only in_cohort()/count_seen() below ever
-    # reference it. `lo`/`hi` are bare integer literals for now (gqc has no
-    # named-constant feature yet -- see gamequeer#421); once that lands,
-    # this is the one place that would need to switch to whatever operand
-    # rule #421 introduces.
+    # reference it. `lo`/`hi` are bare integer literals only: gqc does have
+    # named constants/enums now (gamequeer#421), but this rule doesn't yet
+    # accept their operand forms here -- switching it to whatever operand
+    # rule #421 introduces would be the fix.
     cohort_definition_section = pp.Group(pp.Keyword("cohort") - identifier - pp.Suppress("=") - integer - pp.Suppress("..") - integer - pp.Suppress(";")).set_name("cohort_definition_section")
     cohort_definition_section.set_parse_action(parse_cohort_definition)
 

--- a/gqc/src/gqc/grammar.py
+++ b/gqc/src/gqc/grammar.py
@@ -8,13 +8,14 @@ from .parser import parse_int_expression, parse_int_operand, parse_str_literal, 
 from .parser import parse_str_expression, parse_string_cast_operand
 from .parser import parse_badge_count_operand
 from .parser import parse_fw_version_operand
+from .parser import parse_const_definition, parse_enum_definition, parse_enum_member_operand
 
 """
 Grammar for GQC language
 ========================
 
 program = game_definition_section declaration_section*
-declaration_section = var_definition_section | animation_definition_section | lightcue_definition_section | menu_definition_section | stage_definition_section
+declaration_section = var_definition_section | animation_definition_section | lightcue_definition_section | menu_definition_section | stage_definition_section | const_definition_section | enum_definition_section
 
 game_definition_section = "game" "{" game_assignment* "}"
 game_id_assignment = "id" "=" integer ";"
@@ -28,6 +29,14 @@ var_definitions = var_definition | "{" var_definition* "}"
 var_definition = string_definition | int_definition
 string_definition = "str" identifier ":=" string ";" # | "str" identifier ";"
 int_definition = "int" identifier "=" integer ";" # | "int" identifier ";"
+
+# Named compile-time constants and enums (gamequeer#421): pure parse-time
+# sugar, folded to a literal int wherever they're referenced -- see
+# datamodel.Constant/datamodel.Enum for the scoping rules (single flat
+# file-global namespace, declare-before-use). Must be declared before their
+# first use.
+const_definition_section = "const" identifier "=" int_expression ";"
+enum_definition_section = "enum" identifier "{" identifier ("," identifier)* "}"
 
 animation_definition_section = "animations" animation_assignments
 animation_assignments = animation_assignment | "{" animation_assignment* "}"
@@ -78,7 +87,7 @@ int_assignment = identifier "=" int_expression ";"
 # including str(x) appearing inside a "+" chain (gamequeer#386).
 string_assignment = identifier ":=" ((string_cast &";") | string_expression) ";"
 
-int_operand = badge_count_call | identifier | integer
+int_operand = badge_count_call | enum_member_ref | identifier | integer
 string_cast = 'str' '(' int_expression ')'
 string_operand = identifier | string | string_cast
 
@@ -89,6 +98,11 @@ string_operand = identifier | string | string_cast
 # badge_get it takes an empty, mandatory parameter list, not a bare operand
 # form.
 badge_count_call = "badge_count" "(" ")"
+
+# Enum member reference (gamequeer#421), e.g. "Difficulty.Easy" -- resolved
+# to its int value at parse time, same as a bare int literal or a `const`
+# reference (see identifier's own const-lookup in parser.parse_int_operand).
+enum_member_ref = identifier "." identifier
 
 # Shorthand; see https://stackoverflow.com/a/23956778
 # badge_get is a right-associative unary prefix operator, e.g. badge_get(x).
@@ -194,7 +208,18 @@ def build_game_parser():
     fw_version_call = pp.Group(pp.Keyword("fw_version") - pp.Suppress("(") - pp.Suppress(")")).set_name("fw_version_call")
     fw_version_call.set_parse_action(parse_fw_version_operand)
 
-    int_operand = badge_count_call | fw_version_call | identifier | integer
+    # Enum member reference (gamequeer#421), e.g. "Difficulty.Easy" -- tried
+    # before the bare `identifier` alternative below so a dotted reference
+    # doesn't get swallowed as just its own leading identifier, leaving a
+    # stray "." for whatever follows to choke on. Plain `+` (not `-`): an
+    # ordinary identifier with no "." following it must fail *softly* here
+    # so MatchFirst falls through to the bare `identifier` alternative,
+    # rather than committing partway through like badge_count_call's `-`
+    # deliberately does above.
+    enum_member_ref = pp.Group(identifier + pp.Suppress(".") + identifier).set_name("enum_member_ref")
+    enum_member_ref.set_parse_action(parse_enum_member_operand)
+
+    int_operand = badge_count_call | fw_version_call | enum_member_ref | identifier | integer
     int_operand.set_parse_action(parse_int_operand)
     int_expression = pp.infix_notation(int_operand, [
         (pp.Keyword('badge_get') | pp.one_of('! - ~'), 1, pp.opAssoc.RIGHT),
@@ -210,6 +235,21 @@ def build_game_parser():
     ])
     int_expression.set_parse_action(parse_int_expression)
     int_assignment = pp.Keyword("=") - int_expression - pp.Suppress(";")
+
+    # Named compile-time constants and enums (gamequeer#421). const_definition
+    # reuses int_expression itself, so a `const`'s RHS gets the exact same
+    # compile-time folding (gamequeer#385) a runtime assignment's RHS would;
+    # parser.parse_const_definition then requires the result to have
+    # actually folded to a literal (a `const` has no runtime fallback).
+    const_definition_section = pp.Group(pp.Keyword("const") - identifier - pp.Suppress("=") - int_expression - pp.Suppress(";"))
+    const_definition_section.set_parse_action(parse_const_definition)
+
+    # enum Name { A, B, C } -- auto-numbered from 0 in declaration order;
+    # each member is registered as "Name.Member" (see Enum.define in
+    # datamodel.py) and referenced the same way via enum_member_ref, above.
+    enum_members = pp.Group(identifier - pp.ZeroOrMore(pp.Suppress(",") - identifier))
+    enum_definition_section = pp.Group(pp.Keyword("enum") - identifier - pp.Suppress("{") - enum_members - pp.Suppress("}"))
+    enum_definition_section.set_parse_action(parse_enum_definition)
 
     string_literal = pp.QuotedString('"').setName("string_literal")
     string_literal.set_parse_action(parse_str_literal)
@@ -285,7 +325,7 @@ def build_game_parser():
     stage_definition_section.set_parse_action(parse_stage_definition)
 
     # Finish up
-    gqc_game << game_definition_section - pp.ZeroOrMore(animation_definition_section | lightcue_definition_section | var_definition_section | menu_definition_section | stage_definition_section)
+    gqc_game << game_definition_section - pp.ZeroOrMore(animation_definition_section | lightcue_definition_section | var_definition_section | menu_definition_section | stage_definition_section | const_definition_section | enum_definition_section)
     gqc_game.ignore(pp.cppStyleComment)
 
     return gqc_game

--- a/gqc/src/gqc/linker.py
+++ b/gqc/src/gqc/linker.py
@@ -45,10 +45,11 @@ def _make_fw_probe_frame_source() -> pathlib.Path:
     # package/author asset: no assets/animations/ authoring surface, no
     # packaging footprint, nothing for a project's asset digest cache to
     # ever go stale against. Animation()'s `source` resolves relative to
-    # the CWD (pathlib.Path() / 'assets' / 'animations' / source) *unless*
-    # source is itself absolute, in which case the join returns the
-    # absolute path unchanged -- so passing this temp file's absolute path
-    # in bypasses that CWD-relative convention entirely.
+    # the game's own directory (gamequeer#420; Game.game_dir /
+    # 'assets' / 'animations' / source) *unless* source is itself
+    # absolute, in which case the join returns the absolute path unchanged
+    # -- so passing this temp file's absolute path in bypasses that
+    # game-directory-relative convention entirely.
     fd, path = tempfile.mkstemp(prefix='gqc_fw_probe_', suffix='.png')
     os.close(fd)
     try:

--- a/gqc/src/gqc/linker.py
+++ b/gqc/src/gqc/linker.py
@@ -35,6 +35,28 @@ def create_reserved_variables():
     for reg_name in structs.GQ_REGISTERS_STR:
         var = Variable('str', reg_name, '', 'volatile')
 
+def create_random_state_variables():
+    """Create the hidden LCG state/counter variables backing random()
+    (gamequeer#422) -- only for a game that actually calls random()
+    somewhere (gated on Game.game.needs_random in gqc.py, mirroring
+    inject_fw_version_probe's zero-footprint-when-unused convention below).
+
+    Deferred until after parsing completes, exactly like
+    inject_fw_version_probe, rather than created eagerly the first time
+    random() is *parsed* (parser.parse_random_operand): a game can declare
+    its own `volatile { ... }` section anywhere among its top-level
+    declarations, including *after* a stage that calls random(). Creating
+    these two variables eagerly would make them the first entries in
+    Variable.storageclass_table['volatile'] by the time that later
+    author-declared section gets parsed, and
+    parser.parse_variable_definition_storageclass's one-declaration-per-game
+    check would misidentify them as a pre-existing non-init/non-register
+    volatile var and falsely reject the author's own single, legitimate
+    volatile block.
+    """
+    Variable('int', structs.GQ_RANDOM_STATE_VAR, 0, storageclass='volatile')
+    Variable('int', structs.GQ_RANDOM_CTR_VAR, 0, storageclass='volatile')
+
 def _make_fw_probe_frame_source() -> pathlib.Path:
     # inject_fw_version_probe's bganim needs *a* frame to exist and load --
     # its content is never meaningful (it's on screen for up to ~21 ticks

--- a/gqc/src/gqc/parser.py
+++ b/gqc/src/gqc/parser.py
@@ -7,6 +7,7 @@ from rich import print
 
 from .datamodel import Animation, Game, Stage, Variable, Event, Menu, LightCue, StrExpression
 from .datamodel import IntExpression, GqcIntOperand, GqcStrCastOperand, GqcBadgeCountOperand
+from .datamodel import Cohort, GqcHaveMetOperand, GqcInCohortOperand, GqcCountSeenRangeOperand
 from .datamodel import fold_constant_int_expression
 from .commands import CommandPlay, CommandGoStage, CommandCue, CommandCastStr
 from .commands import CommandSetStr, CommandSetInt, CommandWithIntExpressionArgument
@@ -227,8 +228,79 @@ def parse_badge_count_operand(instring, loc, toks):
     # IntExpression.get_result_symbol to recognize, not a value container.
     return GqcBadgeCountOperand()
 
+# The social vocabulary (gamequeer#423, DEF CON sprint epic gamequeer#419).
+# Each parse action below produces one of the datamodel.py marker
+# namedtuples documented there, following the exact same
+# parse_int_operand/parse_int_expression/IntExpression.get_result_symbol/
+# fold_constant_int_expression recognition pattern parse_badge_count_operand
+# and GqcBadgeCountOperand already established for gamequeer#387.
+
+def parse_have_met_operand(instring, loc, toks):
+    # toks[0] is have_met_call's own pp.Group: ['have_met', arg], where arg
+    # is whatever this call's own int_expression sub-rule already reduced
+    # the argument to (a GqcIntOperand or IntExpression).
+    return GqcHaveMetOperand(id_operand=toks[0][1])
+
+def parse_in_cohort_operand(instring, loc, toks):
+    # toks[0] is in_cohort_call's own pp.Group: ['in_cohort', cohort_name, id].
+    _, cohort_name, id_operand = toks[0]
+
+    if cohort_name not in Cohort.cohort_table:
+        raise GqcParseError(f"Undefined cohort {cohort_name}", instring, loc)
+    cohort = Cohort.cohort_table[cohort_name]
+
+    return GqcInCohortOperand(id_operand=id_operand, lo=cohort.lo, hi=cohort.hi)
+
+def parse_count_seen_operand(instring, loc, toks):
+    # toks[0] is count_seen_call's own pp.Group: either ['count_seen']
+    # (the bare-call form) or ['count_seen', cohort_name].
+    toks = toks[0]
+
+    if len(toks) == 1:
+        # count_seen() with no argument is badge_count() itself
+        # (gamequeer#423) -- the same marker, same lowering, same op-stream.
+        return GqcBadgeCountOperand()
+
+    cohort_name = toks[1]
+    if cohort_name not in Cohort.cohort_table:
+        raise GqcParseError(f"Undefined cohort {cohort_name}", instring, loc)
+    cohort = Cohort.cohort_table[cohort_name]
+
+    return GqcCountSeenRangeOperand(lo=cohort.lo, hi=cohort.hi)
+
+def parse_cohort_definition(instring, loc, toks):
+    toks = toks[0]
+    _, name, lo, hi = toks
+
+    try:
+        return Cohort(name, lo, hi)
+    except ValueError as ve:
+        raise GqcParseError(str(ve), instring, loc)
+
+def parse_seen_self(instring, loc):
+    # seen_self() (gamequeer#423) desugars to the copy-pasted-verbatim idiom
+    # "if (badge_get(GQI_PLAYER_ID)==0) badge_set GQI_PLAYER_ID;" -- built
+    # by hand here rather than via the grammar (there's no source text for
+    # it to parse), mirroring the manual Command construction
+    # IntExpression._emit_badge_count already does for badge_count()'s own
+    # fixed shape.
+    id_operand = GqcIntOperand(is_literal=False, value='GQI_PLAYER_ID')
+    condition = IntExpression(
+        [['badge_get', id_operand], '==', GqcIntOperand(is_literal=True, value=0)],
+        instring, loc,
+    )
+    true_cmds = [CommandWithIntExpressionArgument(CommandType.QCSET, instring, loc, id_operand)]
+
+    return CommandIf(instring, loc, condition, true_cmds)
+
+# Every social-vocabulary operand marker (see datamodel.py) that
+# parse_int_operand/parse_int_expression need to pass through unchanged
+# rather than wrap in a GqcIntOperand -- the same role GqcBadgeCountOperand
+# already plays for badge_count().
+_SOCIAL_VOCAB_OPERAND_TYPES = (GqcBadgeCountOperand, GqcHaveMetOperand, GqcInCohortOperand, GqcCountSeenRangeOperand)
+
 def parse_int_operand(instring, loc, toks):
-    if isinstance(toks[0], (GqcIntOperand, GqcBadgeCountOperand)):
+    if isinstance(toks[0], (GqcIntOperand,) + _SOCIAL_VOCAB_OPERAND_TYPES):
         return toks[0]
     elif isinstance(toks[0], int):
         return GqcIntOperand(True, toks[0])
@@ -250,15 +322,32 @@ def parse_int_expression(instring, loc, toks):
         # re-folding/re-constructing it (which would double-alloc its
         # registers -- see gamequeer#345).
         return toks
-    if isinstance(toks, GqcBadgeCountOperand):
-        # badge_count() as the *entire* RHS, e.g. "x = badge_count();" --
-        # with no sibling operator at this nesting level, infix_notation
-        # hands this back as a bare atom rather than a
-        # [operand, op, operand] token group. Unlike a bare variable
-        # reference, badge_count() always emits real commands (its
-        # popcount loop), so it needs an IntExpression wrapper even here;
-        # get_result_symbol recognizes the same sentinel to build that
-        # loop (see IntExpression._emit_badge_count).
+    if isinstance(toks, _SOCIAL_VOCAB_OPERAND_TYPES):
+        # badge_count() (gamequeer#387) or one of the gamequeer#423 social-
+        # vocabulary markers (have_met/in_cohort/count_seen) as the *entire*
+        # RHS, e.g. "x = badge_count();" -- with no sibling operator at this
+        # nesting level, infix_notation hands this back as a bare atom
+        # rather than a [operand, op, operand] token group.
+        #
+        # Unlike the other three, in_cohort(NAME, id) *can* be a compile-time
+        # constant (a pure range compare, no badge state involved -- see
+        # fold_constant_int_expression's GqcInCohortOperand branch), so try
+        # folding first, exactly like any other bare-atom operand a few
+        # lines below this would -- skipping this would leave an
+        # IntExpression whose own result_symbol is itself a literal with no
+        # emitted commands, a shape CommandWithIntExpressionArgument doesn't
+        # handle (it only ever expects a register/variable-name result from
+        # a *wrapped* IntExpression, gamequeer#423 code review).
+        folded = fold_constant_int_expression(toks)
+        if folded is not None:
+            return GqcIntOperand(is_literal=True, value=folded)
+
+        # Not foldable (badge_count()/have_met()/count_seen() never are;
+        # in_cohort() is here because `id` itself wasn't a literal). Every
+        # one of these always emits real commands (or, for a non-foldable
+        # in_cohort(), a bare comparison), so it needs an IntExpression
+        # wrapper; IntExpression.get_result_symbol recognizes the same
+        # sentinels to build the right shape for each.
         try:
             return IntExpression([toks], instring, loc)
         except ValueError as ve:
@@ -426,6 +515,8 @@ def parse_command(instring, loc, toks):
             return CommandWithIntExpressionArgument(CommandType.QCSET, instring, loc, toks[1])
         elif command == 'badge_clear':
             return CommandWithIntExpressionArgument(CommandType.QCCLR, instring, loc, toks[1])
+        elif command == 'seen_self':
+            return parse_seen_self(instring, loc)
         else:
             raise GqcParseError(f"Invalid command {command}", instring, loc)
         

--- a/gqc/src/gqc/parser.py
+++ b/gqc/src/gqc/parser.py
@@ -1,5 +1,4 @@
 import sys
-import pathlib
 from collections import namedtuple
 
 import pyparsing as pp
@@ -190,7 +189,10 @@ def parse_lightcue_definition_section(instring, loc, toks):
 
     for cue in toks:
         cue_name = cue[0]
-        cue_source = pathlib.Path() / 'assets' / 'lighting' / cue[1]
+        # gamequeer#420: resolved relative to the game's own directory
+        # (Game.game_dir), not the process CWD -- see the matching comment
+        # on Animation.src_path in datamodel.py.
+        cue_source = Game.game_dir / 'assets' / 'lighting' / cue[1]
 
         print(f"[blue]Light cue [italic]{cue_name}[/italic][/blue] from [underline]{cue_source}[/underline]")
         
@@ -238,7 +240,16 @@ def parse_fw_version_operand(instring, loc, toks):
     # inject_fw_version_probe after parsing: a game that never calls
     # fw_version() gets no probe stage, and pays none of its ~1s cost on
     # original firmware.
-    Game.game.needs_fw_probe = True
+    #
+    # gamequeer#420: game{} may not have been parsed yet (it's no longer
+    # required to be the first top-level section), so Game.game can still be
+    # None here -- record the flag on the class itself either way;
+    # Game.__init__ seeds a not-yet-constructed instance's needs_fw_probe
+    # from it, and it's still applied directly to Game.game when that
+    # instance already exists (the common case).
+    Game.needs_fw_probe_seen = True
+    if Game.game is not None:
+        Game.game.needs_fw_probe = True
     return GqcIntOperand(False, structs.GQ_FW_PROBE_RESULT_VAR)
 
 def parse_int_operand(instring, loc, toks):
@@ -468,6 +479,21 @@ def parse(text):
         print(
             "Error: expression nesting is too deep for gqc to parse. "
             "Split it into intermediate variables.",
+            file=sys.stderr,
+        )
+        exit(1)
+
+    # gamequeer#420: game{} is no longer structurally locked to being the
+    # first top-level section (it's just one more alternative in the
+    # top-level section repetition in grammar.py), so the grammar alone
+    # can no longer enforce "exactly one" -- a *second* game{} block is
+    # still caught structurally (Game.__init__ raises "Game already
+    # defined", surfaced as a GqcParseError above), but *zero* game{}
+    # blocks parses cleanly with nothing left to reject it. Check for that
+    # here instead, once parsing is otherwise known to have succeeded.
+    if Game.game is None:
+        print(
+            "Error: no `game { ... }` block found (exactly one is required).",
             file=sys.stderr,
         )
         exit(1)

--- a/gqc/src/gqc/parser.py
+++ b/gqc/src/gqc/parser.py
@@ -7,6 +7,7 @@ from rich import print
 
 from .datamodel import Animation, Game, Stage, Variable, Event, Menu, LightCue, StrExpression
 from .datamodel import IntExpression, GqcIntOperand, GqcStrCastOperand, GqcBadgeCountOperand
+from .datamodel import GqcRandomOperand, GqcMinMaxOperand, GqcClampOperand, GqcAbsOperand
 from .datamodel import fold_constant_int_expression
 from .commands import CommandPlay, CommandGoStage, CommandCue, CommandCastStr
 from .commands import CommandSetStr, CommandSetInt, CommandWithIntExpressionArgument
@@ -241,8 +242,37 @@ def parse_fw_version_operand(instring, loc, toks):
     Game.game.needs_fw_probe = True
     return GqcIntOperand(False, structs.GQ_FW_PROBE_RESULT_VAR)
 
+def parse_random_operand(instring, loc, toks):
+    # random(lo, hi) (gamequeer#422): toks[0] is random_call's own pp.Group,
+    # holding exactly its two already-parsed int_expression arguments (the
+    # "random" keyword itself is suppressed in the grammar, same as
+    # string_cast's "str" -- see parse_string_cast_operand). Setting
+    # needs_random here (mirroring parse_fw_version_operand's needs_fw_probe
+    # above) is what tells gqc.py to call
+    # linker.create_random_state_variables after parsing: a game that never
+    # calls random() gets no hidden LCG state/counter variables.
+    Game.game.needs_random = True
+    lo, hi = toks[0]
+    return GqcRandomOperand(lo, hi)
+
+def parse_min_operand(instring, loc, toks):
+    a, b = toks[0]
+    return GqcMinMaxOperand(a, b, False)
+
+def parse_max_operand(instring, loc, toks):
+    a, b = toks[0]
+    return GqcMinMaxOperand(a, b, True)
+
+def parse_clamp_operand(instring, loc, toks):
+    x, lo, hi = toks[0]
+    return GqcClampOperand(x, lo, hi)
+
+def parse_abs_operand(instring, loc, toks):
+    x = toks[0][0]
+    return GqcAbsOperand(x)
+
 def parse_int_operand(instring, loc, toks):
-    if isinstance(toks[0], (GqcIntOperand, GqcBadgeCountOperand)):
+    if isinstance(toks[0], (GqcIntOperand, GqcBadgeCountOperand, GqcRandomOperand, GqcMinMaxOperand, GqcClampOperand, GqcAbsOperand)):
         return toks[0]
     elif isinstance(toks[0], int):
         return GqcIntOperand(True, toks[0])
@@ -264,15 +294,30 @@ def parse_int_expression(instring, loc, toks):
         # re-folding/re-constructing it (which would double-alloc its
         # registers -- see gamequeer#345).
         return toks
-    if isinstance(toks, GqcBadgeCountOperand):
-        # badge_count() as the *entire* RHS, e.g. "x = badge_count();" --
-        # with no sibling operator at this nesting level, infix_notation
-        # hands this back as a bare atom rather than a
-        # [operand, op, operand] token group. Unlike a bare variable
-        # reference, badge_count() always emits real commands (its
-        # popcount loop), so it needs an IntExpression wrapper even here;
-        # get_result_symbol recognizes the same sentinel to build that
-        # loop (see IntExpression._emit_badge_count).
+    if isinstance(toks, (GqcBadgeCountOperand, GqcRandomOperand, GqcMinMaxOperand, GqcClampOperand, GqcAbsOperand)):
+        # badge_count()/random()/min()/max()/clamp()/abs() as the *entire*
+        # RHS, e.g. "x = badge_count();" or "x = min(3, 7);" -- with no
+        # sibling operator at this nesting level, infix_notation hands this
+        # back as a bare atom rather than a [operand, op, operand] token
+        # group. min()/max()/clamp()/abs() (unlike badge_count()/random(),
+        # which never fold -- see fold_constant_int_expression) fold to a
+        # single literal here too when their own arguments do (gamequeer#422)
+        # -- this is the *only* place a bare-atom marker like this reaches
+        # fold_constant_int_expression directly; the generic fold attempt
+        # further down only ever sees a real [operand, op, operand] node, so
+        # without this a whole-RHS "x = min(3, 7);" would never fold even
+        # though "x = min(3, 7) + 1;" already does (via that generic path
+        # recursing into the marker as one of its two operands).
+        folded = fold_constant_int_expression(toks)
+        if folded is not None:
+            return GqcIntOperand(is_literal=True, value=folded)
+
+        # Otherwise, every one of these always emits real commands (a
+        # popcount loop, LCG arithmetic, or a compare-and-conditionally-
+        # overwrite -- see IntExpression._emit_badge_count/_emit_random/
+        # _emit_minmax/_emit_clamp/_emit_abs), so each needs an
+        # IntExpression wrapper even here; get_result_symbol recognizes the
+        # same markers to build that lowering.
         try:
             return IntExpression([toks], instring, loc)
         except ValueError as ve:

--- a/gqc/src/gqc/parser.py
+++ b/gqc/src/gqc/parser.py
@@ -326,7 +326,16 @@ def parse_random_operand(instring, loc, toks):
     # above) is what tells gqc.py to call
     # linker.create_random_state_variables after parsing: a game that never
     # calls random() gets no hidden LCG state/counter variables.
-    Game.game.needs_random = True
+    #
+    # gamequeer#420: game{} may not have been parsed yet (it's no longer
+    # required to be the first top-level section), so Game.game can still be
+    # None here -- record the flag on the class itself either way;
+    # Game.__init__ seeds a not-yet-constructed instance's needs_random from
+    # it, and it's still applied directly to Game.game when that instance
+    # already exists (the common case).
+    Game.needs_random_seen = True
+    if Game.game is not None:
+        Game.game.needs_random = True
     lo, hi = toks[0]
     return GqcRandomOperand(lo, hi)
 

--- a/gqc/src/gqc/parser.py
+++ b/gqc/src/gqc/parser.py
@@ -18,27 +18,36 @@ from . import structs, GqcParseError
 def parse_game_definition(instring, loc, toks):
     toks = toks[0]
 
-    # Note: if we're already here, the parser has already enforced that each of the key
-    #       parameters for the game are uniquely defined.
-    id = None
-    title = None
-    author = None
-    starting_stage = None
+    # grammar.py's game_assignment is a plain repetition of the
+    # id/title/author/starting_stage alternation, in any order and any
+    # number of times -- not pyparsing's `&` ("each") operator, which could
+    # only ever raise a generic "missing one or more required elements"
+    # ParseException with no way to tell a duplicated key from a genuinely
+    # missing one (gamequeer#331's investigation notes). "Exactly one of
+    # each" is enforced here instead, the same semantic-cardinality
+    # approach gamequeer#420 already uses for zero/duplicate game{}
+    # *blocks* themselves (see parser.parse's Game.game is None check and
+    # Game.__init__'s "Game already defined" check) -- each of toks[1:] is
+    # one already-parsed [key, value] assignment group (game_id_assignment/
+    # game_title_assignment/game_author_assignment/
+    # game_starting_stage_assignment); counting them by key lets a missing
+    # or duplicated key be named specifically in the resulting error.
+    values = {}
+    counts = {"id": 0, "title": 0, "author": 0, "starting_stage": 0}
+
+    for assignment in toks[1:]:
+        key, value = assignment
+        counts[key] += 1
+        values[key] = value
+
+    for key, count in counts.items():
+        if count == 0:
+            raise GqcParseError(f"Missing required game key '{key}'", instring, loc)
+        if count > 1:
+            raise GqcParseError(f"Duplicate game key '{key}'", instring, loc)
 
     try:
-        for assignment in toks[1]:
-            if assignment[0] == "id":
-                id = assignment[1]
-            elif assignment[0] == "title":
-                title = assignment[1]
-            elif assignment[0] == "author":
-                author = assignment[1]
-            elif assignment[0] == "starting_stage":
-                starting_stage = assignment[1]
-            else:
-                raise ValueError(f"Invalid assignment {assignment[0]}")
-        
-        return Game(id, title, author, starting_stage)
+        return Game(values["id"], values["title"], values["author"], values["starting_stage"])
     except ValueError as ve:
         raise GqcParseError(str(ve), instring, loc)
 

--- a/gqc/src/gqc/parser.py
+++ b/gqc/src/gqc/parser.py
@@ -436,6 +436,12 @@ def parse_int_operand(instring, loc, toks):
         # reference, exactly as before this feature existed.
         return GqcIntOperand(True, Constant.const_table[toks[0]])
     else:
+        # Not (yet) a known const/enum member -- could be an ordinary
+        # (forward-reference-tolerant) variable, or a const/enum used
+        # *before* its own declaration; can't tell which until the whole
+        # file has been parsed (see Constant.pending_int_refs' docstring
+        # and check_pending_int_refs, below).
+        Constant.pending_int_refs.append((toks[0], instring, loc))
         return GqcIntOperand(False, toks[0])
 
 def parse_int_expression(instring, loc, toks):
@@ -662,6 +668,38 @@ def parse_command(instring, loc, toks):
     except ValueError as ve:
         raise GqcParseError(str(ve), instring, loc)
 
+def check_pending_int_refs():
+    """Reject any `Constant.pending_int_refs` entry that turns out to name
+    a const/enum member after all (gamequeer#427 review) -- called once
+    parsing has fully finished, so `Constant.const_table` holds every
+    const/enum this file will ever define, including ones declared *after*
+    the offending reference.
+
+    Reports the first such reference in source order (`pending_int_refs`
+    is append-only, in parse order) and exits, matching every other
+    single-error `parser.parse` diagnostic -- there's no multi-error
+    reporting elsewhere in gqc to be consistent with.
+
+    Skips a name that's *also* a declared variable (`Variable.var_table`):
+    gqc doesn't otherwise stop a `const`/`enum` and a `volatile`/
+    `persistent` variable from sharing a name (a separate, pre-existing gap,
+    out of scope here), so in that rare collision case this defers to the
+    parser's own (variable) interpretation rather than guessing wrong.
+    """
+    for name, ref_instring, ref_loc in Constant.pending_int_refs:
+        if name in Constant.const_table and name not in Variable.var_table:
+            print(
+                GqcParseError(
+                    f"{name!r} is a const/enum member declared later in "
+                    "this file. const/enum references must be declared "
+                    "before their first use (they don't get the same "
+                    "forward-reference tolerance ordinary variables do).",
+                    ref_instring, ref_loc,
+                ),
+                file=sys.stderr,
+            )
+            exit(1)
+
 def parse(text):
     # Import here to avoid circular import
     from gqc import grammar
@@ -687,6 +725,13 @@ def parse(text):
             file=sys.stderr,
         )
         exit(1)
+
+    # gamequeer#427 review: a const/enum referenced before its own
+    # declaration couldn't be told apart from an ordinary forward-declared
+    # variable reference while parsing was still in progress -- now that
+    # it's finished, Constant.const_table is complete and this can be
+    # checked for real. See check_pending_int_refs' own docstring.
+    check_pending_int_refs()
 
     # gamequeer#420: game{} is no longer structurally locked to being the
     # first top-level section (it's just one more alternative in the

--- a/gqc/src/gqc/parser.py
+++ b/gqc/src/gqc/parser.py
@@ -7,7 +7,7 @@ from rich import print
 
 from .datamodel import Animation, Game, Stage, Variable, Event, Menu, LightCue, StrExpression
 from .datamodel import IntExpression, GqcIntOperand, GqcStrCastOperand, GqcBadgeCountOperand
-from .datamodel import fold_constant_int_expression
+from .datamodel import fold_constant_int_expression, Constant, Enum
 from .commands import CommandPlay, CommandGoStage, CommandCue, CommandCastStr
 from .commands import CommandSetStr, CommandSetInt, CommandWithIntExpressionArgument
 from .commands import CommandTimer, CommandIf, CommandGoto, CommandLoop, Command, CommandType
@@ -183,6 +183,47 @@ def parse_variable_definition_storageclass(instring, loc, toks):
     for var in toks[1]:
         var.set_storageclass(storageclass)
 
+def parse_const_definition(instring, loc, toks):
+    # gamequeer#421: `const NAME = <int-expression>;`. `value` is whatever
+    # int_expression's own parse action already produced -- a literal
+    # GqcIntOperand if the RHS folded to a compile-time constant (gamequeer
+    # #385's fold_constant_int_expression, reused as-is via int_expression),
+    # or an IntExpression if it didn't (e.g. it references a variable, or a
+    # not-yet-defined name that reads as one -- see Constant's docstring in
+    # datamodel.py for why forward references aren't supported). Either way,
+    # a `const` has no runtime representation to fall back to, so anything
+    # short of an already-folded literal is rejected right here.
+    toks = toks[0]
+    name = toks[1]
+    value_operand = toks[2]
+
+    if not (isinstance(value_operand, GqcIntOperand) and value_operand.is_literal):
+        raise GqcParseError(
+            f"Constant {name} must be initialized with a compile-time "
+            "constant integer expression",
+            instring, loc,
+        )
+
+    try:
+        Constant.define(name, value_operand.value)
+    except ValueError as ve:
+        raise GqcParseError(str(ve), instring, loc)
+
+def parse_enum_definition(instring, loc, toks):
+    # gamequeer#421: `enum Name { A, B, C }`, auto-numbered from 0 in
+    # declaration order. Enum.define does the actual work (including
+    # registering each member into Constant.const_table under
+    # "Name.Member", see its docstring), so it can share the same
+    # duplicate-name and range-checking machinery as a plain `const`.
+    toks = toks[0]
+    name = toks[1]
+    members = list(toks[2])
+
+    try:
+        Enum.define(name, members)
+    except ValueError as ve:
+        raise GqcParseError(str(ve), instring, loc)
+
 def parse_lightcue_definition_section(instring, loc, toks):
     # Import here to avoid circular import
     from .cues import parse_cue
@@ -241,11 +282,32 @@ def parse_fw_version_operand(instring, loc, toks):
     Game.game.needs_fw_probe = True
     return GqcIntOperand(False, structs.GQ_FW_PROBE_RESULT_VAR)
 
+def parse_enum_member_operand(instring, loc, toks):
+    # `Name.Member` (gamequeer#421): resolved to its int value right here,
+    # at parse time, same as badge_count() above is resolved to its
+    # sentinel here -- by the time int_operand's own parse action
+    # (parse_int_operand, below) sees this, it's already a literal
+    # GqcIntOperand, indistinguishable from a bare int literal.
+    enum_name, member_name = toks[0]
+    try:
+        value = Enum.get_member_value(enum_name, member_name)
+    except ValueError as ve:
+        raise GqcParseError(str(ve), instring, loc)
+    return GqcIntOperand(is_literal=True, value=value)
+
 def parse_int_operand(instring, loc, toks):
     if isinstance(toks[0], (GqcIntOperand, GqcBadgeCountOperand)):
         return toks[0]
     elif isinstance(toks[0], int):
         return GqcIntOperand(True, toks[0])
+    elif toks[0] in Constant.const_table:
+        # A bare `const NAME` reference (gamequeer#421) -- substitute its
+        # value immediately, same as a literal int would parse. Must be
+        # declared earlier in the file (see Constant's docstring in
+        # datamodel.py); anything not already in the table by now is
+        # treated as an ordinary (possibly forward-declared) variable
+        # reference, exactly as before this feature existed.
+        return GqcIntOperand(True, Constant.const_table[toks[0]])
     else:
         return GqcIntOperand(False, toks[0])
 

--- a/gqc/src/gqc/structs.py
+++ b/gqc/src/gqc/structs.py
@@ -342,20 +342,25 @@ GQ_REGISTERS_STR = [
 # and the Park-Miller "minimal standard" generator constants it's built
 # from. See IntExpression._emit_random (datamodel.py) for the full
 # derivation; this is just the shared vocabulary between it and
-# parser.parse_random_operand. Deliberately the *same* sequence (seed
-# convention and Schrage-method advance) the game corpus already hand-rolls
-# at the source level -- see e.g. gq-games/games/donsol.gq's card-shuffle
-# `lcg` -- so random() is genuinely just sugar for that pattern, not a
-# different generator. Named `.reg` like GQ_REGISTERS_INT/GQ_FW_PROBE_RESULT_VAR
-# above, but NOT a member of GQ_REGISTERS_INT: it must never be handed out by
-# IntExpression.alloc_register() as ordinary expression scratch space, since
-# unlike those, its value has to survive *between* separate random() calls.
+# parser.parse_random_operand. The *multiplicative core* (Schrage-method
+# advance, same modulus/multiplier) is the same recurrence the game corpus
+# already hand-rolls at the source level -- see e.g. gq-games/games/
+# donsol.gq's card-shuffle `lcg` -- but the *seeding scheme* is deliberately
+# NOT the same as donsol.gq's; see _emit_random's docstring for the actual
+# entropy model and why real per-boot entropy needs an author-side
+# donsol-style timer salt. Named `.reg` like GQ_REGISTERS_INT/
+# GQ_FW_PROBE_RESULT_VAR above, but NOT a member of GQ_REGISTERS_INT: it
+# must never be handed out by IntExpression.alloc_register() as ordinary
+# expression scratch space, since unlike those, its value has to survive
+# *between* separate random() calls.
 GQ_RANDOM_STATE_VAR = '__gq_random_state.reg'
 GQ_RANDOM_CTR_VAR = '__gq_random_ctr.reg'
-# GQI_PLAYER_ID * GQ_RANDOM_SEED_MULTIPLIER + (a monotonically incrementing
-# per-call counter) is the perturbation folded into the LCG state on every
-# call (donsol.gq's own seeding formula, applied per-call instead of
-# per-"run" -- see _emit_random's docstring for why).
+# GQI_PLAYER_ID * GQ_RANDOM_SEED_MULTIPLIER + GQ_RANDOM_CTR_VAR (a counter
+# incremented once per random() *call*, zero-initialized at boot -- NOT a
+# free-running timer counter like donsol.gq's own `ctr`) is the perturbation
+# folded into the LCG state on every call. See _emit_random's docstring for
+# why this makes the first random() call after a fresh boot a deterministic
+# function of GQI_PLAYER_ID alone.
 GQ_RANDOM_SEED_MULTIPLIER = 7919
 # The Park-Miller "minimal standard" LCG: state' = (a * state) mod m, with
 # m = 2**31 - 1 (a Mersenne prime) and a = 48271, computed via Schrage's

--- a/gqc/src/gqc/structs.py
+++ b/gqc/src/gqc/structs.py
@@ -337,3 +337,34 @@ GQ_REGISTERS_INT = [
 GQ_REGISTERS_STR = [
     'GQ_RS0.reg', 'GQ_RS1.reg', 'GQ_RS2.reg', 'GQ_RS3.reg',
 ]
+
+# random(lo, hi) intrinsic (gamequeer#422): hidden LCG state variable names,
+# and the Park-Miller "minimal standard" generator constants it's built
+# from. See IntExpression._emit_random (datamodel.py) for the full
+# derivation; this is just the shared vocabulary between it and
+# parser.parse_random_operand. Deliberately the *same* sequence (seed
+# convention and Schrage-method advance) the game corpus already hand-rolls
+# at the source level -- see e.g. gq-games/games/donsol.gq's card-shuffle
+# `lcg` -- so random() is genuinely just sugar for that pattern, not a
+# different generator. Named `.reg` like GQ_REGISTERS_INT/GQ_FW_PROBE_RESULT_VAR
+# above, but NOT a member of GQ_REGISTERS_INT: it must never be handed out by
+# IntExpression.alloc_register() as ordinary expression scratch space, since
+# unlike those, its value has to survive *between* separate random() calls.
+GQ_RANDOM_STATE_VAR = '__gq_random_state.reg'
+GQ_RANDOM_CTR_VAR = '__gq_random_ctr.reg'
+# GQI_PLAYER_ID * GQ_RANDOM_SEED_MULTIPLIER + (a monotonically incrementing
+# per-call counter) is the perturbation folded into the LCG state on every
+# call (donsol.gq's own seeding formula, applied per-call instead of
+# per-"run" -- see _emit_random's docstring for why).
+GQ_RANDOM_SEED_MULTIPLIER = 7919
+# The Park-Miller "minimal standard" LCG: state' = (a * state) mod m, with
+# m = 2**31 - 1 (a Mersenne prime) and a = 48271, computed via Schrage's
+# method (state / GQ_RANDOM_LCG_Q, state % GQ_RANDOM_LCG_Q, etc.) so the
+# `a * state` multiply never leaves t_gq_int's signed-32-bit range. Valid
+# for any nonzero seed in [1, m-1] -- see the state-normalization step in
+# _emit_random, which seeds from GQ_RANDOM_LCG_MODULUS - 1 (i.e. mod (m-1),
+# then +1) for exactly that reason.
+GQ_RANDOM_LCG_MODULUS = 2147483647
+GQ_RANDOM_LCG_MULTIPLIER = 48271
+GQ_RANDOM_LCG_Q = GQ_RANDOM_LCG_MODULUS // GQ_RANDOM_LCG_MULTIPLIER  # 44488
+GQ_RANDOM_LCG_R = GQ_RANDOM_LCG_MODULUS % GQ_RANDOM_LCG_MULTIPLIER  # 3399

--- a/gqc/tests/support.py
+++ b/gqc/tests/support.py
@@ -15,6 +15,8 @@ in-process test modules in this package for callers. It is additive only:
 nothing in this file changes any production behavior.
 """
 
+import pathlib
+
 from gqc import structs
 from gqc.commands import Command
 from gqc.datamodel import (
@@ -35,6 +37,8 @@ def reset_compiler_state():
     """Clear every class-level compiler registry back to its startup state."""
     Game.link_table.clear()
     Game.game_name = None
+    Game.game_dir = pathlib.Path()
+    Game.needs_fw_probe_seen = False
     Game.game = None
 
     Event.event_table.clear()

--- a/gqc/tests/support.py
+++ b/gqc/tests/support.py
@@ -21,6 +21,9 @@ from gqc import structs
 from gqc.commands import Command
 from gqc.datamodel import (
     Animation,
+    Cohort,
+    Constant,
+    Enum,
     Event,
     Frame,
     FrameData,
@@ -67,6 +70,11 @@ def reset_compiler_state():
     LightCue.link_table.clear()
     LightCue.cue_table.clear()
     LightCueFrame.link_table.clear()
+
+    Constant.const_table.clear()
+    Constant.pending_int_refs.clear()
+    Enum.enum_table.clear()
+    Cohort.cohort_table.clear()
 
     Command.command_list.clear()
 

--- a/gqc/tests/support.py
+++ b/gqc/tests/support.py
@@ -42,6 +42,7 @@ def reset_compiler_state():
     Game.game_name = None
     Game.game_dir = pathlib.Path()
     Game.needs_fw_probe_seen = False
+    Game.needs_random_seen = False
     Game.game = None
 
     Event.event_table.clear()

--- a/gqc/tests/test_constant_folding.py
+++ b/gqc/tests/test_constant_folding.py
@@ -422,3 +422,80 @@ def test_fw_version_never_folds(compile_gq):
     # read fw_version()'s backing variable at runtime instead of folding it.
     load = next(op for op in ops if op.name == "SETVAR" and op.arg1 == addby.arg1)
     assert not (load.flags & structs.OpFlags.LITERAL_ARG2)
+
+
+# --- random() never folds; min()/max()/clamp()/abs() do (gamequeer#422) -------
+
+
+def test_random_never_folds(compile_gq):
+    # random() reads (and mutates) live LCG state seeded from GQI_PLAYER_ID
+    # and a per-call counter, not a constant -- combined with a literal
+    # "+ 1" so a bug that treated it as foldable would visibly collapse the
+    # whole expression to a single SETVAR instead of the real LCG arithmetic.
+    source = game_with_stage("x = random(1, 10) + 1;", "volatile { int x = 0; }")
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    addby_ops = [op for op in ops if op.name == "ADDBY"]
+    # Several ADDBYs belong to random()'s own LCG arithmetic; exactly one
+    # (the outermost) carries the literal "+ 1".
+    literal_addbys = [op for op in addby_ops if op.flags & structs.OpFlags.LITERAL_ARG2 and op.arg2 == 1]
+    assert len(literal_addbys) >= 1
+    assert len(addby_ops) > 1
+
+
+@pytest.mark.parametrize(
+    "expr, expected",
+    [
+        ("min(3, 7)", 3),
+        ("min(7, 3)", 3),
+        ("max(3, 7)", 7),
+        ("max(7, 3)", 7),
+        ("min(-3, 7)", -3),
+        ("max(-3, -7)", -3),
+        ("abs(5)", 5),
+        ("abs(-5)", 5),
+        ("abs(0)", 0),
+        ("clamp(5, 0, 10)", 5),
+        ("clamp(-5, 0, 10)", 0),
+        ("clamp(15, 0, 10)", 10),
+        ("clamp(5, 10, 0)", 0),  # lo > hi: min(max(5, 10), 0) = min(10, 0) = 0
+    ],
+)
+def test_math_intrinsics_of_literal_arguments_fold(compile_gq, expr, expected):
+    source = game_with_stage(f"x = {expr};", "volatile { int x = 0; }")
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+    cmds = (out_dir / "cmds.gqasm").read_text()
+    assert _folded_setvar_value(cmds) == expected
+
+
+def test_min_never_folds_with_a_variable_argument(compile_gq):
+    source = game_with_stage("x = min(y, 7) + 1;", "volatile { int x = 0; int y = 3; }")
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    assert any(op.name in ("LT", "GT") for op in ops)
+    addby_literal = next(op for op in ops if op.name == "ADDBY" and op.flags & structs.OpFlags.LITERAL_ARG2)
+    assert addby_literal.arg2 == 1
+
+
+def test_abs_never_folds_with_a_variable_argument(compile_gq):
+    source = game_with_stage("x = abs(y) + 1;", "volatile { int x = 0; int y = -3; }")
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    assert any(op.name == "NEG" for op in ops) or any(op.name == "LT" for op in ops)
+
+
+def test_abs_of_int32_min_does_not_fold_overflow(compile_gq):
+    # abs(INT32_MIN) is 2**31, one past T_GQ_INT_MAX -- not representable in
+    # t_gq_int, so this must decline to fold (same overflow-declines-to-fold
+    # policy as every other operator; see fold_constant_int_expression's
+    # docstring) rather than silently emit a wrong/truncated constant.
+    source = game_with_stage("x = abs(-2147483648);", "volatile { int x = 0; }")
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    assert [op.name for op in ops] != ["SETVAR", "DONE"]
+    assert any(op.name in ("NEG", "LT") for op in ops)

--- a/gqc/tests/test_constant_folding.py
+++ b/gqc/tests/test_constant_folding.py
@@ -394,3 +394,72 @@ def test_badge_count_never_folds(compile_gq):
     assert len(addby_ops) == 2
     addby_literal = next(op for op in addby_ops if op.flags & structs.OpFlags.LITERAL_ARG2)
     assert addby_literal.arg2 == 1
+
+
+# --- social vocabulary folding (gamequeer#423, DEF CON sprint epic
+# gamequeer#419) -- have_met/count_seen(NAME) never fold (same badge-state
+# reasoning as badge_get/badge_count() above); in_cohort() is the one
+# exception, since it's a pure range compare with no badge state involved.
+
+
+def test_have_met_never_folds_even_with_a_literal_argument(compile_gq):
+    # have_met(id) is a bare rename of badge_get(id) -- reads live badge
+    # state, not a constant, regardless of whether `id` itself is a literal.
+    source = game_with_stage("x = have_met(1) + 1;", "volatile { int x = 0; }")
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+    cmds = (out_dir / "cmds.gqasm").read_text()
+    ops = one_event(cmds).ops
+    assert any(op.name == "QCGET" for op in ops)
+    addby = next(op for op in ops if op.name == "ADDBY")
+    assert addby.flags & structs.OpFlags.LITERAL_ARG2
+    assert addby.arg2 == 1
+
+
+def test_count_seen_range_never_folds(compile_gq):
+    # count_seen(NAME) reads live badge state the same way badge_count()
+    # does, even though NAME's own lo/hi are always compile-time constants.
+    # (count_seen(GUESTS)'s own loop emits 2 ADDBYs -- the idx+lo offset and
+    # the acc accumulation, see IntExpression._emit_count_seen_range -- so
+    # the outer "+ 1" is asserted directly rather than by a total count.)
+    source = game_with_stage(
+        "x = count_seen(GUESTS) + 1;",
+        "cohort GUESTS = 300..319;\nvolatile { int x = 0; }",
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+    cmds = (out_dir / "cmds.gqasm").read_text()
+    ops = one_event(cmds).ops
+    assert any(op.name == "QCGET" for op in ops)
+    outer_addby = [op for op in ops if op.name == "ADDBY"][-1]  # the "+ 1" itself, after the loop
+    assert outer_addby.flags & structs.OpFlags.LITERAL_ARG2
+    assert outer_addby.arg2 == 1
+
+
+def test_in_cohort_folds_when_id_is_a_literal(compile_gq):
+    # Unlike have_met()/count_seen(), in_cohort(NAME, id) is a pure
+    # "(id >= lo) && (id <= hi)" range compare -- no badge state involved --
+    # so it folds whenever `id` itself does, exactly like any other
+    # literal-only subexpression (gamequeer#385).
+    source = game_with_stage(
+        "x = in_cohort(GUESTS, 305);",
+        "cohort GUESTS = 300..319;\nvolatile { int x = 0; }",
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+    cmds = (out_dir / "cmds.gqasm").read_text()
+    assert _folded_setvar_value(cmds) == 1
+
+
+def test_in_cohort_with_variable_id_does_not_fold(compile_gq):
+    source = game_with_stage(
+        "x = in_cohort(GUESTS, y);",
+        "cohort GUESTS = 300..319;\nvolatile { int x = 0; int y = 0; }",
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+    cmds = (out_dir / "cmds.gqasm").read_text()
+    ops = one_event(cmds).ops
+    assert "GE" in [op.name for op in ops]
+    assert "LE" in [op.name for op in ops]
+    assert "AND" in [op.name for op in ops]

--- a/gqc/tests/test_constants.py
+++ b/gqc/tests/test_constants.py
@@ -15,7 +15,11 @@ single flat, file-global namespace, resolved eagerly in source order -- a
 `const`/`enum` must be declared *before* its first use, like a `#define` in
 a single-pass C preprocessor (see `datamodel.Constant`'s docstring for the
 full reasoning). This is a deliberate, documented departure from ordinary
-variable/stage/animation references, which *are* forward-reference-tolerant.
+variable/stage/animation references, which *are* forward-reference-tolerant
+-- and, since gamequeer#427's review, an *enforced* one: a bare `const`
+identifier referenced ahead of its own declaration is a fatal compile error
+(`parser.check_pending_int_refs`), not a silent fall-through to treating it
+as an always-undefined variable.
 """
 
 import pytest
@@ -342,37 +346,55 @@ def test_const_initialized_from_a_variable_rejects(compile_gq):
     assert_no_traceback(stderr)
 
 
-# --- scoping: declare-before-use (documented, deliberate limitation) --------
+# --- scoping: declare-before-use is an enforced, fatal error ----------------
 
 
-def test_const_referenced_before_its_declaration_does_not_error_at_parse_time(
-    compile_gq,
-):
-    # Pins the documented declare-before-use scoping decision (see this
-    # module's docstring and datamodel.Constant's): a `const` referenced
-    # textually before its own declaration is not in Constant.const_table
-    # yet, so parser.parse_int_operand's identifier branch falls through to
-    # treating "LATER" as an ordinary (variable) reference instead, exactly
-    # as it would for any other not-yet-defined name.
+def test_const_referenced_before_its_declaration_rejects(compile_gq):
+    # gamequeer#427 review: a `const` referenced textually before its own
+    # declaration used to compile clean (exit 0) with the reference
+    # silently left at `arg2 == 0` -- Constant.const_table didn't have
+    # "LATER" in it yet when parser.parse_int_operand's identifier branch
+    # ran, so it fell through to treating "LATER" as an ordinary (and, in
+    # this case, always-undefined) variable reference instead, and a
+    # *separate* pre-existing gap in CommandWithIntExpressionArgument.
+    # resolve() (its int-operand branch was missing the "else:
+    # unresolved_symbols.append(...)" its own string-operand counterpart
+    # already had) meant that never even got reported as an unresolved
+    # symbol.
     #
-    # That reference is then silently left at arg2 == 0 rather than
-    # reported as an unresolved symbol -- a *separate*, pre-existing gap in
-    # CommandWithIntExpressionArgument.resolve() (its int-operand branch is
-    # missing the "else: unresolved_symbols.append(...)" its own
-    # string-operand counterpart, CommandWithStrExpressionArgument.resolve,
-    # already has), not something gamequeer#421 introduces or is
-    # responsible for fixing. Pinned here (gqc exits 0) so that gap is
-    # visible and cross-referenced rather than silently masked by this
-    # feature's own tests.
+    # parser.check_pending_int_refs closes the const/enum half of that gap
+    # directly (independent of whether the general unresolved-int-symbol
+    # gap above is ever fixed elsewhere): once the whole file is parsed,
+    # gqc knows "LATER" does eventually get defined as a const, so a
+    # forward reference to it is diagnosed as exactly that, not silently
+    # miscompiled.
     source = (
         f"{GAME_HEADER}"
         "volatile { int x = 0; }\n"
         "stage start { event enter { x = LATER; } }\n"
         "const LATER = 5;\n"
     )
+    exit_code, stderr, _out_dir = compile_gq(source)
+    assert exit_code == 1
+    # Split across two assertions for the same rich line-wrap reason as
+    # test_const_value_exceeding_int32_range_rejects, above.
+    assert "'LATER' is a const/enum member declared later" in stderr
+    assert "must be declared before their first use" in stderr
+    assert_no_traceback(stderr)
+
+
+def test_const_referenced_after_its_declaration_accepts(compile_gq):
+    # Same identifier, same reference, only the order swapped -- the
+    # accept side of the reject test above, so the new diagnostic is
+    # pinned as declare-before-use specifically, not "referencing a const
+    # named LATER" in general.
+    source = (
+        f"{GAME_HEADER}"
+        "const LATER = 5;\n"
+        "volatile { int x = 0; }\n"
+        "stage start { event enter { x = LATER; } }\n"
+    )
     exit_code, stderr, out_dir = compile_gq(source)
     assert exit_code == 0, stderr
     cmds = (out_dir / "cmds.gqasm").read_text()
-    setvar = one_event(cmds).ops[0]
-    assert not (setvar.flags & structs.OpFlags.LITERAL_ARG2)
-    assert setvar.arg2 == 0
+    assert _folded_setvar_value(cmds) == 5

--- a/gqc/tests/test_constants.py
+++ b/gqc/tests/test_constants.py
@@ -1,0 +1,378 @@
+"""Named compile-time constants and enums suite for gqc (gamequeer#421, epic
+gamequeer#419).
+
+`const NAME = <int-expression>;` and `enum Name { A, B, C }` (referenced as
+`Name.Member`) are pure parse-time sugar (`datamodel.Constant`/
+`datamodel.Enum`): every reference is substituted with a literal
+`GqcIntOperand` at the point it's parsed, reusing gamequeer#385's
+`fold_constant_int_expression` for anything more than a bare literal RHS --
+by the time codegen sees one, it's indistinguishable from a hand-written int
+literal. This keeps the feature entirely inside gqc: no new opcode,
+register, or on-cart format (FROZEN VM CONTRACT).
+
+Scoping (the "keep it simple" decision the issue asks for), pinned here: a
+single flat, file-global namespace, resolved eagerly in source order -- a
+`const`/`enum` must be declared *before* its first use, like a `#define` in
+a single-pass C preprocessor (see `datamodel.Constant`'s docstring for the
+full reasoning). This is a deliberate, documented departure from ordinary
+variable/stage/animation references, which *are* forward-reference-tolerant.
+"""
+
+import pytest
+
+from gqc import structs
+
+from .opstream import one_event
+
+GAME_HEADER = 'game { id = 1; title := "T"; author := "A"; starting_stage = start; }\n'
+
+
+def game_with_stage(body: str, decls: str = "") -> str:
+    """A minimal valid game with a single stage `start` whose `enter` event
+    runs `body`, optionally preceded by top-level declarations (e.g. a
+    `const`/`enum` block)."""
+    return f"{GAME_HEADER}{decls}\nstage start {{ event enter {{ {body} }} }}\n"
+
+
+def assert_no_traceback(stderr: str):
+    assert "Traceback" not in stderr, f"raw Python traceback leaked to stderr:\n{stderr}"
+
+
+def _folded_setvar_value(cmds_text: str) -> int:
+    """Assert `cmds_text`'s only real op is a single literal SETVAR (i.e.
+    the whole expression folded to one constant) and return its value."""
+    ops = one_event(cmds_text).ops
+    assert [op.name for op in ops] == ["SETVAR", "DONE"]
+    setvar, _done = ops
+    assert setvar.flags & structs.OpFlags.LITERAL_ARG2
+    return setvar.arg2
+
+
+# --- const: declaration + use, folds to a literal ----------------------------
+
+
+def test_const_bare_literal_accepts_and_folds(compile_gq):
+    source = game_with_stage(
+        "x = MAX_HP;", "const MAX_HP = 21;\nvolatile { int x = 0; }"
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+    cmds = (out_dir / "cmds.gqasm").read_text()
+    assert _folded_setvar_value(cmds) == 21
+
+
+def test_const_expression_rhs_folds_at_declaration(compile_gq):
+    # The const's own RHS is an int_expression, so it gets gamequeer#385's
+    # folding for free -- "20 + 1" never appears as a runtime ADDBY anywhere,
+    # not at the declaration and not at any of its uses.
+    source = game_with_stage(
+        "x = MAX_HP;", "const MAX_HP = 20 + 1;\nvolatile { int x = 0; }"
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+    cmds = (out_dir / "cmds.gqasm").read_text()
+    assert "ADDBY" not in cmds
+    assert _folded_setvar_value(cmds) == 21
+
+
+def test_const_used_multiple_times_each_folds_independently(compile_gq):
+    source = game_with_stage(
+        "x = MAX_HP; y = MAX_HP + 1;",
+        "const MAX_HP = 21;\nvolatile { int x = 0; int y = 0; }",
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+    cmds = (out_dir / "cmds.gqasm").read_text()
+    ops = one_event(cmds).ops
+    assert [op.name for op in ops] == ["SETVAR", "SETVAR", "DONE"]
+    setvar_x, setvar_y, _done = ops
+    assert setvar_x.flags & structs.OpFlags.LITERAL_ARG2
+    assert setvar_x.arg2 == 21
+    assert setvar_y.flags & structs.OpFlags.LITERAL_ARG2
+    assert setvar_y.arg2 == 22
+
+
+def test_const_referencing_an_earlier_const_folds(compile_gq):
+    source = game_with_stage(
+        "x = DOUBLE_MAX_HP;",
+        "const MAX_HP = 21;\nconst DOUBLE_MAX_HP = MAX_HP * 2;\n"
+        "volatile { int x = 0; }",
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+    cmds = (out_dir / "cmds.gqasm").read_text()
+    assert "MULBY" not in cmds
+    assert _folded_setvar_value(cmds) == 42
+
+
+def test_const_usable_in_if_condition(compile_gq):
+    source = game_with_stage(
+        "if (x > MAX_HP) { badge_set 1; }",
+        "const MAX_HP = 21;\nvolatile { int x = 0; }",
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+    cmds = (out_dir / "cmds.gqasm").read_text()
+    ops = one_event(cmds).ops
+    gt = next(op for op in ops if op.name == "GT")
+    assert gt.flags & structs.OpFlags.LITERAL_ARG2
+    assert gt.arg2 == 21
+
+
+def test_const_mixed_with_variable_folds_only_the_literal_side(compile_gq):
+    # Same "literal subtree folds, variable side stays a real op" behavior
+    # test_constant_folding.py already pins for bare literals -- a `const`
+    # reference is just another literal by the time int_operand sees it.
+    source = game_with_stage(
+        "x = y + MAX_HP;", "const MAX_HP = 21;\nvolatile { int x = 0; int y = 0; }"
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+    cmds = (out_dir / "cmds.gqasm").read_text()
+    ops = one_event(cmds).ops
+    addby = next(op for op in ops if op.name == "ADDBY")
+    assert addby.flags & structs.OpFlags.LITERAL_ARG2
+    assert addby.arg2 == 21
+
+
+# --- enum: declaration + Name.Member use, auto-numbered from 0 ---------------
+
+
+def test_enum_members_auto_number_from_zero(compile_gq):
+    source = game_with_stage(
+        "x = Difficulty.Easy; y = Difficulty.Medium; z = Difficulty.Hard;",
+        "enum Difficulty { Easy, Medium, Hard }\n"
+        "volatile { int x = 0; int y = 0; int z = 0; }",
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+    cmds = (out_dir / "cmds.gqasm").read_text()
+    ops = one_event(cmds).ops
+    setvars = [op for op in ops if op.name == "SETVAR"]
+    assert [op.arg2 for op in setvars] == [0, 1, 2]
+    for op in setvars:
+        assert op.flags & structs.OpFlags.LITERAL_ARG2
+
+
+def test_enum_member_usable_in_expression_and_folds(compile_gq):
+    source = game_with_stage(
+        "x = Difficulty.Hard + 1;",
+        "enum Difficulty { Easy, Medium, Hard }\nvolatile { int x = 0; }",
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+    cmds = (out_dir / "cmds.gqasm").read_text()
+    assert "ADDBY" not in cmds
+    assert _folded_setvar_value(cmds) == 3
+
+
+def test_enum_member_usable_in_if_condition(compile_gq):
+    source = game_with_stage(
+        "if (x > Difficulty.Easy) { badge_set 1; }",
+        "enum Difficulty { Easy, Medium, Hard }\nvolatile { int x = 0; }",
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+    cmds = (out_dir / "cmds.gqasm").read_text()
+    ops = one_event(cmds).ops
+    gt = next(op for op in ops if op.name == "GT")
+    assert gt.flags & structs.OpFlags.LITERAL_ARG2
+    assert gt.arg2 == 0
+
+
+def test_const_referencing_enum_member_folds_at_declaration(compile_gq):
+    source = game_with_stage(
+        "x = HARD_BONUS;",
+        "enum Difficulty { Easy, Medium, Hard }\n"
+        "const HARD_BONUS = Difficulty.Hard + 10;\n"
+        "volatile { int x = 0; }",
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+    cmds = (out_dir / "cmds.gqasm").read_text()
+    assert "ADDBY" not in cmds
+    assert _folded_setvar_value(cmds) == 12
+
+
+# --- "const"/"enum" keywords don't swallow a prefixed identifier ------------
+# Matches the existing gamequeer#354 convention pinned for "str"/"badge_get"/
+# "badge_count" -- both are matched via Keyword(), not a bare string.
+
+
+def test_const_prefixed_identifier_accepts(compile_gq):
+    source = game_with_stage(
+        "constant_value = 5;", "volatile { int constant_value = 0; }"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_enum_prefixed_identifier_accepts(compile_gq):
+    source = game_with_stage(
+        "enumerate_x = 5;", "volatile { int enumerate_x = 0; }"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+# --- reject: duplicate definitions -------------------------------------------
+
+
+def test_duplicate_const_rejects(compile_gq):
+    source = (
+        f"{GAME_HEADER}"
+        "const A = 1;\n"
+        "const A = 2;\n"
+        "stage start { event enter { badge_set 1; } }\n"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 1
+    assert "Duplicate definition of constant A" in stderr
+    assert_no_traceback(stderr)
+
+
+def test_duplicate_enum_name_rejects(compile_gq):
+    source = (
+        f"{GAME_HEADER}"
+        "enum Difficulty { Easy, Hard }\n"
+        "enum Difficulty { Trivial, Brutal }\n"
+        "stage start { event enter { badge_set 1; } }\n"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 1
+    assert "Duplicate definition of enum Difficulty" in stderr
+    assert_no_traceback(stderr)
+
+
+def test_duplicate_member_within_enum_rejects(compile_gq):
+    source = (
+        f"{GAME_HEADER}"
+        "enum Difficulty { Easy, Easy, Hard }\n"
+        "stage start { event enter { badge_set 1; } }\n"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 1
+    assert "Duplicate member Easy in enum Difficulty" in stderr
+    assert_no_traceback(stderr)
+
+
+# --- reject: unknown enum / unknown member -----------------------------------
+
+
+def test_unknown_enum_rejects(compile_gq):
+    source = game_with_stage(
+        "x = Bogus.Whatever;", "volatile { int x = 0; }"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 1
+    assert "Unknown enum Bogus" in stderr
+    assert_no_traceback(stderr)
+
+
+def test_unknown_member_of_known_enum_rejects(compile_gq):
+    source = game_with_stage(
+        "x = Difficulty.Nightmare;",
+        "enum Difficulty { Easy, Hard }\nvolatile { int x = 0; }",
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 1
+    assert "Unknown member Nightmare of enum Difficulty" in stderr
+    assert_no_traceback(stderr)
+
+
+# --- reject: out-of-range constant value -------------------------------------
+
+
+def test_const_value_exceeding_int32_range_rejects(compile_gq):
+    # A bare literal RHS is never routed through fold_constant_int_expression
+    # (int_expression's own parse action short-circuits a lone GqcIntOperand
+    # straight through -- see parser.parse_int_expression), so this needs
+    # its own explicit range check in Constant.define; without it, an
+    # over-range `const` would silently reach struct.pack and fail later
+    # with an unrelated OverflowError instead of a clean diagnostic here.
+    source = (
+        f"{GAME_HEADER}"
+        "const BIG = 99999999999;\n"
+        "stage start { event enter { badge_set 1; } }\n"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 1
+    # Split across two assertions (not one long substring): rich's console
+    # wraps long error lines at the terminal width, which would otherwise
+    # insert an unpredictable newline into a single "in stderr" check --
+    # matches the splitting convention test_diagnostics.py's own
+    # long-message cases already use.
+    assert "Constant BIG value 99999999999 is out of range for a" in stderr
+    assert "32-bit int (t_gq_int)" in stderr
+    assert_no_traceback(stderr)
+
+
+def test_const_value_at_int32_max_accepts(compile_gq):
+    source = game_with_stage(
+        "x = INT32_MAX;", "const INT32_MAX = 2147483647;\nvolatile { int x = 0; }"
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+    cmds = (out_dir / "cmds.gqasm").read_text()
+    assert _folded_setvar_value(cmds) == 2147483647
+
+
+# --- reject: const initializer isn't a compile-time constant -----------------
+
+
+def test_const_initialized_from_a_variable_rejects(compile_gq):
+    # `const` has no runtime fallback -- unlike a `volatile`/`persistent`
+    # variable initializer, its RHS must fold all the way to a literal at
+    # declaration time. A reference to an actual runtime variable (or,
+    # indistinguishably from gqc's point of view, a typo'd/undeclared name)
+    # is rejected here rather than silently accepted as an unresolved
+    # symbol.
+    source = (
+        f"{GAME_HEADER}"
+        "volatile { int y = 5; }\n"
+        "const A = y + 1;\n"
+        "stage start { event enter { badge_set 1; } }\n"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 1
+    # Split across two assertions for the same rich line-wrap reason as
+    # test_const_value_exceeding_int32_range_rejects, above.
+    assert "Constant A must be initialized with a compile-time" in stderr
+    assert "constant integer expression" in stderr
+    assert_no_traceback(stderr)
+
+
+# --- scoping: declare-before-use (documented, deliberate limitation) --------
+
+
+def test_const_referenced_before_its_declaration_does_not_error_at_parse_time(
+    compile_gq,
+):
+    # Pins the documented declare-before-use scoping decision (see this
+    # module's docstring and datamodel.Constant's): a `const` referenced
+    # textually before its own declaration is not in Constant.const_table
+    # yet, so parser.parse_int_operand's identifier branch falls through to
+    # treating "LATER" as an ordinary (variable) reference instead, exactly
+    # as it would for any other not-yet-defined name.
+    #
+    # That reference is then silently left at arg2 == 0 rather than
+    # reported as an unresolved symbol -- a *separate*, pre-existing gap in
+    # CommandWithIntExpressionArgument.resolve() (its int-operand branch is
+    # missing the "else: unresolved_symbols.append(...)" its own
+    # string-operand counterpart, CommandWithStrExpressionArgument.resolve,
+    # already has), not something gamequeer#421 introduces or is
+    # responsible for fixing. Pinned here (gqc exits 0) so that gap is
+    # visible and cross-referenced rather than silently masked by this
+    # feature's own tests.
+    source = (
+        f"{GAME_HEADER}"
+        "volatile { int x = 0; }\n"
+        "stage start { event enter { x = LATER; } }\n"
+        "const LATER = 5;\n"
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+    cmds = (out_dir / "cmds.gqasm").read_text()
+    setvar = one_event(cmds).ops[0]
+    assert not (setvar.flags & structs.OpFlags.LITERAL_ARG2)
+    assert setvar.arg2 == 0

--- a/gqc/tests/test_game_layout.py
+++ b/gqc/tests/test_game_layout.py
@@ -18,13 +18,14 @@ concat/merge is explicitly out of scope here -- that's gamequeer#401):
     directory is self-contained regardless of where `gqc compile` is
     invoked from. `gqc new` scaffolds a fresh game directory in that shape.
 
-The "anywhere" cases also exercise two order-dependency traps that moving
-game{} out of its fixed first slot exposed (see datamodel.py's Stage,
-Game.__init__/add_stage, and parser.parse_fw_version_operand): Stage.__init__
-used to call Game.game.add_stage(self) unconditionally, and
-parse_fw_version_operand used to write straight to Game.game.needs_fw_probe
--- both would crash with AttributeError on `NoneType` if the stage in
-question was parsed before game{} itself.
+The "anywhere" cases also exercise order-dependency traps that moving game{}
+out of its fixed first slot exposed (see datamodel.py's Stage,
+Game.__init__/add_stage, and parser.parse_fw_version_operand/
+parse_random_operand): Stage.__init__ used to call Game.game.add_stage(self)
+unconditionally, and parse_fw_version_operand/parse_random_operand used to
+write straight to Game.game.needs_fw_probe/Game.game.needs_random -- all
+three would crash with AttributeError on `NoneType` if the stage in question
+was parsed before game{} itself.
 """
 
 import pathlib
@@ -99,6 +100,22 @@ def test_fw_version_call_before_game_block_accepts(compile_gq):
     # independent).
     source = (
         "stage start { event enter { x = fw_version(); } }\n"
+        + GAME_HEADER
+        + "volatile { int x = 0; }\n"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+    assert "Traceback" not in stderr
+
+
+def test_random_call_before_game_block_accepts(compile_gq):
+    # Regression guard (gamequeer#427, Copilot finding): parse_random_operand
+    # used to write straight to Game.game.needs_random -- an AttributeError
+    # on `NoneType` if the calling stage was parsed before game{} existed,
+    # same hazard as fw_version() above (see Game.needs_random_seen in
+    # datamodel.py, which makes this order-independent too).
+    source = (
+        "stage start { event enter { x = random(0, 10); } }\n"
         + GAME_HEADER
         + "volatile { int x = 0; }\n"
     )

--- a/gqc/tests/test_game_layout.py
+++ b/gqc/tests/test_game_layout.py
@@ -1,0 +1,271 @@
+"""Game-as-directory layout suite for gqc (gamequeer#420, part of the DEF
+CON sprint epic gamequeer#419).
+
+Covers the two structural pieces #420 delivers (multi-file source
+concat/merge is explicitly out of scope here -- that's gamequeer#401):
+
+  - `game{}` may now appear anywhere in the top-level section stream,
+    instead of being structurally locked to first -- with "exactly one"
+    enforced semantically: a second one is still rejected by
+    Game.__init__'s existing "Game already defined" check (unchanged from
+    before #420), and a missing one is now rejected by a new check in
+    parser.parse() (previously impossible: the grammar itself required
+    game_definition_section as the first, mandatory token).
+
+  - `animations{}`/`lightcues{}` asset sources resolve relative to the
+    game's own directory (the entry `.gq` file's parent -- gqc.py's
+    `compile` sets Game.game_dir from it), not the process CWD, so a game
+    directory is self-contained regardless of where `gqc compile` is
+    invoked from. `gqc new` scaffolds a fresh game directory in that shape.
+
+The "anywhere" cases also exercise two order-dependency traps that moving
+game{} out of its fixed first slot exposed (see datamodel.py's Stage,
+Game.__init__/add_stage, and parser.parse_fw_version_operand): Stage.__init__
+used to call Game.game.add_stage(self) unconditionally, and
+parse_fw_version_operand used to write straight to Game.game.needs_fw_probe
+-- both would crash with AttributeError on `NoneType` if the stage in
+question was parsed before game{} itself.
+"""
+
+import pathlib
+import shutil
+import subprocess
+import sys
+
+import pytest
+from PIL import Image
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+CIRCLE_BMP = REPO_ROOT / "gqc" / "examples" / "skel" / "assets" / "animations" / "circle.bmp"
+TEST_GQCUE = REPO_ROOT / "examples" / "assets" / "lighting" / "test.gqcue"
+
+GAME_HEADER = 'game { id = 1; title := "T"; author := "A"; starting_stage = start; }\n'
+STAGE = "stage start { event enter { } }\n"
+
+COMPILE_TIMEOUT_S = 60
+
+
+def _run(cwd, args, timeout=COMPILE_TIMEOUT_S):
+    proc = subprocess.run(
+        [sys.executable, "-m", "gqc", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    return proc.returncode, proc.stderr, proc.stdout
+
+
+# --- game{}: anywhere in the top-level section stream (accept) --------------
+
+
+def test_game_block_after_stage_accepts(compile_gq):
+    source = STAGE + GAME_HEADER
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_game_block_between_other_sections_accepts(compile_gq):
+    source = "volatile { int x = 0; }\n" + GAME_HEADER + STAGE
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_game_block_last_accepts(compile_gq):
+    source = STAGE + "volatile { int x = 0; }\n" + GAME_HEADER
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_starting_stage_defined_before_game_block_resolves(compile_gq):
+    # Regression guard: Stage.__init__ used to call Game.game.add_stage(self)
+    # unconditionally -- an AttributeError on `NoneType` if `stage start`
+    # (the game's own declared starting_stage) was parsed before game{}
+    # existed. A clean (exit 0) compile here also proves Game.starting_stage
+    # actually ended up resolved: Game.to_bytes() raises a hard
+    # "Starting stage not defined" ValueError otherwise, which would surface
+    # as a non-zero exit / traceback, not a clean compile.
+    source = STAGE + GAME_HEADER
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+    assert "Traceback" not in stderr
+
+
+def test_fw_version_call_before_game_block_accepts(compile_gq):
+    # Regression guard: parse_fw_version_operand used to write straight to
+    # Game.game.needs_fw_probe -- an AttributeError on `NoneType` if the
+    # calling stage was parsed before game{} existed (see
+    # Game.needs_fw_probe_seen in datamodel.py, which makes this order-
+    # independent).
+    source = (
+        "stage start { event enter { x = fw_version(); } }\n"
+        + GAME_HEADER
+        + "volatile { int x = 0; }\n"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+    assert "Traceback" not in stderr
+
+
+# --- game{}: exactly-one cardinality (reject) --------------------------------
+
+
+def test_duplicate_game_blocks_reject(compile_gq):
+    # Two separate game{} sections (as opposed to test_grammar.py's
+    # test_game_block_duplicate_key_rejects, which is a duplicate *key*
+    # inside a single game{} block -- an unrelated case). Still caught
+    # structurally by Game.__init__, unchanged by gamequeer#420.
+    source = GAME_HEADER + STAGE + GAME_HEADER
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+    assert "Game already defined" in stderr
+
+
+def test_missing_game_block_rejects(compile_gq):
+    # No game{} block anywhere. Before gamequeer#420 this was impossible to
+    # reach cleanly: the grammar itself required game_definition_section
+    # first, so this failed as a raw pyparsing ParseSyntaxException instead
+    # of the dedicated check parser.parse() now performs once top-level
+    # parsing otherwise succeeds.
+    source = STAGE
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+    assert "game" in stderr.lower()
+    assert "Traceback" not in stderr
+
+
+# --- animations{}/lightcues{}: game-directory-relative asset resolution -----
+
+
+def _write_game_dir(base_dir: pathlib.Path, name: str, decls: str) -> pathlib.Path:
+    game_dir = base_dir / name
+    game_dir.mkdir(parents=True)
+    (game_dir / f"{name}.gq").write_text(
+        f"{GAME_HEADER}{decls}\n{STAGE}"
+    )
+    return game_dir
+
+
+def test_animation_source_resolves_relative_to_game_dir_not_cwd(tmp_path):
+    # The game directory (mygame/) is *not* the invocation CWD (tmp_path,
+    # its parent) -- only Game.game_dir (derived from the entry file's own
+    # path, gqc.py's `compile`) should matter for resolving `<- "circle.bmp"`.
+    game_dir = _write_game_dir(
+        tmp_path, "mygame", 'animations { c <- "circle.bmp"; }\n'
+    )
+    assets_dir = game_dir / "assets" / "animations"
+    assets_dir.mkdir(parents=True)
+    shutil.copyfile(CIRCLE_BMP, assets_dir / "circle.bmp")
+
+    out_dir = tmp_path / "build"
+    exit_code, stderr, _ = _run(
+        tmp_path,
+        ["compile", "-o", str(out_dir), str(game_dir / "mygame.gq")],
+    )
+    assert exit_code == 0, stderr
+
+
+def test_animation_source_at_old_cwd_relative_location_is_not_found(tmp_path):
+    # Negative control for the case above: an asset sitting at the *old*
+    # CWD-relative assets/animations/ location (the invocation CWD, not the
+    # game directory) must no longer be found -- pins that gamequeer#420
+    # actually changed the resolution root rather than just adding a
+    # fallback.
+    game_dir = _write_game_dir(
+        tmp_path, "mygame", 'animations { c <- "circle.bmp"; }\n'
+    )
+    old_style_assets_dir = tmp_path / "assets" / "animations"
+    old_style_assets_dir.mkdir(parents=True)
+    shutil.copyfile(CIRCLE_BMP, old_style_assets_dir / "circle.bmp")
+
+    out_dir = tmp_path / "build"
+    exit_code, stderr, _ = _run(
+        tmp_path,
+        ["compile", "-o", str(out_dir), str(game_dir / "mygame.gq")],
+    )
+    assert exit_code != 0
+    assert "circle.bmp" in stderr
+
+
+def test_lightcue_source_resolves_relative_to_game_dir_not_cwd(tmp_path):
+    game_dir = _write_game_dir(
+        tmp_path, "mygame", 'lightcues { c1 <- "test.gqcue"; }\n'
+    )
+    assets_dir = game_dir / "assets" / "lighting"
+    assets_dir.mkdir(parents=True)
+    shutil.copyfile(TEST_GQCUE, assets_dir / "test.gqcue")
+
+    out_dir = tmp_path / "build"
+    exit_code, stderr, _ = _run(
+        tmp_path,
+        ["compile", "-o", str(out_dir), str(game_dir / "mygame.gq")],
+    )
+    assert exit_code == 0, stderr
+
+
+def test_lightcue_source_at_old_cwd_relative_location_is_not_found(tmp_path):
+    game_dir = _write_game_dir(
+        tmp_path, "mygame", 'lightcues { c1 <- "test.gqcue"; }\n'
+    )
+    old_style_assets_dir = tmp_path / "assets" / "lighting"
+    old_style_assets_dir.mkdir(parents=True)
+    shutil.copyfile(TEST_GQCUE, old_style_assets_dir / "test.gqcue")
+
+    out_dir = tmp_path / "build"
+    exit_code, stderr, _ = _run(
+        tmp_path,
+        ["compile", "-o", str(out_dir), str(game_dir / "mygame.gq")],
+    )
+    assert exit_code != 0
+    assert "test.gqcue" in stderr
+
+
+# --- `gqc new`: scaffolding a fresh game-as-directory game -------------------
+
+
+def test_new_scaffolds_entry_file_and_asset_subdirs(tmp_path):
+    exit_code, stderr, _ = _run(tmp_path, ["new", "mygame"])
+    assert exit_code == 0, stderr
+
+    game_dir = tmp_path / "mygame"
+    assert (game_dir / "mygame.gq").exists()
+    assert (game_dir / "assets" / "animations").is_dir()
+    assert (game_dir / "assets" / "lighting").is_dir()
+
+
+def test_new_scaffolded_entry_file_compiles(tmp_path):
+    exit_code, stderr, _ = _run(tmp_path, ["new", "mygame"])
+    assert exit_code == 0, stderr
+
+    out_dir = tmp_path / "build"
+    exit_code, stderr, _ = _run(
+        tmp_path,
+        ["compile", "-o", str(out_dir), str(tmp_path / "mygame" / "mygame.gq")],
+    )
+    assert exit_code == 0, stderr
+    assert (out_dir / "mygame.gqgame").exists()
+
+
+def test_new_refuses_to_overwrite_existing_game_without_force(tmp_path):
+    exit_code, _, _ = _run(tmp_path, ["new", "mygame"])
+    assert exit_code == 0
+
+    entry_path = tmp_path / "mygame" / "mygame.gq"
+    entry_path.write_text("MODIFIED")
+
+    exit_code, stderr, stdout = _run(tmp_path, ["new", "mygame"])
+    assert exit_code == 0  # click command itself doesn't fail; it just declines
+    assert entry_path.read_text() == "MODIFIED"
+    assert "already exists" in stdout + stderr
+
+
+def test_new_force_overwrites_existing_game(tmp_path):
+    exit_code, _, _ = _run(tmp_path, ["new", "mygame"])
+    assert exit_code == 0
+
+    entry_path = tmp_path / "mygame" / "mygame.gq"
+    entry_path.write_text("MODIFIED")
+
+    exit_code, stderr, _ = _run(tmp_path, ["new", "mygame", "--force"])
+    assert exit_code == 0, stderr
+    assert entry_path.read_text() != "MODIFIED"

--- a/gqc/tests/test_grammar.py
+++ b/gqc/tests/test_grammar.py
@@ -132,6 +132,189 @@ def test_badge_count_bare_no_parens_rejects(compile_gq):
     assert exit_code != 0
 
 
+# --- social vocabulary (gamequeer#423, DEF CON sprint epic gamequeer#419) ----
+# cohort NAME = <lo>..<hi>; have_met(id); in_cohort(NAME, id); seen_self();
+# count_seen() / count_seen(NAME) -- all desugar to badge_get/badge_set/
+# badge_count() and ordinary comparisons, no VM change.
+
+
+def game_with_cohort_and_stage(body: str, cohort_decl: str, decls: str = "") -> str:
+    """Same as game_with_stage, but with a cohort declaration inserted
+    between the game header and any other top-level declarations -- cohort
+    declarations must precede any reference to them (single-pass parse,
+    same requirement as cue/menu/animation declarations elsewhere)."""
+    return f"{GAME_HEADER}{cohort_decl}\n{decls}\nstage start {{ event enter {{ {body} }} }}\n"
+
+
+def test_cohort_declaration_accepts(compile_gq):
+    source = game_with_cohort_and_stage("x = 1;", "cohort GUESTS = 300..319;", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_cohort_declaration_missing_range_rejects(compile_gq):
+    source = game_with_cohort_and_stage("x = 1;", "cohort GUESTS = 300;", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+
+
+def test_cohort_declaration_inverted_range_rejects(compile_gq):
+    # lo > hi -- an empty range is never useful and almost certainly a typo.
+    source = game_with_cohort_and_stage("x = 1;", "cohort GUESTS = 319..300;", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+
+
+def test_cohort_declaration_out_of_bounds_rejects(compile_gq):
+    # hi >= BADGES_ALLOWED (320) -- out of range for the badges-seen bitfield.
+    source = game_with_cohort_and_stage("x = 1;", "cohort GUESTS = 0..320;", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+
+
+def test_cohort_declaration_duplicate_name_rejects(compile_gq):
+    source = game_with_cohort_and_stage(
+        "x = 1;", "cohort GUESTS = 0..5;\ncohort GUESTS = 6..10;", "volatile { int x = 0; }"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+
+
+def test_have_met_call_accepts(compile_gq):
+    source = game_with_stage("x = have_met(5);", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_have_met_no_argument_rejects(compile_gq):
+    # have_met(id) is unary -- the argument is mandatory.
+    source = game_with_stage("x = have_met();", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+    assert "ParseSyntaxException" in stderr
+
+
+def test_have_met_two_arguments_rejects(compile_gq):
+    source = game_with_stage("x = have_met(1, 2);", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+    assert "ParseSyntaxException" in stderr
+
+
+def test_in_cohort_call_accepts(compile_gq):
+    source = game_with_cohort_and_stage(
+        "x = in_cohort(GUESTS, y);", "cohort GUESTS = 300..319;", "volatile { int x = 0; int y = 0; }"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_in_cohort_undefined_cohort_rejects(compile_gq):
+    source = game_with_stage("x = in_cohort(NOPE, y);", "volatile { int x = 0; int y = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+    assert "Undefined cohort" in stderr
+
+
+def test_in_cohort_used_before_declared_rejects(compile_gq):
+    # Single-pass parse, same requirement as cue/menu/animation references:
+    # a cohort must be declared above any use of it.
+    source = (
+        f"{GAME_HEADER}volatile {{ int x = 0; int y = 0; }}\n"
+        "stage start { event enter { x = in_cohort(GUESTS, y); } }\n"
+        "cohort GUESTS = 300..319;\n"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+    assert "Undefined cohort" in stderr
+
+
+def test_in_cohort_one_argument_rejects(compile_gq):
+    source = game_with_cohort_and_stage(
+        "x = in_cohort(GUESTS);", "cohort GUESTS = 300..319;", "volatile { int x = 0; }"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+    assert "ParseSyntaxException" in stderr
+
+
+def test_in_cohort_three_arguments_rejects(compile_gq):
+    source = game_with_cohort_and_stage(
+        "x = in_cohort(GUESTS, y, z);",
+        "cohort GUESTS = 300..319;",
+        "volatile { int x = 0; int y = 0; int z = 0; }",
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+    assert "ParseSyntaxException" in stderr
+
+
+def test_seen_self_call_accepts(compile_gq):
+    source = game_with_stage("seen_self();")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_seen_self_with_argument_rejects(compile_gq):
+    source = game_with_stage("seen_self(1);")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+    assert "ParseSyntaxException" in stderr
+
+
+def test_seen_self_bare_no_parens_rejects(compile_gq):
+    source = game_with_stage("seen_self;")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+
+
+def test_seen_self_as_expression_operand_rejects(compile_gq):
+    # seen_self() is a statement (like badge_set/badge_clear), not an
+    # int_operand -- it can't appear on the RHS of an assignment.
+    source = game_with_stage("x = seen_self();", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+
+
+def test_count_seen_bare_call_accepts(compile_gq):
+    source = game_with_stage("x = count_seen();", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_count_seen_with_cohort_accepts(compile_gq):
+    source = game_with_cohort_and_stage(
+        "x = count_seen(GUESTS);", "cohort GUESTS = 300..319;", "volatile { int x = 0; }"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_count_seen_undefined_cohort_rejects(compile_gq):
+    source = game_with_stage("x = count_seen(NOPE);", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+    assert "Undefined cohort" in stderr
+
+
+def test_count_seen_two_arguments_rejects(compile_gq):
+    source = game_with_cohort_and_stage(
+        "x = count_seen(GUESTS, GUESTS);", "cohort GUESTS = 300..319;", "volatile { int x = 0; }"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+    assert "ParseSyntaxException" in stderr
+
+
+def test_count_seen_literal_argument_rejects(compile_gq):
+    # count_seen()'s optional argument is a bare cohort name (an
+    # identifier), not an arbitrary int_expression.
+    source = game_with_stage("x = count_seen(1);", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+    assert "ParseSyntaxException" in stderr
+
+
 # --- str() cast: whole-RHS and inline (gamequeer#386) ------------------------
 
 

--- a/gqc/tests/test_grammar.py
+++ b/gqc/tests/test_grammar.py
@@ -731,17 +731,19 @@ def test_game_block_missing_key_rejects(compile_gq, game_block, missing_key):
 
 
 def test_game_block_duplicate_key_rejects(compile_gq):
-    # Pins current behavior: pyparsing's "each" operator can't tell a
-    # duplicate `id` from a missing everything-else, so the diagnostic
-    # names the *other* three keys as "missing" rather than naming `id` as
-    # duplicated. See gamequeer#331 investigation notes.
+    # game_assignment is a plain repetition (gamequeer#420 cardinality
+    # follow-up), not pyparsing's `&` ("each") operator -- so unlike the
+    # `&`-based diagnostic this used to pin (which could only ever name the
+    # *other* three keys as "missing", never `id` itself as duplicated; see
+    # gamequeer#331's investigation notes), parser.parse_game_definition
+    # counts each key itself and names the specific duplicated one.
     source = (
         'game { id = 1; id = 2; title := "T"; author := "A"; starting_stage = start; }\n'
         "stage start { event enter { badge_set 1; } }\n"
     )
     exit_code, stderr, _ = compile_gq(source)
     assert exit_code != 0
-    assert "Missing one or more required elements" in stderr
+    assert "id" in stderr
 
 
 def test_game_block_shuffled_order_accepts(compile_gq):

--- a/gqc/tests/test_grammar.py
+++ b/gqc/tests/test_grammar.py
@@ -206,6 +206,173 @@ def test_fw_version_write_rejects(compile_gq):
     assert "read-only" in stderr
 
 
+# --- random()/min()/max()/clamp()/abs() (gamequeer#422) -----------------------
+# Unlike badge_count()/fw_version() above, these all take one or more
+# int_expression *arguments* -- closer in grammar shape to str()'s
+# `str(<int_expression>)` cast (below) than to badge_count()'s empty parens.
+# test_random.py/test_math_intrinsics.py cover what they actually lower to;
+# test_constant_folding.py covers folding (min/max/clamp/abs fold when their
+# arguments do; random() never does). This section is just accept/reject
+# grammar coverage, including the same Keyword-not-bare-string/commits-on-
+# match care badge_count/fw_version/str already established.
+
+
+def test_random_call_accepts(compile_gq):
+    source = game_with_stage("x = random(1, 10);", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_random_combined_with_binary_op_accepts(compile_gq):
+    source = game_with_stage("x = random(1, 10) + 1;", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_random_accepts_full_expression_arguments(compile_gq):
+    # Unlike badge_count()/fw_version(), random()'s arguments are full
+    # int_expressions, not bare operands -- e.g. "y + 1", not just "y".
+    source = game_with_stage(
+        "x = random(y + 1, z * 2);", "volatile { int x = 0; int y = 0; int z = 5; }"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_random_wrong_arity_too_few_rejects(compile_gq):
+    # random() is binary -- Keyword("random") commits (via the grammar's
+    # `-`) as soon as "random" itself matches, so a missing argument fails
+    # with a clean, source-located ParseSyntaxException rather than
+    # silently falling through to some other (wrong) interpretation.
+    source = game_with_stage("x = random(1);", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+    assert "ParseSyntaxException" in stderr
+
+
+def test_random_wrong_arity_too_many_rejects(compile_gq):
+    source = game_with_stage("x = random(1, 10, 100);", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+    assert "ParseSyntaxException" in stderr
+
+
+def test_random_bare_no_parens_rejects(compile_gq):
+    source = game_with_stage("x = random;", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+
+
+def test_random_prefixed_identifier_in_expression_accepts(compile_gq):
+    # "random" is matched via Keyword(), so it doesn't swallow a
+    # random-*prefixed* identifier -- same reasoning as
+    # test_badge_count_prefixed_identifier_in_expression_accepts above
+    # (gamequeer#354).
+    source = game_with_stage(
+        "y = random_seed + 1;",
+        "volatile { int random_seed = 0; int y = 0; }",
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_min_call_accepts(compile_gq):
+    source = game_with_stage("x = min(1, 2);", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_min_wrong_arity_rejects(compile_gq):
+    source = game_with_stage("x = min(1);", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+    assert "ParseSyntaxException" in stderr
+
+
+def test_min_prefixed_identifier_in_expression_accepts(compile_gq):
+    source = game_with_stage(
+        "y = minimum + 1;", "volatile { int minimum = 0; int y = 0; }"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_max_call_accepts(compile_gq):
+    source = game_with_stage("x = max(1, 2);", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_max_wrong_arity_rejects(compile_gq):
+    source = game_with_stage("x = max(1, 2, 3);", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+    assert "ParseSyntaxException" in stderr
+
+
+def test_max_prefixed_identifier_in_expression_accepts(compile_gq):
+    source = game_with_stage(
+        "y = maximum + 1;", "volatile { int maximum = 0; int y = 0; }"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_clamp_call_accepts(compile_gq):
+    source = game_with_stage("x = clamp(5, 0, 10);", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_clamp_wrong_arity_too_few_rejects(compile_gq):
+    source = game_with_stage("x = clamp(5, 0);", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+    assert "ParseSyntaxException" in stderr
+
+
+def test_clamp_wrong_arity_too_many_rejects(compile_gq):
+    source = game_with_stage("x = clamp(5, 0, 10, 20);", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+    assert "ParseSyntaxException" in stderr
+
+
+def test_clamp_prefixed_identifier_in_expression_accepts(compile_gq):
+    source = game_with_stage(
+        "y = clamped + 1;", "volatile { int clamped = 0; int y = 0; }"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_abs_call_accepts(compile_gq):
+    source = game_with_stage("x = abs(-5);", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_abs_wrong_arity_rejects(compile_gq):
+    source = game_with_stage("x = abs(1, 2);", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+    assert "ParseSyntaxException" in stderr
+
+
+def test_abs_bare_no_parens_rejects(compile_gq):
+    source = game_with_stage("x = abs;", "volatile { int x = 0; }")
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code != 0
+
+
+def test_abs_prefixed_identifier_in_expression_accepts(compile_gq):
+    source = game_with_stage(
+        "y = absolute + 1;", "volatile { int absolute = 0; int y = 0; }"
+    )
+    exit_code, stderr, _ = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
 # --- str() cast: whole-RHS and inline (gamequeer#386) ------------------------
 
 

--- a/gqc/tests/test_math_intrinsics.py
+++ b/gqc/tests/test_math_intrinsics.py
@@ -1,0 +1,201 @@
+"""`min()`/`max()`/`clamp()`/`abs()` intrinsic suite for gqc (gamequeer#422,
+part of epic gamequeer#419).
+
+All four desugar to *existing* compare/arithmetic ops -- no dedicated opcode
+(FROZEN VM CONTRACT):
+
+  - `min(a, b)`/`max(a, b)`: `result = a; if (<compare> b result) { result =
+    b; }` (a `<`-compare for min, `>` for max) -- see
+    `IntExpression._emit_minmax`, `gqc/src/gqc/datamodel.py`. `min`/`max`
+    share this one lowering method (and, at the grammar layer, one
+    `GqcMinMaxOperand` marker with a `want_max` flag -- see
+    `parser.parse_min_operand`/`parse_max_operand`).
+  - `clamp(x, lo, hi)`: `min(max(x, lo), hi)`, composed directly from two
+    `_emit_minmax` calls (`IntExpression._emit_clamp`).
+  - `abs(x)`: `result = x; if (result < 0) { result = -result; }`, via the
+    `_emit_negate_if_negative` helper shared with `random()`'s own seed
+    normalization (`IntExpression._emit_abs`).
+
+`test_grammar.py` covers accept/reject grammar forms; `test_constant_folding.py`
+covers folding (all four fold when their arguments do -- unlike `random()`,
+which never folds). This module covers the op-stream shape.
+"""
+
+from gqc import structs
+
+from .opstream import one_event
+
+GAME_HEADER = 'game { id = 1; title := "T"; author := "A"; starting_stage = start; }\n'
+
+
+def game_with_stage(body: str, decls: str = "") -> str:
+    """A minimal valid game with a single stage `start` whose `enter` event
+    runs `body`, optionally preceded by top-level declarations (e.g. a
+    `volatile { ... }` block)."""
+    return f"{GAME_HEADER}{decls}\nstage start {{ event enter {{ {body} }} }}\n"
+
+
+# --- min()/max() ----------------------------------------------------------------
+
+
+def test_min_op_stream_shape(compile_gq):
+    source = game_with_stage(
+        "x = min(a, b);", "volatile { int x = 0; int a = 3; int b = 7; }"
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    assert [op.name for op in ops] == [
+        "SETVAR",  # result = a
+        "SETVAR",  # cmp = b
+        "LT",  # cmp = (cmp(b) < result(a))
+        "GOTOIFN",
+        "SETVAR",  # result = b (only if b < a)
+        "SETVAR",  # x = result
+        "DONE",
+    ]
+
+
+def test_max_op_stream_shape(compile_gq):
+    source = game_with_stage(
+        "x = max(a, b);", "volatile { int x = 0; int a = 3; int b = 7; }"
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    assert [op.name for op in ops] == [
+        "SETVAR", "SETVAR", "GT", "GOTOIFN", "SETVAR", "SETVAR", "DONE",
+    ]
+
+
+def test_min_with_literal_first_argument_compiles(compile_gq):
+    source = game_with_stage("x = min(1, y);", "volatile { int x = 0; int y = 5; }")
+    exit_code, stderr, _out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_min_with_full_expression_arguments_compiles(compile_gq):
+    source = game_with_stage(
+        "x = min(a + 1, b * 2);", "volatile { int x = 0; int a = 3; int b = 7; }"
+    )
+    exit_code, stderr, _out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_min_combined_with_binary_op_compiles(compile_gq):
+    source = game_with_stage(
+        "x = min(a, b) + 1;", "volatile { int x = 0; int a = 3; int b = 7; }"
+    )
+    exit_code, stderr, _out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_max_used_twice_in_one_expression_compiles(compile_gq):
+    source = game_with_stage(
+        "x = max(a, b) + max(a, b);", "volatile { int x = 0; int a = 3; int b = 7; }"
+    )
+    exit_code, stderr, _out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_min_in_if_condition_compiles(compile_gq):
+    source = game_with_stage(
+        "if (min(a, b) == 0) { badge_set 1; }",
+        "volatile { int a = 3; int b = 7; }",
+    )
+    exit_code, stderr, _out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+# --- clamp() ----------------------------------------------------------------
+
+
+def test_clamp_op_stream_shape(compile_gq):
+    source = game_with_stage(
+        "x = clamp(a, lo, hi);",
+        "volatile { int x = 0; int a = 3; int lo = 0; int hi = 10; }",
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    # clamp(x, lo, hi) = min(max(x, lo), hi): a max()'s own 5 ops (result =
+    # x; cmp = lo; cmp = cmp > result; if (cmp) result = lo), then a min()'s
+    # own 5 ops against hi, then the assignment's SETVAR + DONE.
+    assert [op.name for op in ops] == [
+        "SETVAR", "SETVAR", "GT", "GOTOIFN", "SETVAR",  # max(x, lo)
+        "SETVAR", "SETVAR", "LT", "GOTOIFN", "SETVAR",  # min(that, hi)
+        "SETVAR",  # x = result
+        "DONE",
+    ]
+
+
+def test_clamp_within_range_leaves_value_unchanged_registers(compile_gq):
+    # Not a runtime-behavior test (gqc doesn't execute the game) -- just
+    # confirms clamp() compiles for the realistic in-range case too, not
+    # just boundary values.
+    source = game_with_stage(
+        "x = clamp(5, 0, 10);", "volatile { int x = 0; }"
+    )
+    exit_code, stderr, _out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_clamp_combined_with_binary_op_compiles(compile_gq):
+    source = game_with_stage(
+        "x = clamp(a, 0, 10) + 1;", "volatile { int x = 0; int a = 3; }"
+    )
+    exit_code, stderr, _out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+# --- abs() --------------------------------------------------------------------
+
+
+def test_abs_op_stream_shape(compile_gq):
+    source = game_with_stage("x = abs(a);", "volatile { int x = 0; int a = -3; }")
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    assert [op.name for op in ops] == [
+        "SETVAR",  # result = a
+        "SETVAR",  # cmp = result
+        "LT",  # cmp = (cmp < 0)
+        "GOTOIFN",
+        "NEG",  # result = -result (only if result < 0)
+        "SETVAR",  # x = result
+        "DONE",
+    ]
+
+
+def test_abs_of_literal_negative_argument_compiles(compile_gq):
+    source = game_with_stage("x = abs(-5);", "volatile { int x = 0; }")
+    exit_code, stderr, _out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_abs_combined_with_binary_op_compiles(compile_gq):
+    source = game_with_stage(
+        "x = abs(a) + 1;", "volatile { int x = 0; int a = -3; }"
+    )
+    exit_code, stderr, _out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_abs_of_full_expression_argument_compiles(compile_gq):
+    source = game_with_stage(
+        "x = abs(a - b);", "volatile { int x = 0; int a = 3; int b = 7; }"
+    )
+    exit_code, stderr, _out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_abs_used_twice_in_one_expression_compiles(compile_gq):
+    source = game_with_stage(
+        "x = abs(a) + abs(b);", "volatile { int x = 0; int a = -3; int b = 7; }"
+    )
+    exit_code, stderr, _out_dir = compile_gq(source)
+    assert exit_code == 0, stderr

--- a/gqc/tests/test_random.py
+++ b/gqc/tests/test_random.py
@@ -1,28 +1,42 @@
 """`random(lo, hi)` intrinsic suite for gqc (gamequeer#422, part of epic
 gamequeer#419).
 
-`random(lo, hi)` desugars to the exact hand-rolled Park-Miller "minimal
-standard" LCG the game corpus already hand-rolls at the source level -- see
-e.g. gq-games/games/donsol.gq's card-shuffle `lcg` (seed = GQI_PLAYER_ID *
-7919 + a per-call counter, normalized into [1, modulus - 1], then advanced
-one step via Schrage's method) -- mapped into the caller's inclusive
-`[lo, hi]` range. FROZEN VM CONTRACT: every step is an *existing*
-`CommandArithmetic`/`CommandIf` op (`SETVAR`/`ADDBY`/`SUBBY`/`MULBY`/
-`DIVBY`/`MODBY`/`LT`/`LE`/`NEG`/`GOTOIFN`); there's no dedicated opcode.
+`random(lo, hi)` desugars to a Park-Miller "minimal standard" LCG (seed =
+GQI_PLAYER_ID * 7919 + a per-*call* counter, normalized into
+[1, modulus - 1], then advanced one step via Schrage's method) mapped into
+the caller's inclusive `[lo, hi]` range. FROZEN VM CONTRACT: every step is
+an *existing* `CommandArithmetic`/`CommandIf` op (`SETVAR`/`ADDBY`/`SUBBY`/
+`MULBY`/`DIVBY`/`MODBY`/`LT`/`LE`/`NEG`/`GOTOIFN`); there's no dedicated
+opcode.
+
+Only the *multiplicative core* (same modulus/multiplier/Schrage advance)
+matches the LCG the game corpus already hand-rolls at the source level --
+e.g. gq-games/games/donsol.gq's card-shuffle `lcg`. The *seeding* does NOT:
+donsol.gq's own per-call counter (`ctr`) is sampled from a free-running
+`timer` event for real wall-clock entropy, while `random()`'s hidden
+`structs.GQ_RANDOM_CTR_VAR` only increments once per `random()` call and is
+zero-initialized at boot -- so **the first `random()` call after a fresh
+cart boot is a deterministic function of `GQI_PLAYER_ID` alone**, identical
+on every reboot of the same badge. See `IntExpression._emit_random`
+(`gqc/src/gqc/datamodel.py`) for the full derivation and the donsol-style
+timer-salt workaround for authors who need real per-boot entropy.
 
 The LCG state (`structs.GQ_RANDOM_STATE_VAR`) and per-call counter
 (`structs.GQ_RANDOM_CTR_VAR`) are hidden volatile variables, created lazily
 -- only for a game that actually calls random() somewhere -- by
-`linker.create_random_state_variables` (see `IntExpression._emit_random`,
-`gqc/src/gqc/datamodel.py`, for the full derivation).
+`linker.create_random_state_variables`.
 
 `test_grammar.py` covers accept/reject grammar forms; `test_constant_folding.py`
 pins that `random()` never folds. This module covers the op-stream shape,
-the hidden state's zero footprint when unused, and register-pressure/
-re-entrancy when combined with other expressions.
+value-level correctness of the emitted arithmetic (against a Python
+reference implementation of the documented recurrence, executed via a small
+op interpreter -- `_execute_ops` below), the hidden state's zero footprint
+when unused, and register-pressure/re-entrancy when combined with other
+expressions.
 """
 
 from gqc import structs
+from gqc.datamodel import _c_truncating_divmod
 
 from .opstream import one_event, parse_gqasm
 
@@ -46,6 +60,203 @@ def _compile_and_read(compile_gq, source: str, game_name: str = "game"):
     cmds_text = (out_dir / "cmds.gqasm").read_text()
     map_text = (out_dir / "map.txt").read_text()
     return cmds_text, map_text
+
+
+# --- value-level correctness (executes the actual emitted ops) ----------------
+#
+# The op-stream-shape tests below (`test_random_op_stream_shape` etc.) only
+# ever assert on op *names* -- that's exactly how a previous version of this
+# module's own docstring, `_emit_random`'s docstring, and the PR body could
+# all confidently (and wrongly) claim random() emits "the exact hand-rolled
+# Park-Miller LCG donsol.gq already hand-rolls": the seeding-scheme mismatch
+# (see module docstring above) doesn't change a single op *name* in the
+# sequence, only the *values* flowing through it. `_execute_ops` is a tiny,
+# faithful-enough interpreter for exactly the op subset `_emit_random` emits
+# (SETVAR/ADDBY/SUBBY/MULBY/DIVBY/MODBY/LT/LE/NEG/GOTOIFN/DONE), so these
+# tests can check actual output values against `_reference_random_sequence`,
+# an independent Python reimplementation of the documented recurrence.
+
+
+def _wrap_t_gq_int(value: int) -> int:
+    """Truncate `value` into `t_gq_int`'s signed-32-bit range, the same
+    wraparound the VM's native `int32` arithmetic performs (see
+    `_c_truncating_divmod`'s own docstring for why this module can't just
+    use Python's unbounded ints throughout). Not expected to actually
+    trigger for the player-id/lo/hi values these tests exercise -- Schrage's
+    method is specifically chosen so the Schrage step never does -- but
+    applied after every write anyway so `_execute_ops` stays a faithful
+    mini-VM rather than one that silently diverges from real hardware
+    behavior if a future test ever does push a value that far."""
+    return ((value + 2 ** 31) % 2 ** 32) - 2 ** 31
+
+
+def _execute_ops(ops: list, memory: dict) -> dict:
+    """Interpret `ops` (an `EventBlock.ops` list from `opstream.one_event`)
+    against `memory` (address -> `t_gq_int`, mutated in place and returned;
+    unwritten addresses read as 0, matching the VM's zero-initialized RAM),
+    applying the same per-op semantics as the C VM's `run_arithmetic`/main
+    dispatch loop (`gamequeer/src/bytecode.c`): every binary op computes
+    `result = arg1 <op> arg2` and writes it back to arg1's address; `arg2`
+    is `memory[op.arg2]` unless `OpFlags.LITERAL_ARG2` is set, in which case
+    it's `op.arg2` itself; `NEG` is unary (`arg1 = -arg2`, no read of
+    arg1's prior value); `GOTOIFN` jumps to the address in `op.arg1` when
+    its condition (`arg2`, same literal-or-address rule as any other op)
+    is falsy.
+
+    Deliberately narrow: raises on any opcode `_emit_random` doesn't
+    itself emit, rather than silently no-op'ing an unhandled one -- this is
+    a test double for one specific op subset, not a general bytecode VM.
+    """
+    addr_index = {op.addr: i for i, op in enumerate(ops)}
+    i = 0
+    while i < len(ops):
+        op = ops[i]
+        arg2 = op.arg2 if (op.flags & structs.OpFlags.LITERAL_ARG2) else memory.get(op.arg2, 0)
+
+        if op.name == "DONE":
+            break
+        elif op.name == "SETVAR":
+            memory[op.arg1] = arg2
+        elif op.name == "NEG":
+            memory[op.arg1] = _wrap_t_gq_int(-arg2)
+        elif op.name == "GOTOIFN":
+            if not arg2:
+                i = addr_index[op.arg1]
+                continue
+        else:
+            arg1 = memory.get(op.arg1, 0)
+            if op.name == "ADDBY":
+                result = arg1 + arg2
+            elif op.name == "SUBBY":
+                result = arg1 - arg2
+            elif op.name == "MULBY":
+                result = arg1 * arg2
+            elif op.name == "DIVBY":
+                result, _ = _c_truncating_divmod(arg1, arg2)
+            elif op.name == "MODBY":
+                _, result = _c_truncating_divmod(arg1, arg2)
+            elif op.name == "LT":
+                result = int(arg1 < arg2)
+            elif op.name == "LE":
+                result = int(arg1 <= arg2)
+            else:
+                raise AssertionError(
+                    f"_execute_ops doesn't model {op.name!r} -- either "
+                    "_emit_random grew a new op this interpreter needs to "
+                    "learn, or this test is being reused outside its "
+                    "intended (random()-only) scope"
+                )
+            memory[op.arg1] = _wrap_t_gq_int(result)
+        i += 1
+    return memory
+
+
+def _reference_random_sequence(player_id: int, lo: int, hi: int, n: int) -> list:
+    """Independent Python reimplementation of the *documented* random()
+    recurrence (see `IntExpression._emit_random`'s docstring and this
+    module's own docstring above): a Park-Miller LCG state, zero at boot,
+    perturbed on every call by `player_id * GQ_RANDOM_SEED_MULTIPLIER +
+    ctr` (`ctr` incrementing once per call, starting at 0 -- NOT
+    donsol.gq's free-running-timer `ctr`), then advanced one Schrage step
+    and mapped into the caller's inclusive `[lo, hi]` range.
+
+    Deliberately written from the recurrence's math, not by transcribing
+    `_emit_random`'s own op sequence -- it needs to be an independent
+    oracle, not a restatement of the code under test."""
+    modulus = structs.GQ_RANDOM_LCG_MODULUS
+    multiplier = structs.GQ_RANDOM_LCG_MULTIPLIER
+    q = structs.GQ_RANDOM_LCG_Q
+    r = structs.GQ_RANDOM_LCG_R
+    seed_multiplier = structs.GQ_RANDOM_SEED_MULTIPLIER
+    span = hi - lo + 1
+
+    state = 0
+    ctr = 0
+    results = []
+    for _ in range(n):
+        ctr += 1
+        state += player_id * seed_multiplier + ctr
+        if state < 0:
+            state = -state
+        state = state % (modulus - 1) + 1
+        # One Schrage step for state = (multiplier * state) mod modulus.
+        # state/q are both positive here, so plain Python `//`/`%` already
+        # agree with C's truncating division -- no need for
+        # _c_truncating_divmod in this branch.
+        t = state // q
+        state = state % q
+        state = state * multiplier - t * r
+        if state <= 0:
+            state += modulus
+        results.append(state % span + lo)
+    return results
+
+
+def _var_addr(map_text: str, name: str) -> int:
+    line = next(
+        line for line in map_text.splitlines()
+        if f"'{name}'," in line and "Variable(" in line
+    )
+    return int(line.split()[0], 16)
+
+
+def test_random_bytecode_matches_reference_lcg_sequence(compile_gq):
+    """Executes the actual emitted op-stream (not just op *names* -- see
+    `test_random_op_stream_shape` below) for three back-to-back random()
+    calls and checks the resulting sequence of *values* against
+    `_reference_random_sequence`. This is the test that would have caught
+    gamequeer#427's false parity claim: op-name-shape coverage alone can't
+    distinguish "seeded the exact same way as donsol.gq" from "seeded a
+    different (but equally shaped) way", since both compile to the same op
+    mnemonics.
+    """
+    source = game_with_stage(
+        "a = random(1, 1000); b = random(1, 1000); c = random(1, 1000);",
+        "volatile { int a = 0; int b = 0; int c = 0; }",
+    )
+    cmds_text, map_text = _compile_and_read(compile_gq, source)
+    ops = one_event(cmds_text).ops
+
+    player_id_addr = structs.gq_ptr_apply_ns(
+        structs.GQ_PTR_BUILTIN_INT,
+        next(v.addr for v in structs.GQ_RESERVED_INTS if v.name == "GQI_PLAYER_ID"),
+    )
+    result_addrs = [_var_addr(map_text, name) for name in ("a", "b", "c")]
+
+    for player_id in (0, 1, 12345, -7):
+        memory = _execute_ops(ops, {player_id_addr: player_id})
+        actual = [memory[addr] for addr in result_addrs]
+        expected = _reference_random_sequence(player_id, 1, 1000, 3)
+        assert actual == expected, f"player_id={player_id}"
+
+
+def test_random_first_call_after_boot_is_deterministic_in_player_id(compile_gq):
+    """Pins the actual, user-visible consequence of the seeding gap
+    documented above: with `GQ_RANDOM_STATE_VAR`/`GQ_RANDOM_CTR_VAR` both
+    zero-initialized at boot (`linker.create_random_state_variables`), the
+    *first* `random()` call a freshly booted cart makes is a pure function
+    of `GQI_PLAYER_ID` -- same badge, same draw, every single reboot. Two
+    different player IDs must still diverge from each other (the seeding
+    gap isn't degenerate across the whole badge population, just within
+    one badge's own reboots)."""
+    source = game_with_stage("x = random(1, 1000000);", "volatile { int x = 0; }")
+    cmds_text, map_text = _compile_and_read(compile_gq, source)
+    ops = one_event(cmds_text).ops
+
+    player_id_addr = structs.gq_ptr_apply_ns(
+        structs.GQ_PTR_BUILTIN_INT,
+        next(v.addr for v in structs.GQ_RESERVED_INTS if v.name == "GQI_PLAYER_ID"),
+    )
+    x_addr = _var_addr(map_text, "x")
+
+    # Two separate "boots" of the same badge -- a fresh `memory` dict each
+    # time, exactly like a real cart's RAM coming back up zeroed.
+    reboot_1 = _execute_ops(ops, {player_id_addr: 42})[x_addr]
+    reboot_2 = _execute_ops(ops, {player_id_addr: 42})[x_addr]
+    assert reboot_1 == reboot_2
+
+    other_badge = _execute_ops(ops, {player_id_addr: 43})[x_addr]
+    assert other_badge != reboot_1
 
 
 # --- op-stream shape ----------------------------------------------------------

--- a/gqc/tests/test_random.py
+++ b/gqc/tests/test_random.py
@@ -1,0 +1,240 @@
+"""`random(lo, hi)` intrinsic suite for gqc (gamequeer#422, part of epic
+gamequeer#419).
+
+`random(lo, hi)` desugars to the exact hand-rolled Park-Miller "minimal
+standard" LCG the game corpus already hand-rolls at the source level -- see
+e.g. gq-games/games/donsol.gq's card-shuffle `lcg` (seed = GQI_PLAYER_ID *
+7919 + a per-call counter, normalized into [1, modulus - 1], then advanced
+one step via Schrage's method) -- mapped into the caller's inclusive
+`[lo, hi]` range. FROZEN VM CONTRACT: every step is an *existing*
+`CommandArithmetic`/`CommandIf` op (`SETVAR`/`ADDBY`/`SUBBY`/`MULBY`/
+`DIVBY`/`MODBY`/`LT`/`LE`/`NEG`/`GOTOIFN`); there's no dedicated opcode.
+
+The LCG state (`structs.GQ_RANDOM_STATE_VAR`) and per-call counter
+(`structs.GQ_RANDOM_CTR_VAR`) are hidden volatile variables, created lazily
+-- only for a game that actually calls random() somewhere -- by
+`linker.create_random_state_variables` (see `IntExpression._emit_random`,
+`gqc/src/gqc/datamodel.py`, for the full derivation).
+
+`test_grammar.py` covers accept/reject grammar forms; `test_constant_folding.py`
+pins that `random()` never folds. This module covers the op-stream shape,
+the hidden state's zero footprint when unused, and register-pressure/
+re-entrancy when combined with other expressions.
+"""
+
+from gqc import structs
+
+from .opstream import one_event, parse_gqasm
+
+GAME_HEADER = 'game { id = 1; title := "T"; author := "A"; starting_stage = start; }\n'
+
+
+def game_with_stage(body: str, decls: str = "") -> str:
+    """A minimal valid game with a single stage `start` whose `enter` event
+    runs `body`, optionally preceded by top-level declarations (e.g. a
+    `volatile { ... }` block)."""
+    return f"{GAME_HEADER}{decls}\nstage start {{ event enter {{ {body} }} }}\n"
+
+
+def assert_no_traceback(stderr: str):
+    assert "Traceback" not in stderr, f"raw Python traceback leaked to stderr:\n{stderr}"
+
+
+def _compile_and_read(compile_gq, source: str, game_name: str = "game"):
+    exit_code, stderr, out_dir = compile_gq(source, game_name=game_name)
+    assert exit_code == 0, stderr
+    cmds_text = (out_dir / "cmds.gqasm").read_text()
+    map_text = (out_dir / "map.txt").read_text()
+    return cmds_text, map_text
+
+
+# --- op-stream shape ----------------------------------------------------------
+
+
+def test_random_op_stream_shape(compile_gq):
+    source = game_with_stage("x = random(1, 10);", "volatile { int x = 0; }")
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    # range = hi - lo + 1; ctr += 1; state += GQI_PLAYER_ID * 7919 + ctr;
+    # if (state < 0) state = -state; state = state % (m-1) + 1; one Schrage
+    # step; if (state <= 0) state += m; result = state % range + lo. See
+    # IntExpression._emit_random for the full derivation.
+    assert [op.name for op in ops] == [
+        "SETVAR", "SUBBY", "ADDBY",  # range = hi; range -= lo; range += 1
+        "ADDBY",  # ctr += 1
+        "SETVAR", "MULBY", "ADDBY", "ADDBY",  # seed = player_id * 7919 + ctr; state += seed
+        "SETVAR", "LT", "GOTOIFN", "NEG",  # if (state < 0) state = -state;
+        "MODBY", "ADDBY",  # state = state % (m - 1) + 1
+        "SETVAR", "DIVBY", "MODBY", "MULBY", "MULBY", "SUBBY",  # Schrage step
+        "SETVAR", "LE", "GOTOIFN", "ADDBY",  # if (state <= 0) state += m;
+        "SETVAR", "MODBY", "ADDBY",  # result = state % range + lo
+        "SETVAR",  # x = result
+        "DONE",
+    ]
+
+
+def test_random_bytecode_size_is_fixed(compile_gq):
+    # Same "fixed size, not proportional to anything" property badge_count()
+    # has (gamequeer#387): random()'s own bytecode is always the same 27 ops
+    # (270 bytes at GQ_OP_SIZE=10) for a literal-argument call, regardless of
+    # which lo/hi literals are passed.
+    source = game_with_stage("x = random(1, 10);", "volatile { int x = 0; }")
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    random_ops = ops[:-2]  # everything but the assignment's own SETVAR + DONE
+    assert len(random_ops) == 27
+
+
+def test_random_literal_bounds_are_baked_in(compile_gq):
+    source = game_with_stage("x = random(3, 12);", "volatile { int x = 0; }")
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    range_setup = ops[0]  # SETVAR range = hi (literal 12)
+    range_sub = ops[1]  # SUBBY range -= lo (literal 3)
+    result_add = ops[-3]  # ADDBY result += lo (literal 3); ops[-2]/[-1] are x = result / DONE
+
+    assert range_setup.flags & structs.OpFlags.LITERAL_ARG2 and range_setup.arg2 == 12
+    assert range_sub.flags & structs.OpFlags.LITERAL_ARG2 and range_sub.arg2 == 3
+    assert result_add.flags & structs.OpFlags.LITERAL_ARG2 and result_add.arg2 == 3
+
+
+def test_random_reads_gqi_player_id(compile_gq):
+    source = game_with_stage("x = random(1, 10);", "volatile { int x = 0; }")
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    player_id_addr = structs.gq_ptr_apply_ns(
+        structs.GQ_PTR_BUILTIN_INT,
+        next(v.addr for v in structs.GQ_RESERVED_INTS if v.name == "GQI_PLAYER_ID"),
+    )
+    load_player_id = next(
+        op for op in ops
+        if op.name == "SETVAR" and not (op.flags & structs.OpFlags.LITERAL_ARG2) and op.arg2 == player_id_addr
+    )
+    seed_mul = next(op for op in ops if op.name == "MULBY" and op.arg1 == load_player_id.arg1)
+    assert seed_mul.flags & structs.OpFlags.LITERAL_ARG2
+    assert seed_mul.arg2 == structs.GQ_RANDOM_SEED_MULTIPLIER == 7919
+
+
+def test_random_never_writes_a_literal_directly_into_state(compile_gq):
+    # The hidden LCG state variable is only ever written by an
+    # accumulating ADDBY/NEG/MODBY/MULBY/SUBBY op (i.e. state op= something),
+    # never a plain literal SETVAR -- it must always evolve from its own
+    # prior value, not get stomped with a constant.
+    source = game_with_stage("x = random(1, 10);", "volatile { int x = 0; }")
+    _cmds_text, map_text = _compile_and_read(compile_gq, source)
+    ops = one_event(_cmds_text).ops
+    state_addr = int(
+        next(
+            line for line in map_text.splitlines()
+            if structs.GQ_RANDOM_STATE_VAR in line and "Variable(" in line
+        ).split()[0],
+        16,
+    )
+    for op in ops:
+        if op.arg1 == state_addr:
+            assert op.name != "SETVAR", f"state variable written by a plain SETVAR: {op}"
+
+
+# --- hidden state: zero footprint when unused, shared across calls ------------
+
+
+def test_random_unused_creates_no_hidden_state(compile_gq):
+    source = game_with_stage("badge_set 1;")
+    _cmds_text, map_text = _compile_and_read(compile_gq, source)
+    assert structs.GQ_RANDOM_STATE_VAR not in map_text
+    assert structs.GQ_RANDOM_CTR_VAR not in map_text
+
+
+def test_random_called_multiple_times_shares_one_state_and_counter(compile_gq):
+    source = game_with_stage(
+        "x = random(1, 10); y = random(1, 10);",
+        "volatile { int x = 0; int y = 0; }",
+    )
+    _cmds_text, map_text = _compile_and_read(compile_gq, source)
+    assert map_text.count(f"'{structs.GQ_RANDOM_STATE_VAR}'") == 1
+    assert map_text.count(f"'{structs.GQ_RANDOM_CTR_VAR}'") == 1
+
+    ctr_addr = int(
+        next(
+            line for line in map_text.splitlines()
+            if structs.GQ_RANDOM_CTR_VAR in line and "Variable(" in line
+        ).split()[0],
+        16,
+    )
+    ops = one_event(_cmds_text).ops
+    ctr_bumps = [op for op in ops if op.name == "ADDBY" and op.arg1 == ctr_addr]
+    # Both calls' own "ctr += 1" step target the same (shared) counter address.
+    assert len(ctr_bumps) == 2
+    assert all(op.flags & structs.OpFlags.LITERAL_ARG2 and op.arg2 == 1 for op in ctr_bumps)
+
+
+def test_random_volatile_declared_after_a_call_site_still_compiles(compile_gq):
+    # Regression pin: create_random_state_variables is deferred until after
+    # parsing (see its own docstring in linker.py) specifically so this
+    # doesn't false-positive the "one volatile section per game" check --
+    # random() is called in a stage that's parsed *before* the author's own
+    # volatile{} section appears later in the same source file.
+    source = (
+        GAME_HEADER
+        + "stage start { event enter { x = random(1, 10); } }\n"
+        + "volatile { int x = 0; }\n"
+    )
+    exit_code, stderr, _out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+# --- register pressure / re-entrancy -------------------------------------------
+
+
+def test_random_combined_with_binary_op_compiles(compile_gq):
+    source = game_with_stage("x = random(1, 10) + y;", "volatile { int x = 0; int y = 0; }")
+    exit_code, stderr, _out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_random_used_twice_in_one_expression_compiles(compile_gq):
+    source = game_with_stage(
+        "x = random(1, 10) + random(1, 10);", "volatile { int x = 0; }"
+    )
+    exit_code, stderr, _out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+def test_random_with_non_literal_bounds_compiles(compile_gq):
+    source = game_with_stage(
+        "x = random(lo, hi);", "volatile { int x = 0; int lo = 0; int hi = 20; }"
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    range_setup = ops[0]
+    assert not (range_setup.flags & structs.OpFlags.LITERAL_ARG2)  # loaded hi, not a literal
+
+
+def test_random_with_full_expression_bounds_compiles(compile_gq):
+    source = game_with_stage(
+        "x = random(base - 1, base + 10);",
+        "volatile { int x = 0; int base = 5; }",
+    )
+    exit_code, stderr, _out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+
+# --- realistic usage ------------------------------------------------------------
+
+
+def test_random_in_if_condition_compiles(compile_gq):
+    source = game_with_stage(
+        "if (random(0, 1) == 1) { badge_set 1; }",
+    )
+    exit_code, stderr, _out_dir = compile_gq(source)
+    assert exit_code == 0, stderr

--- a/gqc/tests/test_social_vocab.py
+++ b/gqc/tests/test_social_vocab.py
@@ -1,0 +1,367 @@
+"""Social vocabulary suite for gqc (gamequeer#423, DEF CON sprint epic
+gamequeer#419).
+
+`cohort NAME = <lo>..<hi>;`, `have_met(id)`, `in_cohort(NAME, id)`,
+`seen_self()`, and `count_seen()`/`count_seen(NAME)` are a first-class
+desugaring over the *existing* badges-seen bitfield intrinsics
+(`badge_get`/`badge_set`/`badge_count()`, gamequeer#387) -- FROZEN VM
+CONTRACT, no new opcode, register, or on-cart struct. This mirrors
+`test_badge_count.py`'s split: `test_grammar.py` covers accept/reject
+grammar forms (including the reject-with-a-message cases: unknown cohort,
+wrong arity); this module covers the actual op-stream shape each form
+lowers to, plus the handful of cases specific to this feature
+(`in_cohort()`'s constant folding, `count_seen(NAME)`'s `lo == 0`
+optimization, `seen_self()`'s exact idiom shape).
+
+Design notes for anyone extending this suite:
+  - `have_met(id)` is implemented as a bare rename of `badge_get(id)` (see
+    `IntExpression.get_result_symbol`'s `GqcHaveMetOperand` branch in
+    `datamodel.py`), so its op-stream shape is asserted to be byte-for-byte
+    identical to a hand-written `badge_get(id)`.
+  - `count_seen()` (no argument) is literally the same `GqcBadgeCountOperand`
+    marker `badge_count()` itself produces (see
+    `parser.parse_count_seen_operand`), so its op-stream shape is asserted
+    to be identical to `test_badge_count.py`'s own `badge_count()` shape
+    pin.
+  - `count_seen(NAME)` generalizes that loop with a compile-time `lo`
+    offset (`IntExpression._emit_count_seen_range`); when `lo == 0` the
+    offset-add is skipped, so its shape collapses to the exact same 9-op
+    loop `badge_count()`/`count_seen()` use.
+"""
+
+from gqc import structs
+
+from .opstream import one_event
+
+GAME_HEADER = 'game { id = 1; title := "T"; author := "A"; starting_stage = start; }\n'
+
+
+def game_with_stage(body: str, decls: str = "", cohorts: str = "") -> str:
+    """A minimal valid game with a single stage `start` whose `enter` event
+    runs `body`, optionally preceded by top-level `cohort` declarations and
+    a `volatile { ... }`-style decls block."""
+    return f"{GAME_HEADER}{cohorts}\n{decls}\nstage start {{ event enter {{ {body} }} }}\n"
+
+
+def _int_register_addrs() -> set:
+    return {
+        structs.gq_ptr_apply_ns(structs.GQ_PTR_NS_HEAP, i * structs.GQ_INT_SIZE)
+        for i in range(len(structs.GQ_REGISTERS_INT))
+    }
+
+
+# --- have_met(id): a bare rename of badge_get(id) ----------------------------
+
+
+def test_have_met_op_stream_matches_badge_get(compile_gq):
+    have_met_source = game_with_stage("x = have_met(y);", "volatile { int x = 0; int y = 0; }")
+    badge_get_source = game_with_stage("x = badge_get(y);", "volatile { int x = 0; int y = 0; }")
+
+    exit_code, stderr, out_dir = compile_gq(have_met_source, game_name="have_met")
+    assert exit_code == 0, stderr
+    have_met_ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+
+    exit_code, stderr, out_dir = compile_gq(badge_get_source, game_name="badge_get")
+    assert exit_code == 0, stderr
+    badge_get_ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+
+    assert [(op.name, op.flags, op.arg1, op.arg2) for op in have_met_ops] == [
+        (op.name, op.flags, op.arg1, op.arg2) for op in badge_get_ops
+    ]
+
+
+def test_have_met_with_literal_argument_accepts(compile_gq):
+    source = game_with_stage("x = have_met(42);", "volatile { int x = 0; }")
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    qcget = next(op for op in ops if op.name == "QCGET")
+    assert qcget.flags & structs.OpFlags.LITERAL_ARG2
+    assert qcget.arg2 == 42
+
+
+# --- in_cohort(NAME, id): range compare, folds when id is a literal ---------
+
+
+def test_in_cohort_op_stream_shape(compile_gq):
+    source = game_with_stage(
+        "x = in_cohort(GUESTS, y);",
+        cohorts="cohort GUESTS = 300..319;",
+        decls="volatile { int x = 0; int y = 0; }",
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    # y is loaded into a register twice (once per side of the "&&" --
+    # id_operand is referenced twice in the desugared range compare), then
+    # GE/LE/AND, then the assignment's own final SETVAR.
+    assert [op.name for op in ops] == [
+        "SETVAR", "GE", "SETVAR", "LE", "AND", "SETVAR", "DONE",
+    ]
+    load_y_1, ge, load_y_2, le, op_and, final_setvar, _done = ops
+
+    reg_addrs = _int_register_addrs()
+    assert load_y_1.arg1 in reg_addrs and load_y_2.arg1 in reg_addrs
+    assert load_y_1.arg1 != load_y_2.arg1  # distinct registers for each side
+
+    assert ge.flags & structs.OpFlags.LITERAL_ARG2 and ge.arg2 == 300
+    assert ge.arg1 == load_y_1.arg1
+    assert le.flags & structs.OpFlags.LITERAL_ARG2 and le.arg2 == 319
+    assert le.arg1 == load_y_2.arg1
+
+    assert op_and.arg1 == ge.arg1
+    assert op_and.arg2 == le.arg1
+
+    assert not (final_setvar.flags & structs.OpFlags.LITERAL_ARG2)
+    assert final_setvar.arg2 == op_and.arg1
+
+
+def test_in_cohort_with_literal_id_folds_to_compile_time_constant(compile_gq):
+    # id is a literal known to be inside the cohort's range -- the whole
+    # in_cohort() call folds to the literal 1, exactly like any other
+    # compile-time-constant expression (gamequeer#385) -- no GE/LE/AND ops
+    # at all.
+    source = game_with_stage(
+        "x = in_cohort(GUESTS, 305);",
+        cohorts="cohort GUESTS = 300..319;",
+        decls="volatile { int x = 0; }",
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    assert [op.name for op in ops] == ["SETVAR", "DONE"]
+    setvar, _done = ops
+    assert setvar.flags & structs.OpFlags.LITERAL_ARG2
+    assert setvar.arg2 == 1
+
+
+def test_in_cohort_with_literal_id_outside_range_folds_to_zero(compile_gq):
+    source = game_with_stage(
+        "x = in_cohort(GUESTS, 1);",
+        cohorts="cohort GUESTS = 300..319;",
+        decls="volatile { int x = 0; }",
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    assert [op.name for op in ops] == ["SETVAR", "DONE"]
+    setvar, _done = ops
+    assert setvar.flags & structs.OpFlags.LITERAL_ARG2
+    assert setvar.arg2 == 0
+
+
+def test_in_cohort_combined_with_other_arithmetic_still_folds(compile_gq):
+    # A literal-id in_cohort() nested inside a larger otherwise-foldable
+    # expression folds all the way through, same as any other constant
+    # subexpression (gamequeer#385).
+    source = game_with_stage(
+        "x = 1 + in_cohort(GUESTS, 305);",
+        cohorts="cohort GUESTS = 300..319;",
+        decls="volatile { int x = 0; }",
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    assert [op.name for op in ops] == ["SETVAR", "DONE"]
+    setvar, _done = ops
+    assert setvar.flags & structs.OpFlags.LITERAL_ARG2
+    assert setvar.arg2 == 2
+
+
+def test_in_cohort_realistic_gate_idiom_compiles(compile_gq):
+    # The realistic idiom from the gamequeer#423 issue: replaces a
+    # hand-rolled "if (ID>=300 && ID<=319)" chain.
+    source = game_with_stage(
+        "if (in_cohort(GUESTS, GQI_PLAYER_ID)) { badge_set 63; }",
+        cohorts="cohort GUESTS = 300..319;",
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    assert "GE" in [op.name for op in ops]
+    assert "LE" in [op.name for op in ops]
+    assert "AND" in [op.name for op in ops]
+    assert "QCSET" in [op.name for op in ops]
+
+
+# --- seen_self(): the copy-pasted-verbatim idiom, desugared -----------------
+
+
+def test_seen_self_op_stream_shape(compile_gq):
+    source = game_with_stage("seen_self();")
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    # if (badge_get(GQI_PLAYER_ID) == 0) { badge_set GQI_PLAYER_ID; }
+    assert [op.name for op in ops] == ["QCGET", "EQ", "GOTOIFN", "QCSET", "DONE"]
+    qcget, eq, gotoifn, qcset, _done = ops
+
+    player_id_addr = structs.gq_ptr_apply_ns(structs.GQ_PTR_BUILTIN_INT, 0x00005C)
+    assert not (qcget.flags & structs.OpFlags.LITERAL_ARG2)
+    assert qcget.arg2 == player_id_addr
+
+    assert eq.arg1 == qcget.arg1  # compares the badge_get() result register
+    assert eq.flags & structs.OpFlags.LITERAL_ARG2 and eq.arg2 == 0
+
+    assert not (gotoifn.flags & structs.OpFlags.LITERAL_ARG2)
+    assert gotoifn.arg2 == eq.arg1  # tests the == result register
+    assert gotoifn.arg1 == qcset.addr + structs.GQ_OP_SIZE  # skips past QCSET when false
+
+    assert qcset.arg2 == player_id_addr
+
+
+def test_seen_self_matches_hand_written_idiom(compile_gq):
+    seen_self_source = game_with_stage("seen_self();")
+    hand_written_source = game_with_stage(
+        "if (badge_get(GQI_PLAYER_ID)==0) badge_set GQI_PLAYER_ID;"
+    )
+
+    exit_code, stderr, out_dir = compile_gq(seen_self_source, game_name="seen_self")
+    assert exit_code == 0, stderr
+    seen_self_ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+
+    exit_code, stderr, out_dir = compile_gq(hand_written_source, game_name="hand_written")
+    assert exit_code == 0, stderr
+    hand_written_ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+
+    assert [(op.name, op.flags, op.arg1, op.arg2) for op in seen_self_ops] == [
+        (op.name, op.flags, op.arg1, op.arg2) for op in hand_written_ops
+    ]
+
+
+# --- count_seen(): identical to badge_count() --------------------------------
+
+
+def test_count_seen_bare_op_stream_matches_badge_count(compile_gq):
+    count_seen_source = game_with_stage("x = count_seen();", "volatile { int x = 0; }")
+    badge_count_source = game_with_stage("x = badge_count();", "volatile { int x = 0; }")
+
+    exit_code, stderr, out_dir = compile_gq(count_seen_source, game_name="count_seen")
+    assert exit_code == 0, stderr
+    count_seen_ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+
+    exit_code, stderr, out_dir = compile_gq(badge_count_source, game_name="badge_count")
+    assert exit_code == 0, stderr
+    badge_count_ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+
+    assert [(op.name, op.flags, op.arg1, op.arg2) for op in count_seen_ops] == [
+        (op.name, op.flags, op.arg1, op.arg2) for op in badge_count_ops
+    ]
+
+
+# --- count_seen(NAME): a badge_count()-style loop bounded to [lo, hi] -------
+
+
+def test_count_seen_range_op_stream_shape(compile_gq):
+    source = game_with_stage(
+        "x = count_seen(GUESTS);",
+        cohorts="cohort GUESTS = 300..319;",
+        decls="volatile { int x = 0; }",
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    # 2 init SETVARs (accumulator, counter), an 11-op bounded loop (GOTOIFN +
+    # SUBBY + SETVAR-copy-idx + ADDBY-offset-by-lo + QCGET + ADDBY-accumulate
+    # + GOTO-skip-false + break-GOTO + continue-GOTO), then the assignment's
+    # own final SETVAR and the event's DONE.
+    assert [op.name for op in ops] == [
+        "SETVAR", "SETVAR",
+        "GOTOIFN", "SUBBY", "SETVAR", "ADDBY", "QCGET", "ADDBY", "GOTO", "GOTO", "GOTO",
+        "SETVAR", "DONE",
+    ]
+    (
+        init_acc, init_idx,
+        gotoifn, subby, copy_idx, addby_offset, qcget, addby_acc,
+        goto_skip_false, goto_break, goto_continue,
+        final_setvar, _done,
+    ) = ops
+
+    reg_addrs = _int_register_addrs()
+    assert init_acc.arg1 in reg_addrs
+    assert init_idx.arg1 in reg_addrs
+    assert qcget.arg1 in reg_addrs
+    assert len({init_acc.arg1, init_idx.arg1, qcget.arg1}) == 3  # only 3 registers, same as badge_count()
+
+    assert init_acc.flags & structs.OpFlags.LITERAL_ARG2 and init_acc.arg2 == 0
+    # hi - lo + 1 == 319 - 300 + 1 == 20 -- the cohort's own size, not
+    # BADGES_ALLOWED.
+    assert init_idx.flags & structs.OpFlags.LITERAL_ARG2 and init_idx.arg2 == 20
+
+    assert not (gotoifn.flags & structs.OpFlags.LITERAL_ARG2)
+    assert gotoifn.arg2 == init_idx.arg1
+
+    assert subby.flags & structs.OpFlags.LITERAL_ARG2 and subby.arg2 == 1
+    assert subby.arg1 == init_idx.arg1
+
+    # bit_reg = idx_reg (copy), then bit_reg += lo -- the actual badge id.
+    assert not (copy_idx.flags & structs.OpFlags.LITERAL_ARG2)
+    assert copy_idx.arg2 == init_idx.arg1
+    assert copy_idx.arg1 == qcget.arg1
+
+    assert addby_offset.flags & structs.OpFlags.LITERAL_ARG2 and addby_offset.arg2 == 300
+    assert addby_offset.arg1 == qcget.arg1
+
+    # QCGET is self-referential (dst == src): badge_get(bit_reg) overwrites
+    # bit_reg with the read result, safe because the VM reads src into a
+    # local before writing dst (see gamequeer/src/bytecode.c).
+    assert not (qcget.flags & structs.OpFlags.LITERAL_ARG2)
+    assert qcget.arg1 == qcget.arg2
+
+    assert addby_acc.arg1 == init_acc.arg1
+    assert addby_acc.arg2 == qcget.arg1
+
+    assert gotoifn.arg1 == goto_break.addr
+    assert goto_skip_false.arg1 == goto_continue.addr
+    assert goto_break.arg1 == goto_continue.addr + structs.GQ_OP_SIZE
+    assert goto_continue.arg1 == gotoifn.addr
+
+    assert not (final_setvar.flags & structs.OpFlags.LITERAL_ARG2)
+    assert final_setvar.arg2 == init_acc.arg1
+
+
+def test_count_seen_range_starting_at_zero_matches_badge_count_shape(compile_gq):
+    # A cohort starting at badge id 0 skips the idx+lo offset computation
+    # entirely (lo == 0 special-cased in IntExpression._emit_count_seen_range)
+    # -- so its loop body collapses to the exact same shape badge_count()'s
+    # own loop uses, just with a smaller BADGES_ALLOWED-replacement bound.
+    source = game_with_stage(
+        "x = count_seen(FOUNDERS);",
+        cohorts="cohort FOUNDERS = 0..9;",
+        decls="volatile { int x = 0; }",
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    assert [op.name for op in ops] == [
+        "SETVAR", "SETVAR",
+        "GOTOIFN", "SUBBY", "QCGET", "ADDBY", "GOTO", "GOTO", "GOTO",
+        "SETVAR", "DONE",
+    ]
+    init_acc, init_idx = ops[0], ops[1]
+    assert init_idx.arg2 == 10  # hi - lo + 1 == 9 - 0 + 1
+
+
+def test_count_seen_range_never_folds(compile_gq):
+    # count_seen(NAME) reads live badge state, not a constant -- never
+    # folds, even though lo/hi are themselves always compile-time constants
+    # (same reasoning as badge_count(), gamequeer#387).
+    source = game_with_stage(
+        "x = count_seen(GUESTS) + 1;",
+        cohorts="cohort GUESTS = 300..319;",
+        decls="volatile { int x = 0; }",
+    )
+    exit_code, stderr, out_dir = compile_gq(source)
+    assert exit_code == 0, stderr
+
+    ops = one_event((out_dir / "cmds.gqasm").read_text()).ops
+    assert "QCGET" in [op.name for op in ops]

--- a/gqc/tests/test_support.py
+++ b/gqc/tests/test_support.py
@@ -10,11 +10,28 @@ between, must not trip any of gqc's duplicate-definition checks.
 import io
 
 from gqc import linker, parser
+from gqc.datamodel import Cohort, Constant, Enum
 
 from .support import reset_compiler_state
 
 MINIMAL_GAME = (
     'game { id = 1; title := "T"; author := "A"; starting_stage = start; }\n'
+    "stage start { event enter { badge_set 1; } }\n"
+)
+
+# const/enum/cohort (gamequeer#421/#423) all register into their own
+# class-level tables (Constant.const_table, Enum.enum_table,
+# Cohort.cohort_table) directly from a parse action -- see
+# parser.parse_const_definition/parse_enum_definition/
+# parse_cohort_definition -- so re-parsing this twice without a reset would
+# trip Constant.define's/Enum.define's/Cohort.__init__'s own
+# duplicate-definition ValueErrors, exactly like the pre-#421 registries
+# below already do.
+GAME_WITH_CONST_ENUM_COHORT = (
+    'game { id = 1; title := "T"; author := "A"; starting_stage = start; }\n'
+    "const MAX_HP = 21;\n"
+    "enum Difficulty { Easy, Medium, Hard }\n"
+    "cohort GUESTS = 300..319;\n"
     "stage start { event enter { badge_set 1; } }\n"
 )
 
@@ -24,3 +41,23 @@ def test_reset_compiler_state_allows_reparsing_in_process():
         reset_compiler_state()
         linker.create_reserved_variables()
         parser.parse(io.StringIO(MINIMAL_GAME))
+
+
+def test_reset_compiler_state_clears_const_enum_cohort_tables():
+    # gamequeer#427 review: reset_compiler_state() was missing
+    # Constant.const_table/Enum.enum_table/Cohort.cohort_table, so a second
+    # in-process parse of a game with any const/enum/cohort declaration
+    # would raise a spurious "already defined" error even on a clean
+    # source, purely from the *first* parse's leftover state.
+    for _ in range(2):
+        reset_compiler_state()
+        linker.create_reserved_variables()
+        parser.parse(io.StringIO(GAME_WITH_CONST_ENUM_COHORT))
+
+        assert Constant.const_table["MAX_HP"] == 21
+        assert Constant.const_table["Difficulty.Easy"] == 0
+        assert Constant.const_table["Difficulty.Medium"] == 1
+        assert Constant.const_table["Difficulty.Hard"] == 2
+        assert Enum.enum_table["Difficulty"] == ["Easy", "Medium", "Hard"]
+        assert Cohort.cohort_table["GUESTS"].lo == 300
+        assert Cohort.cohort_table["GUESTS"].hi == 319


### PR DESCRIPTION
First batch of the DEF CON authoring-DX sprint (epic #419): four author-facing `gqc` language features, integrated as one branch. **All desugar-only — no VM/bytecode/struct changes (frozen-VM contract held).**

## Features

- **#420 — game-as-directory layout.** `game{}` may now appear anywhere in the top-level stream (exactly one, enforced semantically); asset paths resolve **relative to the game directory** (entry `<name>/<name>.gq`); new `gqc new <name>` scaffolds the layout. The structural half of multi-file (#401); the concat/merge machinery is separate.
- **#421 — named `const` / `enum`.** Compile-time constants and enums, folded to literals at parse time (builds on #385's folding).
- **#422 — `random(lo,hi)` + `min`/`max`/`clamp`/`abs`.** Desugar-only intrinsics in the `badge_count()`/`fw_version()` mold. `random()`'s *multiplicative core* is the same Park-Miller LCG the corpus (`donsol.gq`) already hand-rolls, but its *seeding* is not: `donsol.gq` reseeds from a free-running timer counter (real wall-clock entropy), while `random()`'s own per-call counter only increments once per call and is zero at boot — so the first `random()` call after a fresh cart boot is deterministic in `GQI_PLAYER_ID` alone, and authors who need real per-boot entropy still need the donsol-style timer-salt recipe (kept in the authoring docs). See `IntExpression._emit_random`'s docstring for the full derivation.
- **#423 — social vocabulary.** `cohort NAME = lo..hi;`, `seen_self()`, `have_met(id)`, `in_cohort(id, cohort)`, `count_seen()` / `count_seen(cohort)` — desugaring to the existing badges-seen bitfield intrinsics. `seen_self()` replaces the idiom copy-pasted verbatim across five shipped games.

## Also here
- **Improved `game{}` diagnostics:** a missing or duplicate required key now names the specific offender (`game_assignment` moved off `pp.Each` to a repeated alternation + semantic count in `parse_game_definition`), completing the zero/duplicate-*block* checks #420 added.

## Verification
- `pytest tests` → **442 passed, 2 skipped (ffmpeg-gated), 0 failed** (verified in a clean venv; includes the adversarial-review follow-up fixes below).
- Golden byte-regression suite (`-m golden`) → **15 passed** — existing `.gqgame` output unchanged.
- No edits under `gamequeer/gamequeer/` (C runtime).

## Adversarial-review follow-up (post-merge-review round)
- Corrected the `random()` donsol-parity claim above (and in `_emit_random`'s docstring, `structs.py`, and the authoring docs) to describe the actual seeding model, and added output-*value* tests (a small op-stream interpreter checked against an independent Python reference implementation) — the prior test coverage only ever asserted on op names, which couldn't catch a seeding-model claim being wrong.
- `reset_compiler_state()` (test-only in-process-compile helper) now also clears `Constant.const_table`/`Enum.enum_table`/`Cohort.cohort_table`, which #421/#423 added but it never picked up.
- A `const`/`enum` referenced before its own declaration is now a fatal compile error (clear "declared later in this file" diagnostic) instead of silently compiling to `SETVAR arg2 == 0` — closes the const/enum half of the pre-existing `CommandWithIntExpressionArgument.resolve()` gap noted below, independent of whether #430 also lands.

## Follow-ups (not in this PR)
- **Langium editor parity** for every new keyword (`const`/`enum`/`random`/`min`/`max`/`clamp`/`abs`/`cohort`/`seen_self`/`have_met`/`in_cohort`/`count_seen`) — conformance batch #405 (alongside the existing #406/#407 and `fw_version`/#411 divergences).
- A pre-existing `CommandWithIntExpressionArgument.resolve()` silent-zero-on-undefined-int bug found during #421 — fixed separately.
- `gq-games` corpus migration to the new layout + `gq-game-authoring` skill-doc sync.
- `qc2024` submodule-pointer bump on merge.

Closes #420, #421, #422, #423. Part of epic #419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018zq69LMm7wqY8S3QjB2jon)_
