### PR TITLE
land #429 on default: CST/provenance parse + gqc fmt (stacked-merge race)

### DIFF
--- a/gqc/src/gqc/cst.py
+++ b/gqc/src/gqc/cst.py
@@ -44,6 +44,17 @@ module uses -- without needing to touch this file's tokenizer.
 
 Trivia attachment and the string-escaping simplification are two smaller
 documented gaps; see `Trivia`/`_tokenize` below.
+
+Two more, smaller lexical divergences from `grammar.py`, both deliberate
+simplifications of this generic tokenizer rather than bugs: `_WORD_START`
+accepts a leading `_` in identifiers/keywords (`pp.alphas + "_"`), where
+`grammar.py`'s `identifier` (`pp.Word(pp.alphas, ...)`) requires an
+alphabetic first character and hard-rejects a leading `_`; and this
+tokenizer's whitespace set (`_tokenize`'s ` \t\r\n\f\v`) includes form feed
+(`\f`) and vertical tab (`\v`), which aren't in pyparsing's default
+whitespace (`' \n\t\r'`) and so would be rejected between tokens by
+`grammar.py`'s grammar. Neither is exercised by the corpus this step
+round-trips against.
 """
 
 from dataclasses import dataclass, field

--- a/gqc/src/gqc/cst.py
+++ b/gqc/src/gqc/cst.py
@@ -1,0 +1,411 @@
+"""Comment- and layout-preserving concrete syntax tree (CST) for `.gq`
+source files.
+
+Step 1 of the formatter/linter foundation (gamequeer#424, DEF CON sprint
+epic gamequeer#419). This module is **additive**: `grammar.build_game_parser()`
+/ `parser.parse()` (the compile path) are untouched, and nothing here is on
+that path. `gqc fmt` (see `gqc.py`) is the only current consumer.
+
+Why a separate parser instead of reusing `grammar.py`
+-------------------------------------------------------
+`grammar.py`'s pyparsing grammar is built for *compilation*: its parse
+actions have real side effects (populating `Game.game`, `Cohort.cohort_table`,
+`Variable`/`Stage`/`Event` registries, folding constant expressions, ...),
+and it discards comments outright via `.ignore(pp.cppStyleComment)` since
+compilation never needs them. Layering a lossless, comment-preserving mode
+on top of that grammar would mean either running it with all those side
+effects live (wrong for a tool like `fmt` that must work on
+work-in-progress, possibly-invalid source) or forking every parse action in
+it (a maintenance burden that would fight the "additive, reviewable
+increment" scope of this step). So this is a second, independent, much
+simpler parser purpose-built for losslessness.
+
+What kind of CST this is (and isn't) -- the documented gap
+------------------------------------------------------------
+This is a **generic token/trivia tree, structured by bracket nesting**
+(`{ }` and `( )`), not a fully-typed tree with one node kind per grammar
+production (`game_definition_section`, `stage_definition_section`, ...).
+It doesn't know that `stage foo { ... }` is a stage, or that `x = 1 + 2;`
+is an assignment -- it just knows there's a run of tokens, then a
+brace-delimited `Group`, in document order, with every byte of the
+original file accounted for as either a `Token` or `Trivia`.
+
+That's a deliberate scope cut for this step, not an oversight: a
+per-production CST would mean re-deriving (and keeping in lockstep with)
+every one of `grammar.py`'s ~30 rules, which is exactly the kind of
+big-bang rewrite the issue asks this step to avoid. The generic tree above
+is already sufficient to prove losslessness (this module's actual job) and
+to drive brace-depth-based reindentation later. A later step that wants
+per-construct semantic node types (e.g. for lint rules like "unused
+variable" or "duplicate stage name") can layer that on top of this tree --
+or cross-reference it against `datamodel.py`'s already-typed objects, which
+carry their own `instring`/`loc` back to the same source positions this
+module uses -- without needing to touch this file's tokenizer.
+
+Trivia attachment and the string-escaping simplification are two smaller
+documented gaps; see `Trivia`/`_tokenize` below.
+"""
+
+from dataclasses import dataclass, field
+from typing import Union
+
+import pyparsing as pp
+
+from . import GqcParseError
+
+# Punctuation/operator lexemes recognized by grammar.py, sorted longest-first
+# so the tokenizer's maximal-munch scan tries e.g. ":=" before "=" and "<<"
+# before "<". "{"/"}"/"("/")" are included here too (they're ordinary Tokens
+# like any other punctuation -- bracket *nesting* is a second pass over the
+# resulting token stream, see `_group`).
+_PUNCTUATION = sorted(
+    [
+        ":=", "<-", "..", "->", "<=", ">=", "==", "!=", "&&", "||", "<<", ">>",
+        "{", "}", "(", ")", ";", ",", ":", ".", "=",
+        "+", "-", "*", "/", "%", "!", "~", "&", "|", "^", "<", ">",
+    ],
+    key=len,
+    reverse=True,
+)
+
+_OPEN_TO_CLOSE = {"{": "}", "(": ")"}
+_CLOSE_TO_OPEN = {v: k for k, v in _OPEN_TO_CLOSE.items()}
+
+_WORD_START = pp.alphas + "_"
+_WORD_BODY = pp.alphanums + "_"
+
+
+@dataclass
+class Trivia:
+    """A run of whitespace, or a single comment, between two tokens.
+
+    `kind` is one of "whitespace" | "line_comment" | "block_comment".
+    `text` is the exact source text (for a comment, including its own
+    delimiters: "//...", "/*...*/")."""
+
+    kind: str
+    text: str
+    start: int
+    end: int
+
+
+@dataclass
+class Token:
+    """A single lexeme: an identifier/keyword, an integer literal, a
+    quoted string literal, or one piece of punctuation/an operator (see
+    `_PUNCTUATION`). `kind` is one of "word" | "number" | "string" | "punct".
+
+    `leading_trivia` is every `Trivia` run since the previous token (or
+    since the start of the file, for the very first token) -- this is a
+    leading-only attachment convention (there's no separate "trailing
+    trivia" on a token; what would be "trailing" for token N is leading
+    for token N+1, or the file's own `trailing_trivia` if N is the last
+    token). That's enough to reconstruct the source exactly (see
+    `to_source`) and to tell, e.g., a same-line trailing comment from a
+    comment on its own line (by checking for a newline in the trivia text
+    before it) -- which is what a formatter needs to decide where to put a
+    comment back, without needing a second, redundant trailing-trivia
+    slot."""
+
+    kind: str
+    text: str
+    start: int
+    end: int
+    leading_trivia: list = field(default_factory=list)
+
+
+@dataclass
+class Group:
+    """A bracket-delimited region: `{ ... }` or `( ... )`. `open`/`close`
+    are the delimiter `Token`s themselves (so their `leading_trivia`,
+    e.g. a comment right after `{`, is preserved); `children` is the
+    (`Token` | `Group`) sequence strictly between them, in document
+    order."""
+
+    open: Token
+    close: Token
+    children: list
+
+
+@dataclass
+class CstFile:
+    """The whole-file root. `children` is the top-level (`Token` | `Group`)
+    sequence; `trailing_trivia` is whatever whitespace/comments follow the
+    very last token (there's no token to attach it to as leading trivia)."""
+
+    source: str
+    children: list
+    trailing_trivia: list = field(default_factory=list)
+
+
+Node = Union[Token, Group, CstFile]
+
+
+def pos_to_linecol(source: str, pos: int) -> tuple:
+    """1-based (line, column) for a character offset into `source`, using
+    the same convention (and the same pyparsing helpers) as
+    `GqcParseError`/the rest of gqc's diagnostics."""
+    return pp.lineno(pos, source), pp.col(pos, source)
+
+
+def _tokenize(source: str):
+    """Scan `source` into a flat list of `Token`s (each carrying its own
+    `leading_trivia`) plus whatever trivia trails the last token. Consumes
+    every character of `source` as either trivia or token text -- that
+    completeness is what makes `to_source(parse_cst(source)) == source`
+    hold by construction, rather than needing to be checked separately.
+
+    Raises `GqcParseError` on an unterminated string/block comment or an
+    unrecognized character, both located via the same `(instring, loc)`
+    convention the rest of gqc's parse errors use.
+    """
+    n = len(source)
+    i = 0
+    tokens = []
+    pending_trivia = []
+
+    def add_trivia(kind, start, end):
+        pending_trivia.append(Trivia(kind, source[start:end], start, end))
+
+    while i < n:
+        c = source[i]
+
+        # Whitespace
+        if c in " \t\r\n\f\v":
+            start = i
+            while i < n and source[i] in " \t\r\n\f\v":
+                i += 1
+            add_trivia("whitespace", start, i)
+            continue
+
+        # Line comment
+        if source.startswith("//", i):
+            start = i
+            i += 2
+            while i < n and source[i] not in "\r\n":
+                i += 1
+            add_trivia("line_comment", start, i)
+            continue
+
+        # Block comment
+        if source.startswith("/*", i):
+            start = i
+            end = source.find("*/", i + 2)
+            if end == -1:
+                raise GqcParseError("Unterminated block comment", source, start)
+            i = end + 2
+            add_trivia("block_comment", start, i)
+            continue
+
+        # String literal. grammar.py has two subtly different quoted-string
+        # rules (a plain `pp.QuotedString('"')` with no escape handling at
+        # all for game/menu/stage strings, vs. `escChar='\\'` for
+        # animation/lightcue file paths) -- this generic tokenizer can't
+        # tell which grammar context it's in (that's the whole point of
+        # being generic), so it documents-and-picks one lexing rule for
+        # both: `\"` never terminates the string, and `\\` is a literal
+        # escaped backslash. That's a strict superset of the no-escape
+        # rule for any string that doesn't itself contain a backslash
+        # (true of every string in every committed example game as of this
+        # writing), so it's a safe, deliberate simplification rather than
+        # a silent behavior difference -- see the module docstring's
+        # "documented gap" section.
+        if c == '"':
+            start = i
+            i += 1
+            while i < n and source[i] != '"':
+                if source[i] == "\\" and i + 1 < n:
+                    i += 2
+                else:
+                    i += 1
+            if i >= n:
+                raise GqcParseError("Unterminated string literal", source, start)
+            i += 1  # closing quote
+            tokens.append(Token("string", source[start:i], start, i, pending_trivia))
+            pending_trivia = []
+            continue
+
+        # Word: identifier/keyword
+        if c in _WORD_START:
+            start = i
+            i += 1
+            while i < n and source[i] in _WORD_BODY:
+                i += 1
+            tokens.append(Token("word", source[start:i], start, i, pending_trivia))
+            pending_trivia = []
+            continue
+
+        # Number: a bare run of digits. Unlike grammar.py's `integer` rule,
+        # a leading "-" is always its own separate "punct" token here (see
+        # `_PUNCTUATION`) rather than sometimes being fused into the
+        # number -- grammar.py only fuses it because it has to decide
+        # there and then between a negative literal and a unary-minus
+        # operator, a semantic distinction this tokenizer never needs to
+        # make: either split reconstructs the same source text via
+        # `to_source`.
+        if c.isdigit():
+            start = i
+            i += 1
+            while i < n and source[i].isdigit():
+                i += 1
+            tokens.append(Token("number", source[start:i], start, i, pending_trivia))
+            pending_trivia = []
+            continue
+
+        # Punctuation/operators, longest-match-first.
+        matched = None
+        for punct in _PUNCTUATION:
+            if source.startswith(punct, i):
+                matched = punct
+                break
+        if matched is not None:
+            start = i
+            i += len(matched)
+            tokens.append(Token("punct", matched, start, i, pending_trivia))
+            pending_trivia = []
+            continue
+
+        raise GqcParseError(f"Unrecognized character {c!r}", source, i)
+
+    return tokens, pending_trivia
+
+
+def _group(tokens, source):
+    """Second pass: nest a flat `Token` stream into `Group`s by matching
+    `{}`/`()`. Raises `GqcParseError` (located against `source`, same
+    convention as the rest of gqc's diagnostics) on a mismatched or
+    unterminated bracket."""
+    root = []
+    # Stack of (open_token, expected_close, children_being_built).
+    stack = []
+
+    for tok in tokens:
+        if tok.kind == "punct" and tok.text in _OPEN_TO_CLOSE:
+            stack.append((tok, _OPEN_TO_CLOSE[tok.text], []))
+            continue
+        if tok.kind == "punct" and tok.text in _CLOSE_TO_OPEN:
+            if not stack:
+                raise GqcParseError(
+                    f"Unexpected closing {tok.text!r} with no matching opener",
+                    source,
+                    tok.start,
+                )
+            open_tok, expected_close, children = stack.pop()
+            if tok.text != expected_close:
+                raise GqcParseError(
+                    f"Mismatched bracket: {open_tok.text!r} opened at "
+                    f"offset {open_tok.start} closed with {tok.text!r}",
+                    source,
+                    tok.start,
+                )
+            group = Group(open=open_tok, close=tok, children=children)
+            (stack[-1][2] if stack else root).append(group)
+            continue
+        (stack[-1][2] if stack else root).append(tok)
+
+    if stack:
+        open_tok, _, _ = stack[-1]
+        raise GqcParseError(
+            f"Unterminated {open_tok.text!r} opened at offset {open_tok.start}",
+            source,
+            open_tok.start,
+        )
+
+    return root
+
+
+def parse_cst(source: str) -> CstFile:
+    """Parse `source` (a `.gq` file's full text) into a lossless CST. See
+    the module docstring for what "lossless" and "CST" mean here."""
+    tokens, trailing_trivia = _tokenize(source)
+    children = _group(tokens, source)
+    return CstFile(source=source, children=children, trailing_trivia=trailing_trivia)
+
+
+def _write_trivia(out: list, trivia_list):
+    for t in trivia_list:
+        out.append(t.text)
+
+
+def to_source(node: Node) -> str:
+    """Reconstruct the exact source text a CST node was parsed from, by
+    concatenating leading trivia and token text in document order.
+    `to_source(parse_cst(text)) == text` for any `text` that tokenizes
+    cleanly -- this is the round-trip guarantee the CST exists to provide,
+    and it's what `gqc fmt` step 1 (see `gqc.py`) uses to prove the CST is
+    lossless before any real formatting logic is layered on top of it."""
+    out = []
+    _write(node, out)
+    return "".join(out)
+
+
+def _write(node: Node, out: list) -> None:
+    if isinstance(node, Token):
+        _write_trivia(out, node.leading_trivia)
+        out.append(node.text)
+    elif isinstance(node, Group):
+        _write(node.open, out)
+        for child in node.children:
+            _write(child, out)
+        _write(node.close, out)
+    elif isinstance(node, CstFile):
+        for child in node.children:
+            _write(child, out)
+        _write_trivia(out, node.trailing_trivia)
+    else:
+        raise TypeError(f"Not a CST node: {node!r}")
+
+
+def render(tree: CstFile) -> str:
+    """`gqc fmt`'s entry point for turning a parsed CST back into source
+    text. Step 1 (gamequeer#424) deliberately performs no reformatting --
+    `render` is exactly `to_source`, i.e. an identity transform -- so that
+    landing the CST and proving it lossless is its own reviewable
+    increment, separate from any actual pretty-printing/reindentation
+    policy (explicitly deferred to a follow-on step by the issue). Once
+    that policy exists, it replaces this function's body; nothing about
+    the CST shape above needs to change for it to do so."""
+    return to_source(tree)
+
+
+def iter_tokens(node: Node):
+    """Depth-first iterator over every `Token` in `node` (a `CstFile`,
+    `Group`, or `Token`), in document order. Convenience for tests and for
+    any future pass that wants a flat view of the token stream (e.g. a
+    linter walking for a specific keyword)."""
+    if isinstance(node, Token):
+        yield node
+    elif isinstance(node, Group):
+        yield node.open
+        for child in node.children:
+            yield from iter_tokens(child)
+        yield node.close
+    elif isinstance(node, CstFile):
+        for child in node.children:
+            yield from iter_tokens(child)
+    else:
+        raise TypeError(f"Not a CST node: {node!r}")
+
+
+def iter_comments(node: Node):
+    """Depth-first iterator over every comment `Trivia` (kind
+    "line_comment" or "block_comment") attached anywhere in `node`, in
+    document order. Convenience for tests/tools asserting comments
+    survived a round-trip without needing to walk trivia manually."""
+    if isinstance(node, CstFile):
+        for child in node.children:
+            yield from iter_comments(child)
+        for t in node.trailing_trivia:
+            if t.kind != "whitespace":
+                yield t
+    elif isinstance(node, Group):
+        yield from iter_comments(node.open)
+        for child in node.children:
+            yield from iter_comments(child)
+        yield from iter_comments(node.close)
+    elif isinstance(node, Token):
+        for t in node.leading_trivia:
+            if t.kind != "whitespace":
+                yield t
+    else:
+        raise TypeError(f"Not a CST node: {node!r}")

--- a/gqc/src/gqc/gqc.py
+++ b/gqc/src/gqc/gqc.py
@@ -8,8 +8,10 @@ from rich.progress import Progress
 
 from . import parser
 from . import anim, cues
+from . import cst
 from . import makefile_src
 from . import linker
+from . import GqcParseError
 from .datamodel import Game
 
 DITHER_CHOICES = ('none', 'bayer', 'heckbert', 'floyd_steinberg', 'sierra2', 'sierra2_4a')
@@ -33,6 +35,42 @@ def mkanim(out_path : pathlib.Path, src_path : pathlib.Path, dither : str, frame
 def mkcue(out_path : pathlib.Path, src_path : pathlib.Path):
     with Progress() as progress:
         cues.make_cue(progress, src_path, out_path)
+
+@gqc_cli.command()
+@click.argument('input', type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True, path_type=pathlib.Path), required=True)
+@click.option('--write', '-w', is_flag=True, help="Write the formatted output back to INPUT instead of printing it to stdout.")
+@click.option('--check', is_flag=True, help="Don't write anything; exit nonzero if INPUT isn't already formatted.")
+def fmt(input : pathlib.Path, write : bool, check : bool):
+    """Parse INPUT to gqc's comment- and layout-preserving CST (gqc.cst)
+    and re-emit it, proving the CST round-trips (gamequeer#424 step 1).
+
+    This step's `render` is an identity transform -- no reindentation or
+    other pretty-printing happens yet (that's explicitly deferred to a
+    follow-on step; see gqc.cst's module docstring) -- so today this is
+    mainly useful as a `--check` round-trip/lossless-parse validator, and
+    as the CST's own proof of concept."""
+    with open(input, 'r') as f:
+        source = f.read()
+
+    try:
+        tree = cst.parse_cst(source)
+    except GqcParseError as ge:
+        click.echo(str(ge), err=True)
+        raise SystemExit(1)
+
+    formatted = cst.render(tree)
+
+    if check:
+        if formatted != source:
+            click.echo(f"{input} is not formatted", err=True)
+            raise SystemExit(1)
+        return
+
+    if write:
+        with open(input, 'w') as f:
+            f.write(formatted)
+    else:
+        click.echo(formatted, nl=False)
 
 @gqc_cli.command()
 @click.option('--no-mem-map', '-n', is_flag=True)

--- a/gqc/src/gqc/gqc.py
+++ b/gqc/src/gqc/gqc.py
@@ -50,8 +50,20 @@ def fmt(input : pathlib.Path, write : bool, check : bool):
     follow-on step; see gqc.cst's module docstring) -- so today this is
     mainly useful as a `--check` round-trip/lossless-parse validator, and
     as the CST's own proof of concept."""
+    if write and check:
+        click.echo("--write and --check are mutually exclusive", err=True)
+        raise SystemExit(1)
+
+    # encoding='utf-8': gqc source is UTF-8 (see the UnicodeDecodeError
+    # handling below); without an explicit encoding, open() falls back to
+    # locale.getpreferredencoding(), which varies by platform/locale and can
+    # silently misdecode non-UTF-8 bytes instead of raising. newline='':
+    # disables universal-newline translation, so a CRLF- or CR-terminated
+    # INPUT is read (and, on --write, written back out) exactly as-is --
+    # required for the byte-for-byte round-trip guarantee this module exists
+    # to prove (see test_round_trip_preserves_windows_line_endings).
     try:
-        with open(input, 'r') as f:
+        with open(input, 'r', encoding='utf-8', newline='') as f:
             source = f.read()
     except UnicodeDecodeError as ue:
         click.echo(f"{input}: cannot decode as UTF-8: {ue}", err=True)
@@ -81,7 +93,8 @@ def fmt(input : pathlib.Path, write : bool, check : bool):
         # replaced, never partially written.
         fd, tmp_path = tempfile.mkstemp(prefix=f'.{input.name}.', suffix='.tmp', dir=input.parent)
         try:
-            with os.fdopen(fd, 'w') as f:
+            # Same encoding='utf-8', newline='' rationale as the read above.
+            with os.fdopen(fd, 'w', encoding='utf-8', newline='') as f:
                 f.write(formatted)
             os.replace(tmp_path, input)
         except BaseException:

--- a/gqc/src/gqc/gqc.py
+++ b/gqc/src/gqc/gqc.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import pathlib
+import tempfile
 from collections import namedtuple
 
 import click
@@ -49,8 +50,12 @@ def fmt(input : pathlib.Path, write : bool, check : bool):
     follow-on step; see gqc.cst's module docstring) -- so today this is
     mainly useful as a `--check` round-trip/lossless-parse validator, and
     as the CST's own proof of concept."""
-    with open(input, 'r') as f:
-        source = f.read()
+    try:
+        with open(input, 'r') as f:
+            source = f.read()
+    except UnicodeDecodeError as ue:
+        click.echo(f"{input}: cannot decode as UTF-8: {ue}", err=True)
+        raise SystemExit(1)
 
     try:
         tree = cst.parse_cst(source)
@@ -67,8 +72,21 @@ def fmt(input : pathlib.Path, write : bool, check : bool):
         return
 
     if write:
-        with open(input, 'w') as f:
-            f.write(formatted)
+        # Write to a sibling temp file and os.replace() it into place instead
+        # of truncating INPUT in place (`open(input, 'w')`) -- the latter
+        # destroys the source the instant it's opened, so any failure between
+        # open and a completed write (disk full, process killed, ...) leaves
+        # INPUT empty/truncated with no way back. os.replace() is atomic on
+        # the same filesystem, so INPUT is either untouched or fully
+        # replaced, never partially written.
+        fd, tmp_path = tempfile.mkstemp(prefix=f'.{input.name}.', suffix='.tmp', dir=input.parent)
+        try:
+            with os.fdopen(fd, 'w') as f:
+                f.write(formatted)
+            os.replace(tmp_path, input)
+        except BaseException:
+            os.unlink(tmp_path)
+            raise
     else:
         click.echo(formatted, nl=False)
 

--- a/gqc/tests/conftest.py
+++ b/gqc/tests/conftest.py
@@ -90,3 +90,48 @@ def compile_gq(tmp_path):
         return proc.returncode, proc.stderr, out_dir
 
     return _compile_gq
+
+
+@pytest.fixture
+def fmt_gq(tmp_path):
+    """Run `python -m gqc fmt` on a .gq source string as a subprocess, same
+    hermetic-CWD-per-call convention as `compile_gq` above (gqc's
+    class-level compiler-state registries aren't used by `fmt`, but a fresh
+    process per call keeps this fixture's behavior easy to reason about and
+    consistent with `compile_gq`'s).
+
+    Returns a `(exit_code, stdout, stderr, src_path)` tuple. `extra_args`
+    (e.g. `["--check"]` or `["--write"]`) are appended after the input
+    file path; `src_path` lets a `--write` test read the file back.
+    """
+
+    def _fmt_gq(
+        source: str,
+        game_name: str = "game",
+        extra_args: list[str] | None = None,
+    ) -> tuple[int, str, str, pathlib.Path]:
+        src_path = tmp_path / f"{game_name}.gq"
+        src_path.write_text(source)
+
+        cmd = [sys.executable, "-m", "gqc", "fmt", str(src_path)]
+        if extra_args:
+            cmd.extend(extra_args)
+
+        try:
+            proc = subprocess.run(
+                cmd,
+                cwd=tmp_path,
+                capture_output=True,
+                text=True,
+                timeout=COMPILE_TIMEOUT_S,
+            )
+        except subprocess.TimeoutExpired as exc:
+            pytest.fail(
+                f"gqc fmt did not finish within {COMPILE_TIMEOUT_S}s "
+                f"(cmd={cmd!r}); stdout so far: {exc.stdout!r}; "
+                f"stderr so far: {exc.stderr!r}"
+            )
+
+        return proc.returncode, proc.stdout, proc.stderr, src_path
+
+    return _fmt_gq

--- a/gqc/tests/test_cst.py
+++ b/gqc/tests/test_cst.py
@@ -25,11 +25,14 @@ compile. What matters here is the round-trip/losslessness guarantee itself:
     lex.
 """
 
+import os
 import pathlib
 
 import pytest
+from click.testing import CliRunner
 
 from gqc import cst
+from gqc import gqc as gqc_module
 from gqc import GqcParseError
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
@@ -265,3 +268,55 @@ def test_fmt_reports_a_clean_error_on_unlexable_input(fmt_gq):
     assert exit_code != 0
     assert "Traceback" not in stderr
     assert "Unterminated" in stderr
+
+
+def test_fmt_reports_a_clean_error_on_non_utf8_input(tmp_path):
+    """gamequeer#429 review: the initial `open(input).read()` used to sit
+    outside fmt's try/except, so non-UTF-8 input surfaced as a raw
+    `UnicodeDecodeError` traceback instead of the same clean CLI error
+    style used for unlexable (but decodable) input."""
+    src_path = tmp_path / "game.gq"
+    src_path.write_bytes(b"game { id = 1; title := \"\xff\xfe bad utf-8\"; }")
+
+    result = CliRunner().invoke(gqc_module.fmt, [str(src_path)])
+
+    assert result.exit_code != 0
+    assert "Traceback" not in result.output
+    assert "cannot decode as UTF-8" in result.output
+
+
+def test_fmt_write_failure_leaves_source_intact_and_no_temp_leak(tmp_path, monkeypatch):
+    """gamequeer#429 review: `fmt --write` used to `open(input, 'w')`
+    directly, which truncates INPUT the instant it's opened -- a failure
+    anywhere between that open and a completed write destroys the source
+    with no way back. It now writes to a sibling temp file and
+    `os.replace()`s it into place, so a mid-write failure must leave INPUT
+    byte-for-byte untouched and must not leak the temp file. Simulated here
+    by monkeypatching `os.fdopen` (used internally by the write path) to
+    hand back a file object whose `write` raises partway through."""
+    original = (
+        'game { id = 1; title := "T"; author := "A"; starting_stage = s; }\n'
+        "stage s { event enter { } }\n"
+    )
+    src_path = tmp_path / "game.gq"
+    src_path.write_text(original)
+
+    real_fdopen = os.fdopen
+
+    def boom_fdopen(fd, *args, **kwargs):
+        f = real_fdopen(fd, *args, **kwargs)
+
+        def boom_write(*_args, **_kwargs):
+            raise OSError("simulated mid-write failure")
+
+        f.write = boom_write
+        return f
+
+    monkeypatch.setattr(os, "fdopen", boom_fdopen)
+
+    result = CliRunner().invoke(gqc_module.fmt, [str(src_path), "--write"])
+
+    assert result.exit_code != 0
+    assert src_path.read_text() == original, "a failed write must not corrupt the original source"
+    leaked = [p for p in tmp_path.iterdir() if p != src_path]
+    assert leaked == [], f"temp file(s) leaked: {leaked}"

--- a/gqc/tests/test_cst.py
+++ b/gqc/tests/test_cst.py
@@ -253,6 +253,30 @@ def test_fmt_write_updates_the_file_in_place(fmt_gq):
     assert src_path.read_text() == source
 
 
+def test_fmt_write_preserves_crlf_line_endings_on_disk(fmt_gq):
+    """gamequeer#429 review: `open(input)`/`os.fdopen(fd, 'w')` without an
+    explicit `newline=''` enable universal-newline translation, which would
+    silently rewrite a CRLF-terminated INPUT to LF on the way through
+    --write -- exactly the byte-for-byte round-trip guarantee this module
+    exists to prove. Checked via raw bytes on disk (not `src_path.read_text()`
+    or the subprocess's captured stdout, both of which do their own
+    newline-translation that would mask the bug)."""
+    source = (
+        'game {\r\n id = 1; title := "T"; author := "A"; starting_stage = s;\r\n}\r\n'
+        "stage s { event enter { } }\r\n"
+    )
+    exit_code, stdout, stderr, src_path = fmt_gq(source, extra_args=["--write"])
+    assert exit_code == 0, stderr
+    assert src_path.read_bytes() == source.encode("utf-8")
+
+
+def test_fmt_rejects_write_and_check_together(fmt_gq):
+    source = 'game { id = 1; title := "T"; author := "A"; starting_stage = s; }\nstage s { event enter { } }\n'
+    exit_code, stdout, stderr, _ = fmt_gq(source, extra_args=["--write", "--check"])
+    assert exit_code != 0
+    assert "mutually exclusive" in stderr
+
+
 def test_fmt_of_fmt_output_is_a_fixed_point(fmt_gq, tmp_path):
     """The issue's own idempotence phrasing: fmt(fmt(x)) == fmt(x)."""
     source = REPRESENTATIVE_GAMES[0].read_text()

--- a/gqc/tests/test_cst.py
+++ b/gqc/tests/test_cst.py
@@ -1,0 +1,267 @@
+"""CST / `gqc fmt` round-trip suite (gamequeer#424 step 1, DEF CON sprint
+follow-on epic gamequeer#419).
+
+This is deliberately not a grammar-acceptance suite like test_grammar.py --
+`gqc.cst` doesn't know or care about gqc's grammar rules (see its module
+docstring for what kind of CST it is), so there's no "reject" side to test
+here: any text that lexes (balanced brackets, terminated strings/comments,
+only recognized characters) produces a CST, whether or not it would also
+compile. What matters here is the round-trip/losslessness guarantee itself:
+
+  - `to_source(parse_cst(text)) == text` for arbitrary/synthetic snippets
+    exercising every trivia kind (line comment, block comment, whitespace
+    runs, blank lines).
+  - The same guarantee holds byte-for-byte on every real, committed `.gq`
+    example/golden game in the repo (not just synthetic snippets) --
+    that's the strongest form of the issue's "byte-stability" ask, and a
+    stronger property than the "fmt(fmt(x)) == fmt(x)" idempotence the
+    issue specifically calls for (which follows immediately once fmt(x) ==
+    x for a step 1 whose `render` is an identity transform -- see
+    `gqc.cst.render`'s docstring).
+  - Comments specifically survive (both round-tripped verbatim in place,
+    and individually recoverable via `iter_comments`).
+  - The `gqc fmt` CLI itself round-trips end to end, including its
+    `--check`/`--write` flags and its handling of a file that fails to
+    lex.
+"""
+
+import pathlib
+
+import pytest
+
+from gqc import cst
+from gqc import GqcParseError
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+# A representative subset of the repo's real, committed .gq games (per the
+# task's ask for "a representative subset of the committed example .gq
+# games"): the richest showcase game (multi-stage, both // and /* */
+# comments, animations{}), a menu-heavy game, a tutorial sample, and the C
+# VM's own edge_coverage.gq golden fixture (deliberately exercises a wide
+# grammar spread). test_all_gq_examples_round_trip below additionally
+# sweeps every .gq file in the repo, so this list is just the "headline"
+# subset with individual, separately-named test IDs.
+REPRESENTATIVE_GAMES = [
+    REPO_ROOT / "examples" / "games" / "showcase" / "showcase.gq",
+    REPO_ROOT / "examples" / "games" / "perf" / "perf_menu_text.gq",
+    REPO_ROOT / "examples" / "games" / "tutorial_1.gq",
+    REPO_ROOT / "gqc" / "examples" / "skel" / "games" / "working_samples" / "sample_working.gq",
+    REPO_ROOT / "gamequeer" / "tests" / "golden" / "edge_coverage.gq",
+]
+
+ALL_GQ_FILES = sorted(
+    p for p in REPO_ROOT.glob("**/*.gq") if "node_modules" not in p.parts
+)
+
+
+# --- synthetic snippets: every trivia kind ----------------------------------
+
+
+def test_round_trip_is_byte_identical_for_simple_game():
+    source = (
+        'game { id = 1; title := "T"; author := "A"; starting_stage = s; }\n'
+        "stage s { event enter { } }\n"
+    )
+    tree = cst.parse_cst(source)
+    assert cst.to_source(tree) == source
+
+
+def test_round_trip_preserves_line_comment():
+    source = "game { // a comment\n id = 1; }\n"
+    tree = cst.parse_cst(source)
+    assert cst.to_source(tree) == source
+
+
+def test_round_trip_preserves_block_comment():
+    source = "/* header\n   comment */\ngame { id = 1; }\n"
+    tree = cst.parse_cst(source)
+    assert cst.to_source(tree) == source
+
+
+def test_round_trip_preserves_trailing_comment_after_last_token():
+    source = "game { id = 1; } // trailing\n"
+    tree = cst.parse_cst(source)
+    assert cst.to_source(tree) == source
+    # The trailing comment (and the newline after it) has no *following*
+    # token to attach to as leading trivia -- it lands in the file's own
+    # trailing_trivia instead. Nothing here is dropped either way (see the
+    # round-trip assertion above); this documents *where* it ends up.
+    assert [t.text for t in tree.trailing_trivia if t.kind != "whitespace"] == ["// trailing"]
+
+
+def test_round_trip_preserves_blank_lines_between_sections():
+    source = "game { id = 1; }\n\n\nstage s { event enter { } }\n"
+    tree = cst.parse_cst(source)
+    assert cst.to_source(tree) == source
+
+
+def test_round_trip_preserves_windows_line_endings():
+    source = 'game {\r\n id = 1; // note\r\n}\r\n'
+    tree = cst.parse_cst(source)
+    assert cst.to_source(tree) == source
+
+
+# --- comment survival, specifically -----------------------------------------
+
+
+def test_comments_are_individually_recoverable():
+    source = (
+        "/* block */\n"
+        "game { id = 1; } // line one\n"
+        "stage s { event enter { } } // line two\n"
+    )
+    tree = cst.parse_cst(source)
+    comment_texts = [t.text for t in cst.iter_comments(tree)]
+    assert comment_texts == ["/* block */", "// line one", "// line two"]
+
+
+def test_iter_comments_excludes_whitespace_trivia():
+    source = "game {\n\n    id = 1;\n}\n"
+    tree = cst.parse_cst(source)
+    assert list(cst.iter_comments(tree)) == []
+
+
+# --- structural nesting -----------------------------------------------------
+
+
+def test_braces_and_parens_nest_into_groups():
+    source = "stage s { event input(A) { gostage other; } }\n"
+    tree = cst.parse_cst(source)
+    # top-level: word("stage"), word("s"), Group({...})
+    assert [c.text if isinstance(c, cst.Token) else None for c in tree.children[:2]] == ["stage", "s"]
+    stage_group = tree.children[2]
+    assert isinstance(stage_group, cst.Group)
+    assert stage_group.open.text == "{" and stage_group.close.text == "}"
+    # event input(A) { ... } is itself word/word/Group(paren)/Group(brace)
+    event_paren_group = next(c for c in stage_group.children if isinstance(c, cst.Group) and c.open.text == "(")
+    assert [t.text for t in event_paren_group.children] == ["A"]
+
+
+def test_iter_tokens_is_flat_document_order():
+    source = "game { id = 1; }\n"
+    tree = cst.parse_cst(source)
+    texts = [t.text for t in cst.iter_tokens(tree)]
+    assert texts == ["game", "{", "id", "=", "1", ";", "}"]
+
+
+# --- lex errors --------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "source,expected_fragment",
+    [
+        ("game { id = 1;", "Unterminated '{'"),
+        ("game { id = 1; } }", "Unexpected closing"),
+        ("game { id = 1 ( ; }", "Mismatched bracket"),
+        ('str x := "unterminated', "Unterminated string literal"),
+        ("/* unterminated", "Unterminated block comment"),
+        ("game @ { }", "Unrecognized character"),
+    ],
+)
+def test_lex_errors_are_located_gqc_parse_errors(source, expected_fragment):
+    with pytest.raises(GqcParseError) as excinfo:
+        cst.parse_cst(source)
+    assert expected_fragment in str(excinfo.value)
+    # Same "Error at line N, column N: ..." shape as every other
+    # GqcParseError in gqc (see __init__.py).
+    assert str(excinfo.value).startswith("Error at line ")
+
+
+# --- real, committed .gq games -----------------------------------------------
+
+
+@pytest.mark.parametrize("path", REPRESENTATIVE_GAMES, ids=lambda p: p.name)
+def test_representative_game_round_trips_byte_identical(path):
+    source = path.read_text()
+    tree = cst.parse_cst(source)
+    assert cst.to_source(tree) == source
+
+
+@pytest.mark.parametrize("path", REPRESENTATIVE_GAMES, ids=lambda p: p.name)
+def test_representative_game_render_is_idempotent(path):
+    source = path.read_text()
+    once = cst.render(cst.parse_cst(source))
+    twice = cst.render(cst.parse_cst(once))
+    assert twice == once
+
+
+@pytest.mark.parametrize("path", REPRESENTATIVE_GAMES, ids=lambda p: p.name)
+def test_representative_game_comments_survive(path):
+    source = path.read_text()
+    tree = cst.parse_cst(source)
+    rendered = cst.render(tree)
+    for comment in cst.iter_comments(tree):
+        assert comment.text in rendered
+
+
+def test_all_committed_gq_files_round_trip_byte_identical():
+    """Sweeps every .gq file actually committed in the repo (examples/,
+    the C VM's golden fixtures, and gqc's own skel samples -- including the
+    intentionally-invalid "nonworking_samples", which are lexically fine
+    even though they're rejected at compile time for semantic reasons this
+    module doesn't know about), not just the headline REPRESENTATIVE_GAMES
+    subset above."""
+    assert len(ALL_GQ_FILES) >= 30, "sanity check: did the repo glob find the games?"
+    failures = []
+    for path in ALL_GQ_FILES:
+        source = path.read_text()
+        try:
+            tree = cst.parse_cst(source)
+        except GqcParseError as ge:
+            failures.append(f"{path}: failed to lex: {ge}")
+            continue
+        rendered = cst.to_source(tree)
+        if rendered != source:
+            failures.append(f"{path}: round-trip mismatch")
+    assert not failures, "\n".join(failures)
+
+
+# --- `gqc fmt` CLI -----------------------------------------------------------
+
+
+def test_fmt_default_prints_formatted_source_to_stdout(fmt_gq):
+    source = 'game { id = 1; title := "T"; author := "A"; starting_stage = s; }\nstage s { event enter { } }\n'
+    exit_code, stdout, stderr, _ = fmt_gq(source)
+    assert exit_code == 0, stderr
+    assert stdout == source
+
+
+def test_fmt_preserves_comments_through_the_cli(fmt_gq):
+    source = "game { // note\n id = 1; title := \"T\"; author := \"A\"; starting_stage = s; }\nstage s { event enter { } }\n"
+    exit_code, stdout, stderr, _ = fmt_gq(source)
+    assert exit_code == 0, stderr
+    assert "// note" in stdout
+    assert stdout == source
+
+
+def test_fmt_check_accepts_already_formatted_file(fmt_gq):
+    source = 'game { id = 1; title := "T"; author := "A"; starting_stage = s; }\nstage s { event enter { } }\n'
+    exit_code, stdout, stderr, _ = fmt_gq(source, extra_args=["--check"])
+    assert exit_code == 0, stderr
+    assert stdout == ""
+
+
+def test_fmt_write_updates_the_file_in_place(fmt_gq):
+    source = 'game { id = 1; title := "T"; author := "A"; starting_stage = s; }\nstage s { event enter { } }\n'
+    exit_code, stdout, stderr, src_path = fmt_gq(source, extra_args=["--write"])
+    assert exit_code == 0, stderr
+    assert stdout == ""
+    assert src_path.read_text() == source
+
+
+def test_fmt_of_fmt_output_is_a_fixed_point(fmt_gq, tmp_path):
+    """The issue's own idempotence phrasing: fmt(fmt(x)) == fmt(x)."""
+    source = REPRESENTATIVE_GAMES[0].read_text()
+    exit_code, once, stderr, _ = fmt_gq(source)
+    assert exit_code == 0, stderr
+    exit_code, twice, stderr, _ = fmt_gq(once, game_name="game2")
+    assert exit_code == 0, stderr
+    assert twice == once
+
+
+def test_fmt_reports_a_clean_error_on_unlexable_input(fmt_gq):
+    exit_code, stdout, stderr, _ = fmt_gq("game { id = 1;")
+    assert exit_code != 0
+    assert "Traceback" not in stderr
+    assert "Unterminated" in stderr


### PR DESCRIPTION
#429 (CST + minimal `gqc fmt`, #424 step 1) shows MERGED but its content never reached `default`: it was merged into its stacked base `claude/language-features-np8ywf` at 02:30:46Z — three seconds **after** #427 had merged that branch into `default` at commit 6b9bf08. The merge commit 776fc71 and the three CST commits under it (041a19c feature, 666db14 + 189f332 fix rounds) are therefore stranded off-default; `gqc/src/gqc/cst.py` does not exist on `default` today.

This PR is that exact content, re-landed: head `land-429-cst-fmt` = 776fc71, which is `default`'s own history plus the four stranded commits — nothing new. All of it was already adversarially reviewed and Copilot-converged on #429 (0 unresolved threads on final head 189f332; 480 tests passed / 2 skipped; 46/46 corpus byte-identical round-trip at review time).

No re-review needed beyond confirming the diff vs `default` matches #429's reviewed diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZKhf6qdJnripjqBapoEan