### PR TITLE
fix(gqc): detect flat vs directory game layout for asset resolution

### DIFF
--- a/gqc/src/gqc/gqc.py
+++ b/gqc/src/gqc/gqc.py
@@ -103,6 +103,21 @@ def fmt(input : pathlib.Path, write : bool, check : bool):
     else:
         click.echo(formatted, nl=False)
 
+def _is_directory_layout(input : pathlib.Path) -> bool:
+    """Detect gamequeer#420's game-as-directory layout: the entry file's
+    parent directory is named for the game itself (`<name>/<name>.gq`).
+
+    Purely structural/deterministic -- no filesystem probing beyond the
+    entry path itself, no "try both and see what resolves" fallback (see
+    gamequeer#434). A flat entry file whose parent *happens* to share its
+    name (e.g. a top-level `games/games.gq`, or any `<x>/<x>.gq`) is
+    indistinguishable from a real directory-layout game and is treated as
+    one -- there is no reliable way to tell them apart from the entry path
+    alone, and #420's own convention doesn't require the directory to
+    contain anything else."""
+    return input.parent.name == input.stem
+
+
 @gqc_cli.command()
 @click.option('--no-mem-map', '-n', is_flag=True)
 @click.option('--out-dir', '-o', type=click.Path(file_okay=False, dir_okay=True, writable=True, path_type=pathlib.Path), default=None)
@@ -115,7 +130,29 @@ def compile(input : pathlib.Path, no_mem_map : bool, out_dir : pathlib.Path):
     # This is what makes `gqc compile some/other/dir/foo.gq` work correctly
     # from outside that directory, and is a no-op for the common case where
     # the entry file is already at the top of the invocation directory.
-    Game.game_dir = input.parent
+    #
+    # gamequeer#434: that's only true for entry files that actually follow
+    # #420's `<name>/<name>.gq` convention. #420 set Game.game_dir =
+    # input.parent unconditionally, which broke every *flat*-layout game
+    # (`games/<name>.gq` next to a shared top-level `assets/` dir, sibling
+    # of `games/` -- the entire pre-#420 gq-games corpus, and this repo's
+    # own `examples/skel` fixtures) by resolving assets against
+    # `games/assets/...` instead of the real `assets/...` at the workspace
+    # root. Detect which convention this entry file actually uses and
+    # branch resolution accordingly, so a flat game keeps compiling exactly
+    # as it did before #420 (CWD-relative -- not "entry's grandparent
+    # directory", which breaks for a nested entry like
+    # `games/<subdir>/<name>.gq`; see examples/skel/games/working_samples/).
+    if _is_directory_layout(input):
+        Game.game_dir = input.parent
+    else:
+        Game.game_dir = pathlib.Path.cwd()
+        click.echo(
+            f"{input}: legacy flat-layout asset resolution (pre-gamequeer#420, "
+            "CWD-relative) -- run `gqc migrate` to move this game onto the "
+            "self-contained game-as-directory layout and silence this notice.",
+            err=True,
+        )
 
     # output_path is the directory where the output of the project will be placed
     if out_dir is None:

--- a/gqc/tests/test_game_layout.py
+++ b/gqc/tests/test_game_layout.py
@@ -430,12 +430,20 @@ def test_deprecation_notice_emitted_in_legacy_mode(compile_gq):
     assert "gqc migrate" in stderr
 
 
-def test_deprecation_notice_goes_to_stderr_not_stdout(compile_gq):
-    exit_code, stderr, out_dir = compile_gq(GAME_HEADER + STAGE)
+def test_deprecation_notice_goes_to_stderr_not_stdout(tmp_path):
+    # Uses `_run` (not `compile_gq`) specifically because it's the only
+    # fixture here that captures stdout separately from stderr --
+    # `compile_gq` only returns stderr, so it can't actually prove the
+    # notice *isn't* on stdout.
+    src_path = tmp_path / "game.gq"
+    src_path.write_text(GAME_HEADER + STAGE)
+    out_dir = tmp_path / "build"
+
+    exit_code, stderr, stdout = _run(
+        tmp_path, ["compile", "-o", str(out_dir), str(src_path)]
+    )
     assert exit_code == 0, stderr
     assert "legacy" in stderr.lower()
-    # compile_gq only captures stderr directly, but the compiled artifact
-    # existing (rather than the notice corrupting it) is the load-bearing
-    # machine-parsed-output check: the notice must never land in the
-    # .gqgame byte stream or map.txt.
+    assert "legacy" not in stdout.lower()
+    # Machine-parsed output must be untouched by the notice.
     assert (out_dir / "game.gqgame").exists()

