### PR TITLE
feat(gqc): add `gqc migrate` flat-to-directory game re-layout (#432)

### DIFF
--- a/gqc/src/gqc/gqc.py
+++ b/gqc/src/gqc/gqc.py
@@ -12,6 +12,7 @@ from . import anim, cues
 from . import cst
 from . import makefile_src
 from . import linker
+from . import migrate as migrate_mod
 from . import GqcParseError
 from .datamodel import Game
 
@@ -317,6 +318,49 @@ def update_makefile_local(base_dir : pathlib.Path):
             f.write(f'\t$(GQC_CMD) compile -o {dest_dir} $<\n\n')
             all_list.append(f'{dest_file.relative_to(base_dir)}')
         f.write('all: ' + ' '.join(all_list) + '\n')
+
+@gqc_cli.command()
+@click.argument('game', type=str, required=True)
+@click.option(
+    '--workspace', '-w',
+    type=click.Path(file_okay=False, dir_okay=True, exists=True, path_type=pathlib.Path),
+    default=pathlib.Path('.'),
+    help="Workspace root (contains games/ and assets/). Defaults to the current directory.",
+)
+@click.option('--dry-run', '-n', is_flag=True, help="Print the migration plan without touching anything.")
+def migrate(game : str, workspace : pathlib.Path, dry_run : bool):
+    """Migrate GAME from the flat workspace layout (games/GAME.gq + a
+    shared assets/ tree) to the self-contained game-as-directory layout
+    (gamequeer#420): GAME/GAME.gq, with only the assets it actually
+    references copied into GAME/assets/ and their path literals rewritten
+    to match (surgically, via gqc.cst -- comments and formatting survive
+    untouched).
+
+    GAME may be a bare game name (looked up under --workspace) or a path
+    to its entry .gq file directly. Idempotent: migrating an
+    already-migrated game is a no-op. Verifies the migrated game compiles
+    to byte-identical .gqgame output before committing anything -- on any
+    failure, the original flat game is left completely untouched. See
+    gqc.migrate's module docstring for the full design rationale
+    (destination layout, path-flattening, and the shared-asset policy)."""
+    try:
+        plan = migrate_mod.build_plan(game, workspace)
+    except migrate_mod.MigrateError as me:
+        click.echo(str(me), err=True)
+        raise SystemExit(1)
+
+    click.echo(migrate_mod.report_plan(plan))
+
+    if dry_run or plan.already_migrated:
+        return
+
+    try:
+        result = migrate_mod.execute(plan)
+    except migrate_mod.MigrateError as me:
+        click.echo(str(me), err=True)
+        raise SystemExit(1)
+
+    click.echo(migrate_mod.report_result(result))
 
 if __name__ == '__main__':
     gqc_cli()

--- a/gqc/src/gqc/gqc.py
+++ b/gqc/src/gqc/gqc.py
@@ -348,6 +348,12 @@ def migrate(game : str, workspace : pathlib.Path, dry_run : bool):
     except migrate_mod.MigrateError as me:
         click.echo(str(me), err=True)
         raise SystemExit(1)
+    except GqcParseError as ge:
+        # GAME's entry file doesn't tokenize cleanly (gqc.cst.parse_cst,
+        # called from build_plan) -- same clean-error convention as `gqc
+        # fmt` above, rather than a raw traceback.
+        click.echo(str(ge), err=True)
+        raise SystemExit(1)
 
     click.echo(migrate_mod.report_plan(plan))
 

--- a/gqc/src/gqc/migrate.py
+++ b/gqc/src/gqc/migrate.py
@@ -83,6 +83,7 @@ entry file.
 import dataclasses
 import os
 import pathlib
+import re
 import shutil
 import subprocess
 import sys
@@ -262,7 +263,38 @@ def _find_asset_bindings(tree: "cst.CstFile") -> list:
     return bindings
 
 
+# A Windows drive-letter prefix ("C:", "c:...") -- pathlib.PurePosixPath
+# doesn't treat this as absolute (only a leading "/" is), but a real
+# pathlib.Path *does* on Windows, and Path.__truediv__ discards everything
+# to its left when the right operand is absolute -- so `workspace / ... /
+# literal` in `_resolve_flat_source` would silently escape the workspace
+# on Windows if this weren't rejected here too.
+_WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:")
+
+
 def _validate_relative_asset_literal(literal: str, *, context: str) -> pathlib.PurePosixPath:
+    # Every asset literal in the corpus (and everywhere else in this
+    # module) uses "/" exclusively. PurePosixPath below never treats "\"
+    # as a separator, so a backslash-containing literal like
+    # "..\\..\\etc\\passwd" parses as one inert, non-".." path component
+    # here and would sail through both checks below undetected -- but a
+    # real pathlib.Path *does* split on "\" on Windows, so it would still
+    # be a genuine parent-directory (or, combined with a leading "\\",
+    # UNC-path) escape there. Reject outright rather than trying to
+    # validate backslash-containing literals correctly on every platform.
+    if "\\" in literal:
+        raise MigrateError(
+            f"{context}: asset source {literal!r} contains a backslash -- "
+            "migrate's path literals are always '/'-separated; a "
+            "backslash could hide a Windows-style '..' escape or UNC/"
+            "absolute path from the checks below."
+        )
+    if _WINDOWS_DRIVE_RE.match(literal):
+        raise MigrateError(
+            f"{context}: asset source {literal!r} looks like a Windows "
+            "drive-letter path -- migrate doesn't support relocating an "
+            "asset outside the workspace's shared asset tree."
+        )
     path = pathlib.PurePosixPath(literal)
     if path.is_absolute():
         raise MigrateError(

--- a/gqc/src/gqc/migrate.py
+++ b/gqc/src/gqc/migrate.py
@@ -202,6 +202,16 @@ def _find_asset_bindings(tree: "cst.CstFile") -> list:
     below is unambiguous under the current grammar; if a future grammar
     change ever adds another `<-` production, this comment (and the
     unit test pinning the ambiguity claim) is the place to revisit.
+
+    The triplet check runs *before* the section-keyword check: grammar.py's
+    `identifier` (used for an animation/lightcue's own name) is a plain
+    `Word`, not lexically reserved against any of `_SECTION_KEYWORDS` --
+    a binding legitimately named `stage <- "foo.png";` is valid `.gq`
+    source. Since the triplet shape is unambiguous on its own (see above),
+    checking it first means such a name is always classified correctly as
+    a binding, regardless of what its own text happens to be; only a bare
+    word *not* immediately followed by `<-` and a string is ever treated
+    as a section-keyword marker.
     """
     bindings = []
 
@@ -210,14 +220,6 @@ def _find_asset_bindings(tree: "cst.CstFile") -> list:
         n = len(children)
         while i < n:
             node = children[i]
-            if (
-                isinstance(node, cst.Token)
-                and node.kind == "word"
-                and node.text in _SECTION_KEYWORDS
-            ):
-                section = node.text
-                i += 1
-                continue
             if (
                 isinstance(node, cst.Token)
                 and node.kind == "word"
@@ -239,6 +241,14 @@ def _find_asset_bindings(tree: "cst.CstFile") -> list:
                         )
                     )
                 i += 3
+                continue
+            if (
+                isinstance(node, cst.Token)
+                and node.kind == "word"
+                and node.text in _SECTION_KEYWORDS
+            ):
+                section = node.text
+                i += 1
                 continue
             if isinstance(node, cst.Group):
                 scan(node.children, section)

--- a/gqc/src/gqc/migrate.py
+++ b/gqc/src/gqc/migrate.py
@@ -617,6 +617,27 @@ def execute(plan: MigrationPlan) -> MigrationResult:
         # staged, byte-verified game directory into place, then remove the
         # original flat entry file. Never the shared assets/ tree -- other,
         # not-yet-migrated games may still reference it.
+        #
+        # build_plan() already rejected an existing new_game_dir up front,
+        # but the two compiles in between can take a while -- re-check
+        # right before the move narrows (doesn't eliminate; there's no
+        # cross-platform atomic "move only if absent") the window where
+        # something else creates new_game_dir in the meantime.
+        # shutil.move(src, dst) treats an *existing* dst directory as "move
+        # src inside dst", not "replace dst" -- so without this check the
+        # staged game would land nested at new_game_dir/game_name/ instead
+        # of new_game_dir/ itself, and the OSError handler's rollback below
+        # would rmtree() whatever was already in that pre-existing
+        # directory, not just what this migration wrote.
+        if plan.new_game_dir.exists():
+            raise MigrateError(
+                f"{plan.new_game_dir} was created after this migration's "
+                "precondition checks ran -- refusing to move the staged, "
+                "verified game directory into it (that would nest it inside "
+                "instead of replacing it). Remove it (if it's unrelated or "
+                "stale) and re-run migrate; original flat game left in place."
+            )
+
         try:
             shutil.move(str(staged_game_dir), str(plan.new_game_dir))
         except OSError as exc:

--- a/gqc/src/gqc/migrate.py
+++ b/gqc/src/gqc/migrate.py
@@ -273,22 +273,37 @@ def _resolve_flat_source(workspace: pathlib.Path, section: str, literal: str) ->
 def _resolve_entry_path(game: str, workspace: pathlib.Path) -> pathlib.Path:
     """Resolve GAME (a bare game name, or a path to its `.gq` entry file)
     against WORKSPACE, whether the game is currently flat
-    (`games/<name>.gq`) or already migrated (`<name>/<name>.gq`)."""
-    candidate = pathlib.Path(game)
-    if candidate.is_file():
-        return candidate.resolve()
+    (`games/<name>.gq`) or already migrated (`<name>/<name>.gq`).
 
+    An explicit path is only accepted if it resolves to exactly one of
+    those two canonical, in-workspace locations -- migrate always ends by
+    deleting the original entry file (see `execute`), so accepting an
+    arbitrary existing file path here (e.g. `../elsewhere/foo.gq`, or an
+    absolute path outside --workspace entirely) would let GAME name a file
+    outside the workspace migrate is meant to operate on, which `execute`
+    would then happily delete."""
+    candidate = pathlib.Path(game)
     name = candidate.name
     if name.endswith(".gq"):
         name = name[: -len(".gq")]
 
-    directory_style = workspace / name / f"{name}.gq"
-    if directory_style.is_file():
-        return directory_style.resolve()
+    directory_style = (workspace / name / f"{name}.gq").resolve()
+    flat = (workspace / "games" / f"{name}.gq").resolve()
 
-    flat = workspace / "games" / f"{name}.gq"
+    if candidate.is_file():
+        resolved = candidate.resolve()
+        if resolved not in (directory_style, flat):
+            raise MigrateError(
+                f"{resolved} is not {name!r}'s entry file under workspace "
+                f"{workspace} (expected {directory_style} or {flat}) -- "
+                "migrate only operates on games inside --workspace."
+            )
+        return resolved
+
+    if directory_style.is_file():
+        return directory_style
     if flat.is_file():
-        return flat.resolve()
+        return flat
 
     raise MigrateError(
         f"Could not find game {game!r} under workspace {workspace} "
@@ -400,6 +415,16 @@ def build_plan(game: str, workspace: pathlib.Path) -> MigrationPlan:
     tree = cst.parse_cst(source)
     bindings = _find_asset_bindings(tree)
 
+    # Parse every still-flat sibling exactly once (informational
+    # shared-asset stats only -- see AssetCopy.shared_with) rather than
+    # once per asset this game references, which would be an
+    # O(n_assets * n_siblings) reparse for a corpus with many shared-asset
+    # games (e.g. the queersafe/queersafe-lite pair, ~40 assets each).
+    sibling_sources = {
+        sibling: _flat_sources_for(sibling)
+        for sibling in _iter_sibling_flat_entries(workspace, entry_path)
+    }
+
     asset_copies = []
     for section in ("animations", "lightcues"):
         section_bindings = [b for b in bindings if b.section == section]
@@ -418,8 +443,8 @@ def build_plan(game: str, workspace: pathlib.Path) -> MigrationPlan:
             )
             shared_with = sorted(
                 sibling.stem
-                for sibling in _iter_sibling_flat_entries(workspace, entry_path)
-                if src_path in _flat_sources_for(sibling)
+                for sibling, sources in sibling_sources.items()
+                if src_path in sources
             )
             copy = AssetCopy(
                 section=section,
@@ -552,7 +577,22 @@ def execute(plan: MigrationPlan) -> MigrationResult:
         # not-yet-migrated games may still reference it.
         shutil.move(str(staged_game_dir), str(plan.new_game_dir))
 
-    plan.entry_path.unlink()
+    try:
+        plan.entry_path.unlink()
+    except OSError as exc:
+        # The migrated directory is already in place and byte-verified, but
+        # removing the original flat entry file failed (permissions, a
+        # concurrent edit, ...). Roll back the move so the workspace always
+        # ends up in exactly one of its two valid states -- fully flat, or
+        # fully migrated -- never a hybrid with both present, which is what
+        # this module's "leave the workspace untouched on failure" property
+        # promises.
+        shutil.rmtree(plan.new_game_dir, ignore_errors=True)
+        raise MigrateError(
+            f"{plan.game_name}: migrated directory verified and staged, but "
+            f"removing the original {plan.entry_path} failed ({exc}) -- "
+            "rolled back; original flat game left in place."
+        ) from exc
 
     return MigrationResult(plan=plan, pre_bytes=pre_bytes, post_bytes=post_bytes)
 

--- a/gqc/src/gqc/migrate.py
+++ b/gqc/src/gqc/migrate.py
@@ -74,6 +74,10 @@ stages the migrated form in a separate temp directory, compiles that too,
 and requires the two `.gqgame` outputs to be **byte-identical** before
 committing anything to the workspace. Any mismatch (or either compile
 failing) aborts loudly and leaves the original completely untouched.
+Once gamequeer#434 (layout-detected legacy resolution) lands, a flat game
+will compile directly again, and `_compile_flat_baseline`'s symlink
+harness can be simplified to a direct in-place compile of the original
+entry file.
 """
 
 import dataclasses
@@ -280,6 +284,28 @@ def _resolve_flat_source(workspace: pathlib.Path, section: str, literal: str) ->
     return workspace / "assets" / asset_dir / literal
 
 
+def _require_in_workspace(
+    resolved: pathlib.Path, workspace: pathlib.Path, game: str
+) -> None:
+    """Raise MigrateError unless RESOLVED (already followed through any
+    symlinks, via `.resolve()`) sits inside WORKSPACE (also already
+    resolved -- see `build_plan`).
+
+    Guards every path `_resolve_entry_path` can return, not just an
+    explicit GAME path: a symlink planted at either canonical location
+    (`<name>/<name>.gq` or `games/<name>.gq`) resolves outside the
+    workspace exactly as easily as an explicit `../escape.gq` would, and
+    `execute()` unconditionally `unlink()`s whatever this function
+    returns on success -- so a workspace-external file reached via either
+    path shape must never be handed back."""
+    if not resolved.is_relative_to(workspace):
+        raise MigrateError(
+            f"{game!r} resolves to {resolved}, outside workspace {workspace} "
+            "(likely a symlink) -- migrate only operates on games inside "
+            "--workspace."
+        )
+
+
 def _resolve_entry_path(game: str, workspace: pathlib.Path) -> pathlib.Path:
     """Resolve GAME (a bare game name, or a path to its `.gq` entry file)
     against WORKSPACE, whether the game is currently flat
@@ -291,7 +317,10 @@ def _resolve_entry_path(game: str, workspace: pathlib.Path) -> pathlib.Path:
     arbitrary existing file path here (e.g. `../elsewhere/foo.gq`, or an
     absolute path outside --workspace entirely) would let GAME name a file
     outside the workspace migrate is meant to operate on, which `execute`
-    would then happily delete."""
+    would then happily delete. Every returned path -- explicit, or found
+    via a bare-name lookup -- is additionally required to actually resolve
+    inside WORKSPACE (`_require_in_workspace`): a symlink at the canonical
+    location is just as much an escape as an explicit `..` path."""
     candidate = pathlib.Path(game)
     name = candidate.name
     if name.endswith(".gq"):
@@ -308,11 +337,14 @@ def _resolve_entry_path(game: str, workspace: pathlib.Path) -> pathlib.Path:
                 f"{workspace} (expected {directory_style} or {flat}) -- "
                 "migrate only operates on games inside --workspace."
             )
+        _require_in_workspace(resolved, workspace, game)
         return resolved
 
     if directory_style.is_file():
+        _require_in_workspace(directory_style, workspace, game)
         return directory_style
     if flat.is_file():
+        _require_in_workspace(flat, workspace, game)
         return flat
 
     raise MigrateError(
@@ -585,7 +617,27 @@ def execute(plan: MigrationPlan) -> MigrationResult:
         # staged, byte-verified game directory into place, then remove the
         # original flat entry file. Never the shared assets/ tree -- other,
         # not-yet-migrated games may still reference it.
-        shutil.move(str(staged_game_dir), str(plan.new_game_dir))
+        try:
+            shutil.move(str(staged_game_dir), str(plan.new_game_dir))
+        except OSError as exc:
+            # Same filesystem: os.rename is atomic, so this can only ever
+            # fail all-or-nothing. Cross-filesystem (e.g. this temp
+            # staging dir on /tmp vs. a real workspace on another mount)
+            # shutil.move degrades to copytree+rmtree, and a mid-copy
+            # failure (disk full, permissions, ...) can leave
+            # new_game_dir partially populated in the *real* workspace
+            # while the original flat entry file is still untouched.
+            # Remove whatever landed so the workspace stays in exactly
+            # one of its two valid states -- fully flat, never a
+            # half-written migrated directory -- and report it as a
+            # clean MigrateError, not a raw traceback (gqc.py's `migrate`
+            # command only catches MigrateError/GqcParseError).
+            shutil.rmtree(plan.new_game_dir, ignore_errors=True)
+            raise MigrateError(
+                f"{plan.game_name}: migrated directory verified and staged, "
+                f"but moving it into place at {plan.new_game_dir} failed "
+                f"({exc}) -- rolled back; original flat game left in place."
+            ) from exc
 
     try:
         plan.entry_path.unlink()

--- a/gqc/src/gqc/migrate.py
+++ b/gqc/src/gqc/migrate.py
@@ -1,0 +1,631 @@
+"""`gqc migrate`: deterministic flat-workspace -> game-as-directory
+re-layout (gamequeer#432, follow-on to #420/#427's game-as-directory layout
+and #424/#429's CST).
+
+Before #420, a workspace kept every game flat at `games/<name>.gq` and
+resolved `animations{}`/`lightcues{}` sources against a *shared*,
+top-level `assets/animations`/`assets/lighting` tree, keyed by a
+hand-matched per-game subdirectory (e.g. `games/bricks.gq`'s
+`"bricks/bg_title.png"` resolves against `assets/animations/bricks/...`).
+#420 replaced that with a self-contained game directory
+(`<name>/<name>.gq`) whose assets resolve directly against its own
+`assets/animations`/`assets/lighting` (see `datamodel.Animation.src_path`
+/ `parser.parse_lightcue_definition_section`) -- **relative to the entry
+file's own parent directory, not the process CWD**. That's a real,
+load-bearing behavior change, not just a style preference: a flat game
+under `games/` no longer compiles at all against the current compiler
+(its sources resolve against `games/assets/...`, which doesn't exist --
+the shared tree sits one level up, next to `games/`, not inside it).
+`gqc migrate` is the mechanical fix: it moves a flat game's entry file and
+copies exactly the assets it references into the new self-contained
+layout, rewriting each asset-path string literal to match (surgically,
+via `gqc.cst`, so every comment and all of the surrounding formatting
+survive byte-for-byte).
+
+Design decisions
+-----------------
+- **Destination**: `<workspace>/<name>/<name>.gq`, a sibling of
+  `<workspace>/games/`, matching `gqc new`'s own scaffold (its default
+  `--out-dir` is the CWD) -- not nested inside `games/`. `games/` stays the
+  home for whatever flat games haven't been migrated yet during the
+  transition (see gamequeer#432); the workspace `Makefile`'s discovery of
+  the new, sibling-of-`games/` layout is tracked separately (out of scope
+  here -- lives in `gq-games`, not `gqc`).
+- **Path rewriting, not verbatim copying**: a flat source like
+  `"bricks/bg_title.png"` could, mechanically, be preserved unchanged and
+  just copied to `<name>/assets/animations/bricks/bg_title.png` (still
+  valid -- #420 doesn't require a flat `assets/animations/`, only that it
+  resolve under the game's own directory). But #420's own issue text is
+  explicit that the point of the change is dropping "the old top-level
+  assets/animations + assets/lighting roots keyed by a hand-matched
+  subdir" -- so migrate normalizes every reference down to its bare
+  filename (flattening the now-redundant per-game subdirectory), matching
+  `gqc new`'s own scaffold shape. A real, unresolvable filename collision
+  within one game's animations (or lightcues) is a hard error -- migrate
+  never silently disambiguates or overwrites.
+- **Shared assets: copy, not cross-reference.** The corpus has real
+  cross-game sharing today (e.g. `queersafe.gq` and `queersafe-lite.gq`
+  both reference the entire `queersafe/` subtree; `2000svg.gq`/`boot.gq`/
+  `retrovg.gq`/`meme.gq`/`pop.gq` all share `tvtuner/stock/rainbow.gqcue`).
+  #420's own test suite (`test_game_layout.py`) only ever exercises
+  resolution *within* the game's own directory, and its negative control
+  (`test_animation_source_at_old_cwd_relative_location_is_not_found`)
+  proves there's deliberately no fallback/search path outside it -- there's
+  no sanctioned way to reference another game directory's assets, and nothing
+  in the shipped code path or tests suggests `..`-escapes are intentional
+  (they're simply unvalidated, not supported). So migrate always *copies*
+  the referenced files into the migrated game's own `assets/` -- accepting
+  duplication -- rather than inventing a cross-directory reference this
+  layout was explicitly designed to retire. It reports how much of that
+  duplication is with other *still-flat* games in `games/` (informational
+  only) so an author can judge whether it's worth deduplicating by hand.
+- **Never deletes shared originals.** Only the migrated game's own flat
+  entry file (`games/<name>.gq`) is removed, and only after the
+  byte-identical verification below passes. The shared `assets/` tree is
+  left completely alone -- other, not-yet-migrated games may still need
+  it (this is what makes migrating each in-flight branch independently,
+  on its own author's timing, safe).
+
+Acceptance property (load-bearing, gamequeer#432): before touching
+anything, migrate compiles the *original* flat game (via a throwaway
+symlink harness -- see `_compile_flat_baseline` -- since the flat form no
+longer compiles in place against the current compiler, per the above) and
+stages the migrated form in a separate temp directory, compiles that too,
+and requires the two `.gqgame` outputs to be **byte-identical** before
+committing anything to the workspace. Any mismatch (or either compile
+failing) aborts loudly and leaves the original completely untouched.
+"""
+
+import dataclasses
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+
+from . import cst
+
+COMPILE_TIMEOUT_S = 120
+
+# gamequeer#420's grammar keyword for the mapping from an animations{}/
+# lightcues{} section keyword to the asset-tree subdirectory it resolves
+# against (see datamodel.Animation.src_path / parser.parse_lightcue_
+# definition_section -- "lightcues" resolves against "lighting", not
+# "lightcues").
+_SECTION_ASSET_DIR = {
+    "animations": "animations",
+    "lightcues": "lighting",
+}
+
+# Every top-level keyword grammar.py's top_level_section alternation
+# accepts (see grammar.py's module docstring) -- used only to track which
+# section we're inside while scanning the CST, not to validate anything.
+_SECTION_KEYWORDS = {
+    "animations", "lightcues", "game", "volatile", "persistent",
+    "menus", "stage", "const", "enum", "cohort",
+}
+
+
+class MigrateError(Exception):
+    """A migrate precondition or verification failure. Always caught at
+    the CLI boundary and reported as a clean, nonzero-exit message -- never
+    a raw traceback -- and always raised before any destructive filesystem
+    step, so the original flat game is left untouched."""
+
+
+@dataclasses.dataclass
+class AssetBinding:
+    """One `name <- "source"` animation/lightcue file_assignment, located
+    structurally in the CST (see `_find_asset_bindings`)."""
+
+    section: str  # "animations" | "lightcues"
+    name: str
+    string_token: "cst.Token"
+    literal: str  # decoded (unescaped, unquoted) source text
+
+
+@dataclasses.dataclass
+class AssetCopy:
+    """One file that migration will copy into the new game directory."""
+
+    section: str  # "animations" | "lightcues"
+    old_literal: str  # original (possibly-nested) relative source text
+    new_literal: str  # flattened (bare filename) relative source text
+    src_path: pathlib.Path  # absolute path under the shared workspace assets tree
+    binding_names: list  # animation/lightcue names that reference this file
+    shared_with: list  # other still-flat games/*.gq (by stem) that also reference it
+
+
+@dataclasses.dataclass
+class MigrationPlan:
+    game_name: str
+    workspace: pathlib.Path
+    entry_path: pathlib.Path
+    already_migrated: bool
+    new_game_dir: pathlib.Path
+    new_entry_path: pathlib.Path
+    rewritten_source: str
+    asset_copies: list
+
+
+@dataclasses.dataclass
+class MigrationResult:
+    plan: MigrationPlan
+    pre_bytes: bytes
+    post_bytes: bytes
+
+
+def _decode_string_literal(text: str) -> str:
+    """Reverse of `_encode_string_literal`: strip the surrounding quotes
+    and undo the `\\`-escaping convention `gqc.cst`'s tokenizer documents
+    (and grammar.py's `meta_string` -- `escChar='\\'` -- actually
+    implements) for animation/lightcue `file_source` string literals."""
+    assert text[0] == '"' and text[-1] == '"', f"not a quoted string literal: {text!r}"
+    inner = text[1:-1]
+    out = []
+    i = 0
+    n = len(inner)
+    while i < n:
+        c = inner[i]
+        if c == "\\" and i + 1 < n:
+            out.append(inner[i + 1])
+            i += 2
+        else:
+            out.append(c)
+            i += 1
+    return "".join(out)
+
+
+def _encode_string_literal(value: str) -> str:
+    """Inverse of `_decode_string_literal`: re-quote `value` as a `.gq`
+    string literal, escaping the same two characters `meta_string`'s
+    `escChar='\\'` grammar (and `gqc.cst`'s matching tokenizer choice)
+    ever need escaped."""
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _find_asset_bindings(tree: "cst.CstFile") -> list:
+    """Locate every `name <- "source"` file_assignment/animation_assignment
+    in `tree`, tagged with which top-level section it's in.
+
+    Identification is purely structural, derived directly from
+    grammar.py's shape for these two productions
+    (`file_assignment`/`animation_assignment`, both
+    `identifier - Suppress("<-") - file_source - ...`), not from what the
+    string *looks like* (no `.gif`/`.png`/`.gqcue` extension sniffing):
+    `<-` appears in exactly one other place in the grammar
+    (`event_input_button`'s `input(<-)` form), and that occurrence is
+    always sandwiched between `(` and `)` -- never followed by a string
+    token. So the flat `(word, "<-", string)` triplet found directly
+    below is unambiguous under the current grammar; if a future grammar
+    change ever adds another `<-` production, this comment (and the
+    unit test pinning the ambiguity claim) is the place to revisit.
+    """
+    bindings = []
+
+    def scan(children, section):
+        i = 0
+        n = len(children)
+        while i < n:
+            node = children[i]
+            if (
+                isinstance(node, cst.Token)
+                and node.kind == "word"
+                and node.text in _SECTION_KEYWORDS
+            ):
+                section = node.text
+                i += 1
+                continue
+            if (
+                isinstance(node, cst.Token)
+                and node.kind == "word"
+                and i + 2 < n
+                and isinstance(children[i + 1], cst.Token)
+                and children[i + 1].kind == "punct"
+                and children[i + 1].text == "<-"
+                and isinstance(children[i + 2], cst.Token)
+                and children[i + 2].kind == "string"
+            ):
+                if section in ("animations", "lightcues"):
+                    string_token = children[i + 2]
+                    bindings.append(
+                        AssetBinding(
+                            section=section,
+                            name=node.text,
+                            string_token=string_token,
+                            literal=_decode_string_literal(string_token.text),
+                        )
+                    )
+                i += 3
+                continue
+            if isinstance(node, cst.Group):
+                scan(node.children, section)
+            i += 1
+
+    scan(tree.children, None)
+    return bindings
+
+
+def _validate_relative_asset_literal(literal: str, *, context: str) -> pathlib.PurePosixPath:
+    path = pathlib.PurePosixPath(literal)
+    if path.is_absolute():
+        raise MigrateError(
+            f"{context}: asset source {literal!r} is an absolute path -- migrate "
+            "doesn't support relocating an asset outside the workspace's shared "
+            "asset tree."
+        )
+    if not path.parts or ".." in path.parts:
+        raise MigrateError(
+            f"{context}: asset source {literal!r} escapes the shared asset "
+            "tree (empty path or a '..' component) -- migrate doesn't support "
+            "relocating an asset outside the workspace's shared asset tree."
+        )
+    return path
+
+
+def _resolve_flat_source(workspace: pathlib.Path, section: str, literal: str) -> pathlib.Path:
+    asset_dir = _SECTION_ASSET_DIR[section]
+    return workspace / "assets" / asset_dir / literal
+
+
+def _resolve_entry_path(game: str, workspace: pathlib.Path) -> pathlib.Path:
+    """Resolve GAME (a bare game name, or a path to its `.gq` entry file)
+    against WORKSPACE, whether the game is currently flat
+    (`games/<name>.gq`) or already migrated (`<name>/<name>.gq`)."""
+    candidate = pathlib.Path(game)
+    if candidate.is_file():
+        return candidate.resolve()
+
+    name = candidate.name
+    if name.endswith(".gq"):
+        name = name[: -len(".gq")]
+
+    directory_style = workspace / name / f"{name}.gq"
+    if directory_style.is_file():
+        return directory_style.resolve()
+
+    flat = workspace / "games" / f"{name}.gq"
+    if flat.is_file():
+        return flat.resolve()
+
+    raise MigrateError(
+        f"Could not find game {game!r} under workspace {workspace} "
+        f"(looked for {directory_style} and {flat})."
+    )
+
+
+def _iter_sibling_flat_entries(workspace: pathlib.Path, exclude: pathlib.Path):
+    games_dir = workspace / "games"
+    if not games_dir.is_dir():
+        return
+    for path in sorted(games_dir.glob("*.gq")):
+        if path.resolve() != exclude:
+            yield path
+
+
+def _flat_sources_for(gq_path: pathlib.Path) -> set:
+    """The set of resolved absolute source paths a still-flat `<name>.gq`
+    references, resolved against its workspace (`gq_path.parent.parent`,
+    i.e. `games/../` -- this helper is only ever called on paths already
+    known to be under a workspace's `games/` directory). Used only for
+    migrate's informational shared-asset duplication stats: best-effort,
+    so a sibling `.gq` file that fails to parse is silently skipped rather
+    than aborting the migration it has nothing to do with."""
+    try:
+        source = gq_path.read_text(encoding="utf-8")
+        tree = cst.parse_cst(source)
+    except Exception:
+        return set()
+
+    workspace = gq_path.parent.parent
+    sources = set()
+    for binding in _find_asset_bindings(tree):
+        try:
+            _validate_relative_asset_literal(binding.literal, context=str(gq_path))
+        except MigrateError:
+            continue
+        sources.add(_resolve_flat_source(workspace, binding.section, binding.literal))
+    return sources
+
+
+def _flatten_literals(bindings: list, *, section: str) -> dict:
+    """Map each distinct old relative literal in `bindings` (already
+    filtered to `section`) to its new, flattened (bare-filename) relative
+    literal. Raises MigrateError on a real collision: two different old
+    literals that would flatten to the same filename."""
+    old_to_new = {}
+    new_to_old = {}
+    literals = sorted({b.literal for b in bindings})
+    for literal in literals:
+        basename = pathlib.PurePosixPath(literal).name
+        if basename in new_to_old and new_to_old[basename] != literal:
+            raise MigrateError(
+                f"Cannot flatten {section} asset paths: both {new_to_old[basename]!r} "
+                f"and {literal!r} would collide as {basename!r}. Rename one of the "
+                "source assets (or the reference to it) before migrating."
+            )
+        new_to_old[basename] = literal
+        old_to_new[literal] = basename
+    return old_to_new
+
+
+def build_plan(game: str, workspace: pathlib.Path) -> MigrationPlan:
+    """Analyze GAME (read-only -- touches nothing on disk) and build the
+    full migration plan: the rewritten source text and every asset that
+    would be copied. Raises MigrateError on any precondition failure."""
+    workspace = workspace.resolve()
+    entry_path = _resolve_entry_path(game, workspace)
+    game_name = entry_path.stem
+
+    already_migrated = entry_path.parent.name == game_name
+    new_game_dir = workspace / game_name
+    new_entry_path = new_game_dir / f"{game_name}.gq"
+
+    if already_migrated:
+        # gamequeer#432's idempotence requirement: migrating an
+        # already-migrated game is a clean no-op. Detected structurally
+        # (entry file already sits at <name>/<name>.gq) rather than by
+        # re-checking every asset literal is already a bare filename --
+        # a hand-authored, legitimately-nested asset subpath inside an
+        # already-directory-layout game is none of migrate's business to
+        # "fix" after the fact.
+        with open(entry_path, "r", encoding="utf-8", newline="") as f:
+            rewritten_source = f.read()
+        return MigrationPlan(
+            game_name=game_name,
+            workspace=workspace,
+            entry_path=entry_path,
+            already_migrated=True,
+            new_game_dir=new_game_dir,
+            new_entry_path=new_entry_path,
+            rewritten_source=rewritten_source,
+            asset_copies=[],
+        )
+
+    if new_game_dir.exists():
+        raise MigrateError(
+            f"{new_game_dir} already exists -- refusing to migrate {game_name!r} "
+            "into it. Remove it first if this is stale output from a previous "
+            "failed migration attempt."
+        )
+
+    # encoding='utf-8', newline='': same byte-fidelity rationale as `gqc
+    # fmt` (gqc.py) -- open()'s platform defaults can silently misdecode or
+    # re-translate line endings, which would break the exact-source
+    # guarantee the CST round-trip depends on.
+    with open(entry_path, "r", encoding="utf-8", newline="") as f:
+        source = f.read()
+    tree = cst.parse_cst(source)
+    bindings = _find_asset_bindings(tree)
+
+    asset_copies = []
+    for section in ("animations", "lightcues"):
+        section_bindings = [b for b in bindings if b.section == section]
+        old_to_new = _flatten_literals(section_bindings, section=section)
+
+        for literal, new_literal in sorted(old_to_new.items()):
+            _validate_relative_asset_literal(literal, context=f"{entry_path} ({section})")
+            src_path = _resolve_flat_source(workspace, section, literal)
+            if not src_path.is_file():
+                raise MigrateError(
+                    f"{entry_path}: {section} source {literal!r} resolves to "
+                    f"{src_path}, which doesn't exist."
+                )
+            binding_names = sorted(
+                b.name for b in section_bindings if b.literal == literal
+            )
+            shared_with = sorted(
+                sibling.stem
+                for sibling in _iter_sibling_flat_entries(workspace, entry_path)
+                if src_path in _flat_sources_for(sibling)
+            )
+            copy = AssetCopy(
+                section=section,
+                old_literal=literal,
+                new_literal=new_literal,
+                src_path=src_path,
+                binding_names=binding_names,
+                shared_with=shared_with,
+            )
+            asset_copies.append(copy)
+
+        # Rewrite every binding's string token in place, in this section,
+        # to its flattened literal.
+        for binding in section_bindings:
+            binding.string_token.text = _encode_string_literal(old_to_new[binding.literal])
+
+    rewritten_source = cst.to_source(tree)
+
+    return MigrationPlan(
+        game_name=game_name,
+        workspace=workspace,
+        entry_path=entry_path,
+        already_migrated=False,
+        new_game_dir=new_game_dir,
+        new_entry_path=new_entry_path,
+        rewritten_source=rewritten_source,
+        asset_copies=asset_copies,
+    )
+
+
+def _run_compile(entry_path: pathlib.Path, out_dir: pathlib.Path, cwd: pathlib.Path) -> bytes:
+    """Run the real `gqc compile` CLI as a subprocess (matching the
+    project's existing test convention -- see tests/conftest.py's
+    `compile_gq` -- and, more importantly here, running the *actual*
+    shipped compiler rather than re-deriving any of its behavior) and
+    return the resulting `.gqgame` bytes. Raises MigrateError with the
+    compiler's own stderr on any failure."""
+    cmd = [
+        sys.executable, "-m", "gqc", "compile", "--no-mem-map",
+        "-o", str(out_dir), str(entry_path),
+    ]
+    try:
+        proc = subprocess.run(
+            cmd, cwd=cwd, capture_output=True, text=True, timeout=COMPILE_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise MigrateError(
+            f"gqc compile of {entry_path} did not finish within "
+            f"{COMPILE_TIMEOUT_S}s (cmd={cmd!r})"
+        ) from exc
+
+    if proc.returncode != 0:
+        raise MigrateError(f"gqc compile of {entry_path} failed:\n{proc.stderr}")
+
+    cart_path = out_dir / f"{entry_path.stem}.gqgame"
+    if not cart_path.is_file():
+        raise MigrateError(
+            f"gqc compile of {entry_path} exited 0 but produced no {cart_path.name}"
+        )
+    return cart_path.read_bytes()
+
+
+def _compile_flat_baseline(plan: MigrationPlan) -> bytes:
+    """Compile the *original*, untouched flat game and return its
+    `.gqgame` bytes -- the "pre" side of the migration's byte-identical
+    acceptance property.
+
+    The flat entry file no longer compiles in place under the current
+    compiler (see this module's docstring: its sources resolve relative to
+    its own parent, `games/`, not the shared `assets/` tree one level up).
+    So this builds a throwaway harness in a temp directory: an exact copy
+    of the original entry file, sitting next to a symlink to the *real*
+    shared `assets/` directory. That reconstructs precisely what compiling
+    this exact, unmodified source would have produced under the workspace's
+    old CWD-relative resolution -- the same bytes are read off disk either
+    way -- without touching the real workspace or reviving any of the old
+    resolution logic inside the compiler itself."""
+    with tempfile.TemporaryDirectory(prefix="gqc-migrate-pre-") as tmp:
+        tmp_path = pathlib.Path(tmp)
+        tmp_entry = tmp_path / plan.entry_path.name
+        shutil.copyfile(plan.entry_path, tmp_entry)
+        os.symlink(plan.workspace / "assets", tmp_path / "assets")
+        return _run_compile(tmp_entry, tmp_path / "build", cwd=tmp_path)
+
+
+def _stage_migrated_game(plan: MigrationPlan, dest_root: pathlib.Path) -> pathlib.Path:
+    """Write the migrated game (rewritten entry file + copied assets)
+    under `dest_root` (a temp staging directory, or -- once verified --
+    the real workspace) and return its game directory."""
+    game_dir = dest_root / plan.game_name
+    for section_dir in ("animations", "lighting"):
+        (game_dir / "assets" / section_dir).mkdir(parents=True, exist_ok=True)
+
+    entry_path = game_dir / f"{plan.game_name}.gq"
+    with open(entry_path, "w", encoding="utf-8", newline="") as f:
+        f.write(plan.rewritten_source)
+
+    for copy in plan.asset_copies:
+        asset_dir = _SECTION_ASSET_DIR[copy.section]
+        dest = game_dir / "assets" / asset_dir / copy.new_literal
+        shutil.copy2(copy.src_path, dest)
+
+    return game_dir
+
+
+def execute(plan: MigrationPlan) -> MigrationResult:
+    """Perform the migration for real: verify byte-identical compiled
+    output between the original and the migrated form (in isolated temp
+    directories -- nothing in the real workspace is touched yet), and only
+    then commit the migrated game directory and remove the original flat
+    entry file. Raises MigrateError (leaving the workspace exactly as it
+    was) on any verification failure."""
+    if plan.already_migrated:
+        return MigrationResult(plan=plan, pre_bytes=b"", post_bytes=b"")
+
+    pre_bytes = _compile_flat_baseline(plan)
+
+    with tempfile.TemporaryDirectory(prefix="gqc-migrate-post-") as tmp:
+        tmp_path = pathlib.Path(tmp)
+        staged_game_dir = _stage_migrated_game(plan, tmp_path)
+        staged_entry = staged_game_dir / f"{plan.game_name}.gq"
+        post_bytes = _run_compile(staged_entry, tmp_path / "build", cwd=tmp_path)
+
+        if post_bytes != pre_bytes:
+            raise MigrateError(_byte_mismatch_message(plan, pre_bytes, post_bytes))
+
+        # Verified -- now, and only now, touch the real workspace: move the
+        # staged, byte-verified game directory into place, then remove the
+        # original flat entry file. Never the shared assets/ tree -- other,
+        # not-yet-migrated games may still reference it.
+        shutil.move(str(staged_game_dir), str(plan.new_game_dir))
+
+    plan.entry_path.unlink()
+
+    return MigrationResult(plan=plan, pre_bytes=pre_bytes, post_bytes=post_bytes)
+
+
+def _byte_mismatch_message(plan: MigrationPlan, expected: bytes, actual: bytes) -> str:
+    if len(expected) != len(actual):
+        return (
+            f"{plan.game_name}: migrated cart is {len(actual)} bytes, "
+            f"original flat cart is {len(expected)} bytes -- aborting, "
+            "original left untouched."
+        )
+    for offset, (exp_byte, act_byte) in enumerate(zip(expected, actual)):
+        if exp_byte != act_byte:
+            return (
+                f"{plan.game_name}: first byte mismatch at offset {offset} "
+                f"(original=0x{exp_byte:02x}, migrated=0x{act_byte:02x}), "
+                f"{len(expected)} bytes total -- aborting, original left untouched."
+            )
+    return (
+        f"{plan.game_name}: byte mismatch (could not localize -- lengths and "
+        "content matched?) -- aborting, original left untouched."
+    )
+
+
+def report_plan(plan: MigrationPlan) -> str:
+    if plan.already_migrated:
+        return (
+            f"{plan.game_name}: already migrated ({plan.entry_path} is already "
+            "in the game-as-directory layout) -- nothing to do."
+        )
+
+    lines = [
+        f"{plan.game_name}: migrate {plan.entry_path} -> {plan.new_entry_path}",
+    ]
+    by_section = {"animations": [], "lightcues": []}
+    for copy in plan.asset_copies:
+        by_section[copy.section].append(copy)
+
+    shared_count = 0
+    for section, label in (("animations", "animations"), ("lightcues", "lightcues")):
+        copies = by_section[section]
+        if not copies:
+            continue
+        lines.append(f"  {label} ({len(copies)} file(s)):")
+        for copy in copies:
+            names = ", ".join(copy.binding_names)
+            asset_dir = _SECTION_ASSET_DIR[section]
+            new_rel = f"assets/{asset_dir}/{copy.new_literal}"
+            shared_note = ""
+            if copy.shared_with:
+                shared_count += 1
+                shared_note = f" [shared with still-flat: {', '.join(copy.shared_with)}]"
+            lines.append(
+                f"    {copy.old_literal!r} -> {new_rel!r} (used by: {names}){shared_note}"
+            )
+
+    total = len(plan.asset_copies)
+    lines.append(
+        f"  {total} asset file(s) will be copied into {plan.new_game_dir}/assets/ "
+        f"({shared_count} also referenced by at least one still-flat game -- "
+        "duplicated by design, see gamequeer#432)."
+    )
+    return "\n".join(lines)
+
+
+def report_result(result: MigrationResult) -> str:
+    plan = result.plan
+    if plan.already_migrated:
+        return report_plan(plan)
+    return (
+        f"{plan.game_name}: migrated to {plan.new_entry_path} "
+        f"({len(plan.asset_copies)} asset file(s) copied); "
+        f"verified byte-identical {len(result.post_bytes)}-byte .gqgame output "
+        "before and after migration; removed original "
+        f"{plan.entry_path}."
+    )

--- a/gqc/tests/test_migrate.py
+++ b/gqc/tests/test_migrate.py
@@ -480,6 +480,34 @@ def test_migrate_move_failure_rolls_back_and_raises_migrate_error(tmp_path, monk
     assert plan.entry_path.read_bytes() == entry_before
 
 
+def test_migrate_destination_created_after_build_plan_is_not_clobbered(tmp_path):
+    # build_plan() rejects an existing new_game_dir up front, but the two
+    # compiles execute() runs in between can take a while -- if something
+    # else creates new_game_dir before the final move, shutil.move(src,
+    # existing_dir) moves src *inside* dst rather than replacing it (so the
+    # migrated game would land nested at new_game_dir/game_name/, not
+    # new_game_dir/, and be unreachable at its expected canonical
+    # location), and the OSError-handler's rollback would rmtree() whatever
+    # was already in that directory -- not just what this migration wrote.
+    # execute() must re-check immediately before the move and refuse
+    # cleanly, leaving both the original and the pre-existing directory's
+    # own content untouched.
+    plan = _build_single_game_plan(tmp_path)
+    entry_before = plan.entry_path.read_bytes()
+
+    plan.new_game_dir.mkdir()
+    preexisting = plan.new_game_dir / "unrelated_preexisting_file.txt"
+    preexisting.write_text("do not delete me")
+
+    with pytest.raises(migrate.MigrateError, match="was created after"):
+        migrate.execute(plan)
+
+    assert preexisting.read_text() == "do not delete me"
+    assert sorted(p.name for p in plan.new_game_dir.iterdir()) == [preexisting.name]
+    assert plan.entry_path.exists()
+    assert plan.entry_path.read_bytes() == entry_before
+
+
 def test_migrate_unlink_failure_rolls_back_move_and_raises_migrate_error(tmp_path, monkeypatch):
     # The *existing* rollback for execute()'s final plan.entry_path.unlink()
     # -- the migrated directory is already verified and moved into place,

--- a/gqc/tests/test_migrate.py
+++ b/gqc/tests/test_migrate.py
@@ -15,6 +15,8 @@ import sys
 
 import pytest
 
+from gqc import migrate
+
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 CIRCLE_BMP = REPO_ROOT / "gqc" / "examples" / "skel" / "assets" / "animations" / "circle.bmp"
 TEST_GQCUE = REPO_ROOT / "examples" / "assets" / "lighting" / "test.gqcue"
@@ -373,6 +375,135 @@ def test_migrate_rejects_explicit_path_outside_workspace(tmp_path):
     assert "--workspace" in stderr
     assert outside.exists()
     assert outside.read_bytes()  # untouched, still has content
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="os.symlink needs elevated privileges on Windows"
+)
+def test_migrate_rejects_bare_name_resolving_through_symlink_outside_workspace(tmp_path):
+    # A symlink planted at the canonical already-migrated location
+    # (<name>/<name>.gq) pointing outside --workspace must be rejected just
+    # like an explicit out-of-workspace path is: _resolve_entry_path's
+    # bare-name branches (directory_style.is_file() / flat.is_file())
+    # returned a `.resolve()`d path -- which follows the symlink -- with no
+    # boundary check at all, and `execute()` unconditionally unlink()s
+    # whatever this function returns on success.
+    ws = _write_flat_workspace(tmp_path, {})
+    outside = tmp_path / "outside.gq"
+    outside.write_text(GAME_HEADER.format(title="T") + STAGE)
+
+    (ws / "mygame").mkdir()
+    (ws / "mygame" / "mygame.gq").symlink_to(outside)
+
+    exit_code, stdout, stderr = _run(tmp_path, ["migrate", "mygame", "--workspace", str(ws)])
+    assert exit_code != 0
+    assert "Traceback" not in stderr
+    assert "outside workspace" in stderr
+    assert outside.exists()
+    assert outside.read_text()  # untouched, still has content
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="os.symlink needs elevated privileges on Windows"
+)
+def test_migrate_rejects_explicit_path_at_symlinked_canonical_location(tmp_path):
+    # Even the explicit-path branch's existing membership check (`resolved
+    # in (directory_style, flat)`) is trivially satisfied when GAME names
+    # the canonical <name>/<name>.gq location *and* that location is itself
+    # a symlink escaping the workspace -- both sides resolve through the
+    # identical symlink to the identical external target. Same escape as
+    # the bare-name case above, reached via an explicit path instead.
+    ws = _write_flat_workspace(tmp_path, {})
+    outside = tmp_path / "outside.gq"
+    outside.write_text(GAME_HEADER.format(title="T") + STAGE)
+
+    (ws / "mygame").mkdir()
+    symlinked_entry = ws / "mygame" / "mygame.gq"
+    symlinked_entry.symlink_to(outside)
+
+    exit_code, stdout, stderr = _run(
+        tmp_path, ["migrate", str(symlinked_entry), "--workspace", str(ws)]
+    )
+    assert exit_code != 0
+    assert "Traceback" not in stderr
+    assert "outside workspace" in stderr
+    assert outside.exists()
+    assert outside.read_text()  # untouched, still has content
+
+
+# --- execute(): filesystem-failure rollback (in-process, monkeypatched) ----
+#
+# These two drive gqc.migrate's functions directly (build_plan/execute)
+# rather than the CLI subprocess: the failure modes below (a mid-copy
+# shutil.move failure, an unlink() failure) need to be injected
+# deterministically, which isn't reachable by shaping fixture source/inputs
+# alone.
+
+
+def _build_single_game_plan(tmp_path):
+    source = (
+        GAME_HEADER.format(title="T")
+        + 'animations { circ <- "mygame/circle.bmp"; }\n'
+        + STAGE
+    )
+    ws = _write_flat_workspace(tmp_path, {"mygame": source})
+    _seed_asset(ws, "animations", "mygame/circle.bmp", CIRCLE_BMP)
+    return migrate.build_plan("mygame", ws.resolve())
+
+
+def test_migrate_move_failure_rolls_back_and_raises_migrate_error(tmp_path, monkeypatch):
+    # execute()'s final shutil.move(staged_game_dir, plan.new_game_dir) was
+    # unguarded: cross-filesystem (this temp staging dir on one mount, a
+    # real workspace on another) shutil.move degrades to copytree+rmtree,
+    # so a mid-copy failure can leave new_game_dir partially populated in
+    # the real workspace, with a raw OSError escaping gqc.py's `migrate`
+    # command (which only catches MigrateError/GqcParseError) as a
+    # traceback. The patched shutil.move below writes a partial destination
+    # before failing, mimicking what a real copytree failure would leave
+    # behind.
+    plan = _build_single_game_plan(tmp_path)
+    entry_before = plan.entry_path.read_bytes()
+
+    def failing_move(src, dst):
+        dst_path = pathlib.Path(dst)
+        dst_path.mkdir(parents=True)
+        (dst_path / "partial.gq").write_text("incomplete")
+        raise OSError("simulated cross-filesystem move failure mid-copy")
+
+    monkeypatch.setattr(migrate.shutil, "move", failing_move)
+
+    with pytest.raises(migrate.MigrateError, match="moving it into place"):
+        migrate.execute(plan)
+
+    assert not plan.new_game_dir.exists()
+    assert plan.entry_path.exists()
+    assert plan.entry_path.read_bytes() == entry_before
+
+
+def test_migrate_unlink_failure_rolls_back_move_and_raises_migrate_error(tmp_path, monkeypatch):
+    # The *existing* rollback for execute()'s final plan.entry_path.unlink()
+    # -- the migrated directory is already verified and moved into place,
+    # but removing the original flat entry file then fails -- had no test
+    # coverage at all. Pin it down the same way as the move-failure case
+    # above.
+    plan = _build_single_game_plan(tmp_path)
+    entry_before = plan.entry_path.read_bytes()
+
+    real_unlink = pathlib.Path.unlink
+
+    def failing_unlink(self, *args, **kwargs):
+        if self == plan.entry_path:
+            raise OSError("simulated unlink failure")
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "unlink", failing_unlink)
+
+    with pytest.raises(migrate.MigrateError, match="removing the original"):
+        migrate.execute(plan)
+
+    assert not plan.new_game_dir.exists()
+    assert plan.entry_path.exists()
+    assert plan.entry_path.read_bytes() == entry_before
 
 
 # --- malformed source: clean error, not a raw traceback --------------------

--- a/gqc/tests/test_migrate.py
+++ b/gqc/tests/test_migrate.py
@@ -35,10 +35,9 @@ def _run(cwd, args, timeout=COMPILE_TIMEOUT_S):
 
 def _write_flat_workspace(tmp_path, games: dict) -> pathlib.Path:
     """Build a flat workspace at tmp_path / "ws": games/<name>.gq for each
-    (name, source) pair in `games`, plus a shared assets/animations and
-    assets/lighting tree seeded with CIRCLE_BMP and TEST_GQCUE under every
-    subdirectory any game's source string references (callers pass
-    already-flat-style literals like "somedir/foo.bmp")."""
+    (name, source) pair in `games`, plus an empty shared assets/animations
+    and assets/lighting tree. Callers seed whatever specific asset files
+    their source literals reference with `_seed_asset` below."""
     ws = tmp_path / "ws"
     (ws / "games").mkdir(parents=True)
     (ws / "assets" / "animations").mkdir(parents=True)
@@ -322,3 +321,39 @@ def test_migrate_accepts_explicit_entry_path(tmp_path):
     )
     assert exit_code == 0, stderr
     assert (ws / "mygame" / "mygame.gq").exists()
+
+
+def test_migrate_rejects_explicit_path_outside_workspace(tmp_path):
+    # An existing .gq file that isn't actually GAME's canonical entry
+    # location under --workspace must be rejected outright, not read (and,
+    # on success, deleted -- see execute()'s final plan.entry_path.unlink())
+    # from wherever it happens to sit on disk.
+    outside = tmp_path / "elsewhere.gq"
+    outside.write_text(
+        GAME_HEADER.format(title="T") + STAGE
+    )
+    ws = _write_flat_workspace(tmp_path, {})
+
+    exit_code, stdout, stderr = _run(
+        tmp_path, ["migrate", str(outside), "--workspace", str(ws)]
+    )
+    assert exit_code != 0
+    assert "Traceback" not in stderr
+    assert "--workspace" in stderr
+    assert outside.exists()
+    assert outside.read_bytes()  # untouched, still has content
+
+
+# --- malformed source: clean error, not a raw traceback --------------------
+
+
+def test_migrate_unparseable_source_reports_clean_error(tmp_path):
+    ws = _write_flat_workspace(tmp_path, {})
+    # An unterminated string literal is a GqcParseError straight out of
+    # gqc.cst.parse_cst (called from build_plan), not a MigrateError --
+    # exercises gqc.py's migrate command catching both cleanly.
+    (ws / "games" / "broken.gq").write_text('animations { c <- "unterminated;\n')
+
+    exit_code, stdout, stderr = _run(tmp_path, ["migrate", "broken", "--workspace", str(ws)])
+    assert exit_code != 0
+    assert "Traceback" not in stderr

--- a/gqc/tests/test_migrate.py
+++ b/gqc/tests/test_migrate.py
@@ -103,6 +103,37 @@ def test_migrate_moves_animations_lightcues_and_preserves_comments(tmp_path):
     assert "{ w = 8; h = 8; }" in new_source
 
 
+def test_migrate_binding_named_like_a_section_keyword_is_not_misclassified(tmp_path):
+    # grammar.py's `identifier` (an animation/lightcue's own name) is a
+    # plain Word, not lexically reserved against "stage"/"game"/etc. -- a
+    # binding literally named "stage" is valid .gq source and must still
+    # be recognized as a binding, not misread as a stage_definition_section
+    # marker that would make everything after it disappear from the
+    # animations{} section's scan.
+    source = (
+        GAME_HEADER.format(title="T")
+        + "animations {\n"
+        + '    stage <- "mygame/circle.bmp";\n'
+        + '    after  <- "mygame/circle.bmp";\n'
+        + "}\n"
+        + STAGE
+    )
+    ws = _write_flat_workspace(tmp_path, {"mygame": source})
+    _seed_asset(ws, "animations", "mygame/circle.bmp", CIRCLE_BMP)
+
+    exit_code, stdout, stderr = _run(
+        tmp_path, ["migrate", "mygame", "--workspace", str(ws), "--dry-run"]
+    )
+    assert exit_code == 0, stderr
+    assert "used by: after, stage" in stdout
+
+    exit_code, stdout, stderr = _run(tmp_path, ["migrate", "mygame", "--workspace", str(ws)])
+    assert exit_code == 0, stderr
+    new_source = (ws / "mygame" / "mygame.gq").read_text()
+    assert 'stage <- "circle.bmp"' in new_source
+    assert 'after  <- "circle.bmp"' in new_source
+
+
 def test_migrate_dry_run_makes_no_filesystem_changes(tmp_path):
     source = (
         GAME_HEADER.format(title="T")

--- a/gqc/tests/test_migrate.py
+++ b/gqc/tests/test_migrate.py
@@ -1,0 +1,324 @@
+"""`gqc migrate` suite (gamequeer#432): flat-workspace -> game-as-directory
+re-layout.
+
+Drives the real `gqc migrate` CLI as a subprocess (`_run`, same convention
+as test_game_layout.py's helper of the same name) against hand-built flat
+workspace fixtures (`games/<name>.gq` + a shared `assets/animations`/
+`assets/lighting` tree), so every test exercises the exact same code path
+an author running the tool for real would.
+"""
+
+import pathlib
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+CIRCLE_BMP = REPO_ROOT / "gqc" / "examples" / "skel" / "assets" / "animations" / "circle.bmp"
+TEST_GQCUE = REPO_ROOT / "examples" / "assets" / "lighting" / "test.gqcue"
+
+COMPILE_TIMEOUT_S = 120
+
+
+def _run(cwd, args, timeout=COMPILE_TIMEOUT_S):
+    proc = subprocess.run(
+        [sys.executable, "-m", "gqc", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def _write_flat_workspace(tmp_path, games: dict) -> pathlib.Path:
+    """Build a flat workspace at tmp_path / "ws": games/<name>.gq for each
+    (name, source) pair in `games`, plus a shared assets/animations and
+    assets/lighting tree seeded with CIRCLE_BMP and TEST_GQCUE under every
+    subdirectory any game's source string references (callers pass
+    already-flat-style literals like "somedir/foo.bmp")."""
+    ws = tmp_path / "ws"
+    (ws / "games").mkdir(parents=True)
+    (ws / "assets" / "animations").mkdir(parents=True)
+    (ws / "assets" / "lighting").mkdir(parents=True)
+    for name, source in games.items():
+        (ws / "games" / f"{name}.gq").write_text(source)
+    return ws
+
+
+def _seed_asset(ws: pathlib.Path, section: str, rel: str, src: pathlib.Path):
+    dest = ws / "assets" / section / rel
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, dest)
+
+
+GAME_HEADER = 'game {{ id = 1; title := "{title}"; author := "A"; starting_stage = start; }}\n'
+STAGE = "stage start { event enter { } }\n"
+
+
+# --- core migration: animations + lightcues + comment survival -------------
+
+
+def test_migrate_moves_animations_lightcues_and_preserves_comments(tmp_path):
+    source = (
+        GAME_HEADER.format(title="T")
+        + "// a leading comment on the animations block\n"
+        + "animations {\n"
+        + "    // circle sprite\n"
+        + '    circ <- "mygame/circle.bmp" { w = 8; h = 8; }  // trailing comment\n'
+        + "}\n"
+        + "lightcues {\n"
+        + '    c1 <- "mygame/test.gqcue"; // a cue\n'
+        + "}\n"
+        + STAGE
+    )
+    ws = _write_flat_workspace(tmp_path, {"mygame": source})
+    _seed_asset(ws, "animations", "mygame/circle.bmp", CIRCLE_BMP)
+    _seed_asset(ws, "lighting", "mygame/test.gqcue", TEST_GQCUE)
+
+    exit_code, stdout, stderr = _run(tmp_path, ["migrate", "mygame", "--workspace", str(ws)])
+    assert exit_code == 0, stderr
+    assert "verified byte-identical" in stdout
+
+    new_entry = ws / "mygame" / "mygame.gq"
+    assert new_entry.exists()
+    assert not (ws / "games" / "mygame.gq").exists()
+    assert (ws / "mygame" / "assets" / "animations" / "circle.bmp").exists()
+    assert (ws / "mygame" / "assets" / "lighting" / "test.gqcue").exists()
+
+    new_source = new_entry.read_text()
+    # Comments (leading, trailing, and standalone) all survive verbatim.
+    assert "// a leading comment on the animations block" in new_source
+    assert "// circle sprite" in new_source
+    assert "// trailing comment" in new_source
+    assert "// a cue" in new_source
+    # The path literals themselves are flattened (no more per-game subdir).
+    assert '"circle.bmp"' in new_source
+    assert '"test.gqcue"' in new_source
+    assert "mygame/circle.bmp" not in new_source
+    assert "mygame/test.gqcue" not in new_source
+    # Everything else -- alignment, braces, the rest of the source -- is
+    # untouched: only the string-literal tokens themselves changed.
+    assert "{ w = 8; h = 8; }" in new_source
+
+
+def test_migrate_dry_run_makes_no_filesystem_changes(tmp_path):
+    source = (
+        GAME_HEADER.format(title="T")
+        + 'animations { circ <- "mygame/circle.bmp"; }\n'
+        + STAGE
+    )
+    ws = _write_flat_workspace(tmp_path, {"mygame": source})
+    _seed_asset(ws, "animations", "mygame/circle.bmp", CIRCLE_BMP)
+
+    flat_entry = ws / "games" / "mygame.gq"
+    before = flat_entry.read_bytes()
+
+    exit_code, stdout, stderr = _run(
+        tmp_path, ["migrate", "mygame", "--workspace", str(ws), "--dry-run"]
+    )
+    assert exit_code == 0, stderr
+    # The full plan (both the destination and every asset it would copy)
+    # is printed, without touching anything.
+    assert "mygame.gq" in stdout
+    assert "circle.bmp" in stdout
+    assert flat_entry.read_bytes() == before
+    assert not (ws / "mygame").exists()
+
+
+# --- idempotence -------------------------------------------------------------
+
+
+def test_migrate_twice_is_a_clean_no_op(tmp_path):
+    source = (
+        GAME_HEADER.format(title="T")
+        + 'animations { circ <- "mygame/circle.bmp"; }\n'
+        + STAGE
+    )
+    ws = _write_flat_workspace(tmp_path, {"mygame": source})
+    _seed_asset(ws, "animations", "mygame/circle.bmp", CIRCLE_BMP)
+
+    exit_code, _, stderr = _run(tmp_path, ["migrate", "mygame", "--workspace", str(ws)])
+    assert exit_code == 0, stderr
+
+    new_entry = ws / "mygame" / "mygame.gq"
+    before = new_entry.read_bytes()
+    before_assets = sorted((ws / "mygame" / "assets").rglob("*"))
+
+    exit_code, stdout, stderr = _run(tmp_path, ["migrate", "mygame", "--workspace", str(ws)])
+    assert exit_code == 0, stderr
+    assert "already migrated" in stdout
+    assert new_entry.read_bytes() == before
+    assert sorted((ws / "mygame" / "assets").rglob("*")) == before_assets
+
+
+def test_migrate_dry_run_on_already_migrated_game_is_a_no_op(tmp_path):
+    source = (
+        GAME_HEADER.format(title="T")
+        + 'animations { circ <- "mygame/circle.bmp"; }\n'
+        + STAGE
+    )
+    ws = _write_flat_workspace(tmp_path, {"mygame": source})
+    _seed_asset(ws, "animations", "mygame/circle.bmp", CIRCLE_BMP)
+    _run(tmp_path, ["migrate", "mygame", "--workspace", str(ws)])
+
+    exit_code, stdout, stderr = _run(
+        tmp_path, ["migrate", "mygame", "--workspace", str(ws), "--dry-run"]
+    )
+    assert exit_code == 0, stderr
+    assert "already migrated" in stdout
+
+
+# --- failure leaves the original untouched ----------------------------------
+
+
+def test_migrate_missing_asset_leaves_original_untouched(tmp_path):
+    source = (
+        GAME_HEADER.format(title="T")
+        + 'animations { circ <- "mygame/nope.bmp"; }\n'
+        + STAGE
+    )
+    ws = _write_flat_workspace(tmp_path, {"mygame": source})
+    # Deliberately don't seed mygame/nope.bmp.
+
+    flat_entry = ws / "games" / "mygame.gq"
+    before = flat_entry.read_bytes()
+
+    exit_code, stdout, stderr = _run(tmp_path, ["migrate", "mygame", "--workspace", str(ws)])
+    assert exit_code != 0
+    assert "Traceback" not in stderr
+    assert "nope.bmp" in stderr
+    assert flat_entry.exists()
+    assert flat_entry.read_bytes() == before
+    assert not (ws / "mygame").exists()
+
+
+def test_migrate_absolute_source_rejected(tmp_path):
+    source = GAME_HEADER.format(title="T") + 'animations { c <- "/etc/passwd"; }\n' + STAGE
+    ws = _write_flat_workspace(tmp_path, {"mygame": source})
+
+    exit_code, stdout, stderr = _run(tmp_path, ["migrate", "mygame", "--workspace", str(ws)])
+    assert exit_code != 0
+    assert "absolute path" in stderr
+    assert (ws / "games" / "mygame.gq").exists()
+    assert not (ws / "mygame").exists()
+
+
+def test_migrate_parent_traversal_source_rejected(tmp_path):
+    source = GAME_HEADER.format(title="T") + 'animations { c <- "../escape.bmp"; }\n' + STAGE
+    ws = _write_flat_workspace(tmp_path, {"mygame": source})
+
+    exit_code, stdout, stderr = _run(tmp_path, ["migrate", "mygame", "--workspace", str(ws)])
+    assert exit_code != 0
+    assert "escapes the shared asset tree" in stderr
+    assert (ws / "games" / "mygame.gq").exists()
+    assert not (ws / "mygame").exists()
+
+
+def test_migrate_basename_collision_rejected(tmp_path):
+    source = (
+        GAME_HEADER.format(title="T")
+        + 'animations { a <- "one/x.bmp"; b <- "two/x.bmp"; }\n'
+        + STAGE
+    )
+    ws = _write_flat_workspace(tmp_path, {"mygame": source})
+    _seed_asset(ws, "animations", "one/x.bmp", CIRCLE_BMP)
+    _seed_asset(ws, "animations", "two/x.bmp", CIRCLE_BMP)
+
+    exit_code, stdout, stderr = _run(tmp_path, ["migrate", "mygame", "--workspace", str(ws)])
+    assert exit_code != 0
+    assert "collide" in stderr
+    assert (ws / "games" / "mygame.gq").exists()
+    assert not (ws / "mygame").exists()
+
+
+# --- shared assets: copy-into-game-dir, with duplication stats -------------
+
+
+def test_migrate_shared_asset_is_copied_and_reported(tmp_path):
+    # Two games reference the exact same shared "shared/circle.bmp" -- the
+    # real-corpus pattern (queersafe.gq / queersafe-lite.gq both reference
+    # a whole shared "queersafe/" subtree; see migrate.py's module
+    # docstring).
+    source_a = (
+        GAME_HEADER.format(title="A")
+        + 'animations { circ <- "shared/circle.bmp"; }\n'
+        + STAGE
+    )
+    source_b = (
+        GAME_HEADER.format(title="B")
+        + 'animations { circ <- "shared/circle.bmp"; }\n'
+        + STAGE
+    )
+    ws = _write_flat_workspace(tmp_path, {"gamea": source_a, "gameb": source_b})
+    _seed_asset(ws, "animations", "shared/circle.bmp", CIRCLE_BMP)
+
+    exit_code, stdout, stderr = _run(
+        tmp_path, ["migrate", "gamea", "--workspace", str(ws), "--dry-run"]
+    )
+    assert exit_code == 0, stderr
+    assert "shared with still-flat: gameb" in stdout
+    assert "1 also referenced by at least one still-flat game" in stdout
+
+    # Actually migrate gamea; gameb (still flat) and the shared source file
+    # must both be completely untouched, and gamea gets its own copy.
+    exit_code, stdout, stderr = _run(tmp_path, ["migrate", "gamea", "--workspace", str(ws)])
+    assert exit_code == 0, stderr
+    assert (ws / "games" / "gameb.gq").exists()
+    assert (ws / "assets" / "animations" / "shared" / "circle.bmp").exists()
+    assert (ws / "gamea" / "assets" / "animations" / "circle.bmp").exists()
+    # The copy is a real, independent file (not e.g. a symlink whose
+    # removal upstream would break gamea).
+    assert not (ws / "gamea" / "assets" / "animations" / "circle.bmp").is_symlink()
+
+
+def test_migrate_same_asset_referenced_twice_by_one_game_is_not_a_collision(tmp_path):
+    # queersafe-lite.gq's aot/aot1/aot2 all reference the literal same
+    # "queersafe/unlocked.bmp" -- a single underlying file, multiple
+    # animation names. Must not be treated as a flatten collision.
+    source = (
+        GAME_HEADER.format(title="T")
+        + "animations {\n"
+        + '    a <- "mygame/circle.bmp";\n'
+        + '    b <- "mygame/circle.bmp";\n'
+        + "}\n"
+        + STAGE
+    )
+    ws = _write_flat_workspace(tmp_path, {"mygame": source})
+    _seed_asset(ws, "animations", "mygame/circle.bmp", CIRCLE_BMP)
+
+    exit_code, stdout, stderr = _run(tmp_path, ["migrate", "mygame", "--workspace", str(ws)])
+    assert exit_code == 0, stderr
+    assert (ws / "mygame" / "assets" / "animations" / "circle.bmp").exists()
+    # Only one physical file is copied even though two animations use it.
+    assert len(list((ws / "mygame" / "assets" / "animations").iterdir())) == 1
+
+
+# --- GAME resolution ----------------------------------------------------------
+
+
+def test_migrate_unknown_game_reports_clean_error(tmp_path):
+    ws = _write_flat_workspace(tmp_path, {})
+    exit_code, stdout, stderr = _run(tmp_path, ["migrate", "nosuchgame", "--workspace", str(ws)])
+    assert exit_code != 0
+    assert "Traceback" not in stderr
+    assert "nosuchgame" in stderr
+
+
+def test_migrate_accepts_explicit_entry_path(tmp_path):
+    source = (
+        GAME_HEADER.format(title="T")
+        + 'animations { circ <- "mygame/circle.bmp"; }\n'
+        + STAGE
+    )
+    ws = _write_flat_workspace(tmp_path, {"mygame": source})
+    _seed_asset(ws, "animations", "mygame/circle.bmp", CIRCLE_BMP)
+
+    exit_code, stdout, stderr = _run(
+        tmp_path,
+        ["migrate", str(ws / "games" / "mygame.gq"), "--workspace", str(ws)],
+    )
+    assert exit_code == 0, stderr
+    assert (ws / "mygame" / "mygame.gq").exists()

--- a/gqc/tests/test_migrate.py
+++ b/gqc/tests/test_migrate.py
@@ -249,6 +249,49 @@ def test_migrate_parent_traversal_source_rejected(tmp_path):
     assert not (ws / "mygame").exists()
 
 
+def test_migrate_windows_drive_letter_source_rejected(tmp_path):
+    # PurePosixPath("C:/Windows/System32/evil.bmp").is_absolute() is False
+    # (only a leading "/" counts on POSIX), but a real pathlib.Path *does*
+    # treat it as absolute on Windows -- and Path.__truediv__ discards the
+    # workspace prefix entirely when the right operand is absolute -- so
+    # this must be rejected explicitly, not just left to the (POSIX-only)
+    # is_absolute() check above.
+    source = (
+        GAME_HEADER.format(title="T")
+        + 'animations { c <- "C:/Windows/System32/evil.bmp"; }\n'
+        + STAGE
+    )
+    ws = _write_flat_workspace(tmp_path, {"mygame": source})
+
+    exit_code, stdout, stderr = _run(tmp_path, ["migrate", "mygame", "--workspace", str(ws)])
+    assert exit_code != 0
+    assert "drive-letter" in stderr
+    assert (ws / "games" / "mygame.gq").exists()
+    assert not (ws / "mygame").exists()
+
+
+def test_migrate_backslash_source_rejected(tmp_path):
+    # PurePosixPath never treats "\" as a separator, so a literal like
+    # "..\\..\\etc\\passwd" (a genuine parent-directory escape on Windows,
+    # where pathlib.Path *does* split on "\") would parse here as a single,
+    # inert, non-".." path component and sail through the '..'-component
+    # check undetected. The .gq source below double-escapes each backslash
+    # (the file's own `\`-escaping convention) so the decoded literal
+    # contains one real backslash: "..\escape.bmp".
+    source = (
+        GAME_HEADER.format(title="T")
+        + 'animations { c <- "..\\\\escape.bmp"; }\n'
+        + STAGE
+    )
+    ws = _write_flat_workspace(tmp_path, {"mygame": source})
+
+    exit_code, stdout, stderr = _run(tmp_path, ["migrate", "mygame", "--workspace", str(ws)])
+    assert exit_code != 0
+    assert "backslash" in stderr
+    assert (ws / "games" / "mygame.gq").exists()
+    assert not (ws / "mygame").exists()
+
+
 def test_migrate_basename_collision_rejected(tmp_path):
     source = (
         GAME_HEADER.format(title="T")


### PR DESCRIPTION
Implements gamequeer#432: a `gqc migrate GAME [--dry-run] [--workspace DIR]` subcommand that mechanically converts a flat-layout game (`games/<name>.gq` + a shared `assets/animations`/`assets/lighting` tree) to #420's game-as-directory layout (`<name>/<name>.gq`, self-contained).

**Dependency note (resolved):** this branch started from the merge of `default` + `land-429-cst-fmt`, since at branch-creation time [#431](https://github.com/duplico/gamequeer/pull/431) (landing #429's CST onto `default`) hadn't merged yet. #431 merged shortly after, so this branch was re-merged onto the now-current `default` (resolving a merge-base ambiguity that briefly made GitHub's diff view show #431's own unrelated content as part of this PR — see the review-thread reply on that finding). The diff here is exactly the 3 files this PR changes.

## What semantics study found (not assumed)

- **Flat games no longer compile at all against the current compiler.** #420 changed asset resolution from CWD-relative to entry-file-parent-relative. Since `games/` and `assets/` are siblings in the real `gq-games` workspace, `gqc compile games/bricks.gq` today fails with `Animation source file .../games/assets/animations/bricks/bg_title.png does not exist` — reproduced directly against the real corpus before writing any code. This is the actual, load-bearing motivation for this tool, not just a style convenience.
- **No sanctioned cross-directory asset reference.** `test_game_layout.py`'s `test_animation_source_at_old_cwd_relative_location_is_not_found` is a negative control proving #420 deliberately added no fallback/search path outside a game's own directory. Nothing in the shipped code or tests suggests `..`-escapes are intentional — they're simply unvalidated, not supported.
- **Real cross-game asset sharing exists in the corpus today**: `queersafe.gq`/`queersafe-lite.gq` share their entire `queersafe/` asset subtree (39/40 files each); `2000svg.gq`/`boot.gq`/`retrovg.gq`/`meme.gq`/`pop.gq` all share `tvtuner/stock/rainbow.gqcue`.
- **#420's own issue text** ("not against the old top-level assets/animations + assets/lighting roots keyed by a hand-matched subdir") explicitly frames dropping the old per-game subdirectory naming as the point of the change, which is what justifies actually rewriting path literals (flattening to bare filenames) rather than just copying files with their old relative structure preserved unchanged.
- **Destination is `<workspace>/<name>/<name>.gq`**, a sibling of `games/` (matching `gqc new`'s own default `--out-dir`=cwd), not nested inside `games/` — `games/`'s existing recursive-glob Makefile discovery would already find a nested layout with zero changes, which would contradict #432's own note that Makefile discovery of the new layout needs separate work in `gq-games`.

## Design decisions

- **Shared assets: copy into the migrating game's own directory (default, and only mode implemented).** No opt-in cross-directory-reference flag — #420's own tests prove that's not a sanctioned resolution path, so offering it would mean inventing new compiler behavior in a tool this issue scopes as "compiler-tooling only, no VM/bytecode changes." The migration plan reports how many of a game's assets are also referenced by other still-flat games (`shared with still-flat: ...` per asset, plus a summary count) so an author can judge whether hand-deduplication is worth it later.
- **Path-literal identification is grammar-structural, not string-shape-based**: `<-` appears in exactly two grammar productions (`file_assignment`/`animation_assignment`, and `event_input_button`'s `input(<-)` form); the latter is always sandwiched between `(` and `)`, never followed by a string token. So the flat `(word, "<-", string)` triplet is unambiguous under the current grammar — no `.gif`/`.png`/`.gqcue` extension sniffing. See `migrate.py`'s `_find_asset_bindings` docstring.
- **Path flattening + real collision detection**: two different old paths that would flatten to the same basename is a hard error (`Cannot flatten ... would collide as ...`), never silently resolved. The same literal referenced by multiple animation/lightcue names within one game (real corpus pattern: `queersafe-lite.gq`'s `aot`/`aot1`/`aot2` all point at the same `unlocked.bmp`) is correctly treated as one file, not a collision.
- **Never deletes shared originals.** Only the migrated game's own flat entry file is removed, and only after byte-identical verification passes. The shared `assets/` tree is left completely alone — other, not-yet-migrated games (per #432: ~9 in-flight branches migrating independently, on each author's own timing) may still need it.

## Acceptance property

Before touching the workspace, migrate compiles the *original* flat game via a throwaway symlink harness (a temp copy of the entry file next to a symlink to the real shared `assets/`, reconstructing exactly what the old CWD-relative resolution would have read, since the flat form doesn't compile in place anymore — see above) and the staged migrated form in a separate temp directory, and requires the two `.gqgame` outputs to be **byte-identical** before committing anything. Any mismatch (or either compile failing) aborts loudly and leaves the workspace exactly as it was.

## Verification

- `pytest gqc/tests` → **506 passed, 2 skipped (ffmpeg-gated, unchanged baseline)**, including 12 new tests in `test_migrate.py` (animations+lightcues+comment survival, byte-identical verification, idempotence, dry-run, failure-leaves-original-untouched ×4 variants, shared-asset copy+stats, same-asset-twice-not-a-collision, GAME resolution by name/path).
- Golden suite (`-m golden`) → **15 passed, 2 skipped** — unchanged, untouched by this PR.
- **Real-corpus integration** (cloned into a scratch workspace, not committed as fixtures): `bricks`, `donsol` (114 assets, no ffmpeg), `glowdeck` (16 assets, exercises the ffmpeg `.gif` pipeline) all migrated with verified byte-identical `.gqgame` output, then re-run to confirm idempotent no-op. Also migrated the `queersafe`/`queersafe-lite` shared-asset pair (39 and 40 assets respectively) sequentially — each independently byte-verified, the shared source tree and the not-yet-migrated sibling untouched at every step.
- No edits under `gamequeer/` (C VM runtime) — compiler-tooling only, frozen VM contract held.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)