--- a/gqc/tests/test_game_layout.py
+++ b/gqc/tests/test_game_layout.py
@@ -26,6 +26,18 @@ unconditionally, and parse_fw_version_operand/parse_random_operand used to
 write straight to Game.game.needs_fw_probe/Game.game.needs_random -- all
 three would crash with AttributeError on `NoneType` if the stage in question
 was parsed before game{} itself.
+
+The suite's final section (gamequeer#434) covers layout *detection*: an
+entry file only gets #420's game_dir-relative resolution if its parent
+directory is actually named for it (`<name>/<name>.gq`); anything else --
+including the entire pre-#420 gq-games corpus, whose games live flat in a
+shared `games/` directory next to a sibling top-level `assets/` -- falls
+back to legacy (pre-#420), CWD-relative resolution, with a one-line
+deprecation notice on stderr pointing at `gqc migrate`. There is no
+try-both-and-see fallback: a directory-layout game never consults the CWD
+(see the existing negative-control tests above, unchanged by #434), and a
+flat entry file whose parent coincidentally matches the convention (e.g.
+`games/games.gq`) is treated as directory layout, not flat.
 """
 
 import pathlib
@@ -286,3 +298,144 @@ def test_new_force_overwrites_existing_game(tmp_path):
     exit_code, stderr, _ = _run(tmp_path, ["new", "mygame", "--force"])
     assert exit_code == 0, stderr
     assert entry_path.read_text() != "MODIFIED"
+
+
+# --- gamequeer#434: layout detection / legacy flat-layout fallback ---------
+
+
+def test_legacy_flat_layout_compiles_and_resolves_assets_at_cwd(tmp_path):
+    # Flat layout (pre-#420, the shape of the whole pre-migration gq-games
+    # corpus): the entry file lives in a `games/` directory whose name
+    # doesn't match the entry's own stem, with a *sibling* top-level
+    # `assets/` (not nested under `games/`). That fails the
+    # `<name>/<name>.gq` directory-layout check, so resolution falls back
+    # to the process CWD -- exactly how gqc resolved assets before #420.
+    games_dir = tmp_path / "games"
+    games_dir.mkdir()
+    (games_dir / "foo.gq").write_text(
+        GAME_HEADER + 'animations { c <- "circle.bmp"; }\n' + STAGE
+    )
+    assets_dir = tmp_path / "assets" / "animations"
+    assets_dir.mkdir(parents=True)
+    shutil.copyfile(CIRCLE_BMP, assets_dir / "circle.bmp")
+
+    out_dir = tmp_path / "build"
+    exit_code, stderr, _ = _run(
+        tmp_path,
+        ["compile", "-o", str(out_dir), str(games_dir / "foo.gq")],
+    )
+    assert exit_code == 0, stderr
+
+
+def test_legacy_flat_layout_does_not_find_game_dir_relative_assets(tmp_path):
+    # Companion negative control: the same flat entry file, but the asset
+    # sits at the *directory-layout*-style location (nested under the
+    # entry's own parent) instead of the real legacy CWD-relative spot --
+    # pins that legacy mode doesn't also try game_dir-relative as a
+    # fallback.
+    games_dir = tmp_path / "games"
+    games_dir.mkdir()
+    (games_dir / "foo.gq").write_text(
+        GAME_HEADER + 'animations { c <- "circle.bmp"; }\n' + STAGE
+    )
+    dir_layout_style_assets = games_dir / "assets" / "animations"
+    dir_layout_style_assets.mkdir(parents=True)
+    shutil.copyfile(CIRCLE_BMP, dir_layout_style_assets / "circle.bmp")
+
+    out_dir = tmp_path / "build"
+    exit_code, stderr, _ = _run(
+        tmp_path,
+        ["compile", "-o", str(out_dir), str(games_dir / "foo.gq")],
+    )
+    assert exit_code != 0
+    assert "circle.bmp" in stderr
+
+
+def test_directory_layout_game_emits_no_deprecation_notice(tmp_path):
+    # Companion to the animation/lightcue game_dir-relative tests above:
+    # pins that a real directory-layout game gets #420's resolution with no
+    # legacy notice, even when invoked (as here) from its own parent
+    # directory, one level up from the game directory itself.
+    game_dir = _write_game_dir(
+        tmp_path, "mygame", 'animations { c <- "circle.bmp"; }\n'
+    )
+    assets_dir = game_dir / "assets" / "animations"
+    assets_dir.mkdir(parents=True)
+    shutil.copyfile(CIRCLE_BMP, assets_dir / "circle.bmp")
+
+    out_dir = tmp_path / "build"
+    exit_code, stderr, _ = _run(
+        tmp_path,
+        ["compile", "-o", str(out_dir), str(game_dir / "mygame.gq")],
+    )
+    assert exit_code == 0, stderr
+    assert "legacy" not in stderr.lower()
+    assert "gqc migrate" not in stderr
+
+
+def test_flat_entry_matching_directory_convention_is_treated_as_directory_layout(tmp_path):
+    # Edge case (gamequeer#434): a flat entry file whose parent directory
+    # happens to share its own name -- e.g. a top-level `games/games.gq` --
+    # is structurally indistinguishable from a real directory-layout game
+    # (`<name>/<name>.gq`), and there's no fallback to try both: directory
+    # layout wins unconditionally, so its assets must live *inside*
+    # `games/`, not at a sibling top-level `assets/`.
+    games_dir = tmp_path / "games"
+    games_dir.mkdir()
+    (games_dir / "games.gq").write_text(
+        GAME_HEADER + 'animations { c <- "circle.bmp"; }\n' + STAGE
+    )
+    dir_layout_assets = games_dir / "assets" / "animations"
+    dir_layout_assets.mkdir(parents=True)
+    shutil.copyfile(CIRCLE_BMP, dir_layout_assets / "circle.bmp")
+
+    out_dir = tmp_path / "build"
+    exit_code, stderr, _ = _run(
+        tmp_path,
+        ["compile", "-o", str(out_dir), str(games_dir / "games.gq")],
+    )
+    assert exit_code == 0, stderr
+    assert "legacy" not in stderr.lower()
+
+
+def test_flat_entry_matching_directory_convention_ignores_sibling_assets(tmp_path):
+    # Same edge case, but the asset sits at the legacy CWD-relative spot
+    # instead -- must NOT be found, since `games/games.gq` resolved as
+    # directory layout (see test above) never falls back to the CWD.
+    games_dir = tmp_path / "games"
+    games_dir.mkdir()
+    (games_dir / "games.gq").write_text(
+        GAME_HEADER + 'animations { c <- "circle.bmp"; }\n' + STAGE
+    )
+    legacy_style_assets = tmp_path / "assets" / "animations"
+    legacy_style_assets.mkdir(parents=True)
+    shutil.copyfile(CIRCLE_BMP, legacy_style_assets / "circle.bmp")
+
+    out_dir = tmp_path / "build"
+    exit_code, stderr, _ = _run(
+        tmp_path,
+        ["compile", "-o", str(out_dir), str(games_dir / "games.gq")],
+    )
+    assert exit_code != 0
+    assert "circle.bmp" in stderr
+
+
+def test_deprecation_notice_emitted_in_legacy_mode(compile_gq):
+    # compile_gq's entry file is always named "game" by default and sits
+    # directly in the hermetic tmp_path CWD, whose own name never matches
+    # -- always legacy under gamequeer#434's detection rule.
+    exit_code, stderr, _ = compile_gq(GAME_HEADER + STAGE)
+    assert exit_code == 0, stderr
+    assert "legacy" in stderr.lower()
+    assert "gqc migrate" in stderr
+
+
+def test_deprecation_notice_goes_to_stderr_not_stdout(compile_gq):
+    exit_code, stderr, out_dir = compile_gq(GAME_HEADER + STAGE)
+    assert exit_code == 0, stderr
+    assert "legacy" in stderr.lower()
+    # compile_gq only captures stderr directly, but the compiled artifact
+    # existing (rather than the notice corrupting it) is the load-bearing
+    # machine-parsed-output check: the notice must never land in the
+    # .gqgame byte stream or map.txt.
+    assert (out_dir / "game.gqgame").exists()


### PR DESCRIPTION
## Summary

Fixes https://github.com/duplico/gamequeer/issues/434.

gamequeer#420's `Game.game_dir = input.parent` (unconditional) broke every
**flat-layout** game -- `games/<name>.gq` sitting next to a shared
top-level `assets/` directory that's a *sibling* of `games/`, not nested
under it. That's the shape of the **entire pre-#420 gq-games corpus**
(bricks, donsol, glowdeck, etc.) and of this repo's own
`gqc/examples/skel` fixtures. Post-#420, `games/bricks.gq`'s
`animations{}`/`lightcues{}` sources resolved against
`games/assets/animations/...` instead of the real
`assets/animations/...` at the workspace root -- every asset reference
missed, and no flat game could compile at all.

Reproduced directly before touching anything: copied `bricks.gq` +
`assets/` from the real gq-games corpus into a flat scratch layout and
compiled with tip gqc --

```
Error at line 128, column 5: Animation source file
games/assets/animations/bricks/bg_title.png does not exist
```

## The fix: layout-detected resolution, no fallback

`gqc.py`'s `compile` command now branches deterministically on the entry
file's own path, structurally, with no "try both and see" fallback:

- **Directory layout** (`<name>/<name>.gq` -- the entry's parent directory
  is named for the entry itself): `Game.game_dir = input.parent`, exactly
  as #420 left it. No behavior change for already-migrated games.
- **Anything else (legacy)**: `Game.game_dir = pathlib.Path.cwd()` --
  restoring the *exact* pre-#420 resolution semantics
  (`pathlib.Path() / 'assets' / 'animations' / source`, which resolves
  relative to the process CWD), verified against git history at
  `3a235ec` (pre-#420). CWD-relative, not "entry's grandparent
  directory": the latter breaks for a nested flat entry like
  `examples/skel/games/working_samples/sample_working.gq`, where the
  workspace root sits *two* levels above the entry file, not one -- and
  the corpus's own `Makefile`/`update-makefile-local` always invokes
  `gqc compile` from the workspace root regardless of how deep a `.gq`
  file is nested under `games/`.
- Legacy mode emits a one-line deprecation notice to **stderr** (never
  stdout, so `.gqgame`/`map.txt`/`cmds.gqasm` output is untouched)
  pointing at `gqc migrate` (#433, not yet merged to `default` as of this
  PR -- see note below).

**Edge case, deliberately not "fixed":** a flat entry file whose parent
directory happens to share its own name (`games/games.gq`) is structurally
indistinguishable from a real directory-layout game -- there's no reliable
way to tell them apart from the entry path alone, and there's no
try-both fallback by design. Directory layout wins. Pinned by
`test_flat_entry_matching_directory_convention_is_treated_as_directory_layout`
and its sibling negative-control test.

## Acceptance evidence

**Full gq-games corpus (12 titles), invoked exactly as its Makefile
invokes gqc** (`GQC_CMD=... make` against a scratch copy of the real
corpus, `cwd` = workspace root, same as `update-makefile-local`'s
generated targets):

| Title | Result |
|---|---|
| 2000svg | PASS (1982464 bytes) |
| boot | PASS (651264 bytes) |
| bricks | PASS (24576 bytes) |
| donsol | PASS (217088 bytes) |
| glowdeck | PASS (20480 bytes) |
| hack | PASS (1892352 bytes) |
| meme | PASS (233472 bytes) |
| photobooth | PASS (16384 bytes) |
| pop | PASS (1613824 bytes) |
| queersafe | PASS (4345856 bytes) |
| queersafe-lite | PASS (81920 bytes) |
| retrovg | PASS (1826816 bytes) |

All 12 exit 0 and emit exactly one legacy deprecation notice on stderr.

**Byte-compare against a pre-#420 baseline** (`3a235ec`, installed into a
second venv): **not** byte-identical for bricks/donsol/glowdeck against
tip. Root-caused, not hand-waved: the delta is fully explained by
*unrelated* intervening language-feature work -- specifically the string
constant pool (gamequeer#418, landed via #427/#429/#431) inserting a new
`.const` section that shifts every downstream address, independent of
this fix. Confirmed by isolating the fix's own correctness instead: under
**this same gqc version**, compiling bricks/donsol/glowdeck via the
legacy (flat) path and via the directory-layout path (same game content,
just relocated to `<name>/<name>.gq` with its assets nested inside)
produces **byte-identical** `.gqgame` output for all three:

```
bricks:   IDENTICAL
donsol:   IDENTICAL
glowdeck: IDENTICAL
```

That isolates the asset-resolution logic itself as correct, decoupled
from the noise of a dozen unrelated compiler commits between `3a235ec`
and `default`.

**Existing test suite**: all 501 tests pass (494 before this PR's own 7
new tests), 2 skipped (ffmpeg-gated, environment-dependent), unchanged.
`test_game_layout.py`'s existing negative control
(`test_animation_source_at_old_cwd_relative_location_is_not_found`) needed
**no changes** -- it already pins exactly the "directory layout gets no
CWD fallback" contract this fix preserves untouched; verified by running
it (still passes) rather than assuming.

**Golden suite** (`-m golden`): untouched, 15 passed / 2 skipped.

**New tests** (`gqc/tests/test_game_layout.py`, 7 added): legacy flat
compile succeeds + resolves at CWD (with a negative control against
game_dir-relative assets); directory-layout compile emits no legacy
notice; the `games/games.gq` edge case (positive + negative control);
deprecation notice present in legacy mode / absent in directory mode;
notice lands on stderr only, `.gqgame` output unaffected.

## Note on #433 (`gqc migrate`)

#433 (`gqc migrate`, not yet merged to `default`) currently compiles a
flat game's *baseline* via a symlink harness, because "the flat form no
longer compiles in place at all" under tip `default`. This PR removes
that premise -- flat games compile in place again -- which may let #433
simplify its baseline-compile step. Flagging, not changing #433 here.

## Frozen-VM contract

Compiler-only (`gqc/src/gqc/gqc.py` + its test suite). No changes under
`gamequeer/` (C runtime), no bytecode/struct changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZKhf6qdJnripjqBapoEan