### PR TITLE
revert(gqc): remove flat-layout legacy resolution mode

### DIFF
--- a/gqc/src/gqc/__init__.py
+++ b/gqc/src/gqc/__init__.py
@@ -6,3 +6,13 @@ class GqcParseError(Exception):
     def __init__(self, message, s, loc):
         message = f"Error at line {pp.lineno(loc, s)}, column {pp.col(loc, s)}: {message}"
         super().__init__(message)
+
+class GqcAssetNotFoundError(ValueError):
+    """An animation/lightcue asset was not found at its resolved
+    (game-dir-relative, gamequeer#420) path.
+
+    Distinct from a plain ValueError so callers with game-name context
+    (parser.py, which catches this to append a `gqc migrate` hint) can
+    single it out without treating every other ValueError from asset
+    processing (bad dithering option, malformed cue, ...) as a possible
+    layout problem."""

--- a/gqc/src/gqc/__init__.py
+++ b/gqc/src/gqc/__init__.py
@@ -8,8 +8,11 @@ class GqcParseError(Exception):
         super().__init__(message)
 
 class GqcAssetNotFoundError(ValueError):
-    """An animation/lightcue asset was not found at its resolved
-    (game-dir-relative, gamequeer#420) path.
+    """An animation/lightcue asset was not found at its resolved path.
+    On the compile path (anim.py/Animation.__init__) that path is always
+    game-dir-relative (gamequeer#420); `gqc mkcue`'s standalone entry point
+    (cues.make_cue) raises this too, for a user-supplied `src_path` that
+    isn't necessarily game-dir-relative at all.
 
     Distinct from a plain ValueError so callers with game-name context
     (parser.py, which catches this to append a `gqc migrate` hint) can

--- a/gqc/src/gqc/anim.py
+++ b/gqc/src/gqc/anim.py
@@ -79,7 +79,8 @@ def make_animation(progress: Progress, anim_src_path : pathlib.Path, output_dir 
     for file in output_dir.glob('frame*.bmp'):
         file.unlink()
 
-    # Check whether the source file exists and raise a value error if it doesn't
+    # Check whether the source file exists and raise a GqcAssetNotFoundError
+    # (a ValueError subclass) if it doesn't
     if not anim_src_path.exists():
         raise GqcAssetNotFoundError(f"Animation source file {anim_src_path} does not exist")
     

--- a/gqc/src/gqc/anim.py
+++ b/gqc/src/gqc/anim.py
@@ -6,6 +6,8 @@ from PIL.Image import Dither
 
 from rich.progress import Progress
 
+from . import GqcAssetNotFoundError
+
 def make_animation_from_video(progress: Progress, anim_src_path : pathlib.Path, output_dir : pathlib.Path, dithering : str = 'none', frame_rate : int = 25, height : int = 128, width : int = 128):
     # Load the source file
     in_file = ffmpeg.input(anim_src_path)
@@ -79,7 +81,7 @@ def make_animation(progress: Progress, anim_src_path : pathlib.Path, output_dir 
 
     # Check whether the source file exists and raise a value error if it doesn't
     if not anim_src_path.exists():
-        raise ValueError(f"Animation source file {anim_src_path} does not exist")
+        raise GqcAssetNotFoundError(f"Animation source file {anim_src_path} does not exist")
     
     # Check whether the source file is a video or an image
     if anim_src_path.suffix in ['.bmp', '.png', '.jpg', '.jpeg']:

--- a/gqc/src/gqc/cues.py
+++ b/gqc/src/gqc/cues.py
@@ -84,7 +84,8 @@ def make_cue(progress : Progress, src_path : pathlib.Path, output_dir : pathlib.
     task = progress.add_task(f"Parsing light cue '{src_path}'", total=1)
     # Set up the output directory
     output_dir.mkdir(parents=True, exist_ok=True)
-    # Check whether the source file exists and raise a value error if it doesn't
+    # Check whether the source file exists and raise a GqcAssetNotFoundError
+    # (a ValueError subclass) if it doesn't
     if not src_path.exists():
         raise GqcAssetNotFoundError(f"Light cue source file {src_path} does not exist")
     

--- a/gqc/src/gqc/cues.py
+++ b/gqc/src/gqc/cues.py
@@ -6,7 +6,7 @@ import pyparsing as pp
 from rich.progress import Progress
 from rich import print
 
-from . import GqcParseError
+from . import GqcAssetNotFoundError, GqcParseError
 from .datamodel import CueColor, LightCueFrame, LightCue
 
 def parse_cue(text) -> LightCue:
@@ -86,7 +86,7 @@ def make_cue(progress : Progress, src_path : pathlib.Path, output_dir : pathlib.
     output_dir.mkdir(parents=True, exist_ok=True)
     # Check whether the source file exists and raise a value error if it doesn't
     if not src_path.exists():
-        raise ValueError(f"Light cue source file {src_path} does not exist")
+        raise GqcAssetNotFoundError(f"Light cue source file {src_path} does not exist")
     
     with open(src_path, 'r') as f:
         parsed_cue = parse_cue(f)

--- a/gqc/src/gqc/cues.py
+++ b/gqc/src/gqc/cues.py
@@ -85,7 +85,14 @@ def make_cue(progress : Progress, src_path : pathlib.Path, output_dir : pathlib.
     # Set up the output directory
     output_dir.mkdir(parents=True, exist_ok=True)
     # Check whether the source file exists and raise a GqcAssetNotFoundError
-    # (a ValueError subclass) if it doesn't
+    # (a ValueError subclass) if it doesn't. NOTE (gamequeer#437 review):
+    # this function is only reached from gqc.py's `mkcue` CLI command
+    # (a library/tooling entry point, no Game context) -- the compile path
+    # never calls it. parser.parse_lightcue_definition_section does its own
+    # separate exists() check before ever opening a lightcue source, so this
+    # GqcAssetNotFoundError never reaches parser.py's `gqc migrate` hint
+    # (unlike the animation half of this same pattern in anim.py, which
+    # *is* reached from Animation.__init__ on the compile path).
     if not src_path.exists():
         raise GqcAssetNotFoundError(f"Light cue source file {src_path} does not exist")
     

--- a/gqc/src/gqc/datamodel.py
+++ b/gqc/src/gqc/datamodel.py
@@ -12,7 +12,7 @@ from PIL import Image
 from rich import print
 from rich.progress import Progress, TextColumn, BarColumn, TaskProgressColumn, TimeElapsedColumn
 
-from . import structs
+from . import structs, GqcAssetNotFoundError
 from .structs import EventType
 from .anim import make_animation
 
@@ -637,6 +637,20 @@ class Animation:
             self.src_path = Game.game_dir / 'assets' / 'animations' / source
             self.dst_path = pathlib.Path() / 'build' / 'assets' / 'animations' / Game.game_name / name
             digest_path = self.dst_path / '.digest'
+
+            # gamequeer#437 review: anim.make_animation does its own
+            # existence check and raises GqcAssetNotFoundError, but that's
+            # only reached below on a cache *miss*. The cache-hit branch
+            # right below calls self.digest(), which opens self.src_path
+            # directly -- a stale build/ digest cache left over from a
+            # previous compile (the asset has since moved or been deleted,
+            # e.g. a still-flat game whose assets haven't been migrated yet)
+            # would otherwise hit that open() as a raw, unhandled
+            # FileNotFoundError instead of the same diagnostic + `gqc
+            # migrate` hint a fresh (no-cache) compile gets. Checking once,
+            # up front, covers both branches below.
+            if not self.src_path.exists():
+                raise GqcAssetNotFoundError(f"Animation source file {self.src_path} does not exist")
 
             # Check if the dst_path has a file in it called .digest and compare it to self.digest()
             # If they match, skip the ffmpeg conversion step

--- a/gqc/src/gqc/gqc.py
+++ b/gqc/src/gqc/gqc.py
@@ -104,21 +104,6 @@ def fmt(input : pathlib.Path, write : bool, check : bool):
     else:
         click.echo(formatted, nl=False)
 
-def _is_directory_layout(input : pathlib.Path) -> bool:
-    """Detect gamequeer#420's game-as-directory layout: the entry file's
-    parent directory is named for the game itself (`<name>/<name>.gq`).
-
-    Purely structural/deterministic -- no filesystem probing beyond the
-    entry path itself, no "try both and see what resolves" fallback (see
-    gamequeer#434). A flat entry file whose parent *happens* to share its
-    name (e.g. a top-level `games/games.gq`, or any `<x>/<x>.gq`) is
-    indistinguishable from a real directory-layout game and is treated as
-    one -- there is no reliable way to tell them apart from the entry path
-    alone, and #420's own convention doesn't require the directory to
-    contain anything else."""
-    return input.parent.name == input.stem
-
-
 @gqc_cli.command()
 @click.option('--no-mem-map', '-n', is_flag=True)
 @click.option('--out-dir', '-o', type=click.Path(file_okay=False, dir_okay=True, writable=True, path_type=pathlib.Path), default=None)
@@ -132,28 +117,11 @@ def compile(input : pathlib.Path, no_mem_map : bool, out_dir : pathlib.Path):
     # from outside that directory, and is a no-op for the common case where
     # the entry file is already at the top of the invocation directory.
     #
-    # gamequeer#434: that's only true for entry files that actually follow
-    # #420's `<name>/<name>.gq` convention. #420 set Game.game_dir =
-    # input.parent unconditionally, which broke every *flat*-layout game
-    # (`games/<name>.gq` next to a shared top-level `assets/` dir, sibling
-    # of `games/` -- the entire pre-#420 gq-games corpus, and this repo's
-    # own `examples/skel` fixtures) by resolving assets against
-    # `games/assets/...` instead of the real `assets/...` at the workspace
-    # root. Detect which convention this entry file actually uses and
-    # branch resolution accordingly, so a flat game keeps compiling exactly
-    # as it did before #420 (CWD-relative -- not "entry's grandparent
-    # directory", which breaks for a nested entry like
-    # `games/<subdir>/<name>.gq`; see examples/skel/games/working_samples/).
-    if _is_directory_layout(input):
-        Game.game_dir = input.parent
-    else:
-        Game.game_dir = pathlib.Path.cwd()
-        click.echo(
-            f"{input}: legacy flat-layout asset resolution (pre-gamequeer#420, "
-            "CWD-relative) -- run `gqc migrate` to move this game onto the "
-            "self-contained game-as-directory layout and silence this notice.",
-            err=True,
-        )
+    # gqc expects the game-as-directory layout everywhere (`<name>/<name>.gq`
+    # with its assets nested underneath) -- there is no CWD-relative
+    # fallback for a flat entry file. A game still on the old flat layout
+    # should be moved onto this layout with `gqc migrate` (see migrate.py).
+    Game.game_dir = input.parent
 
     # output_path is the directory where the output of the project will be placed
     if out_dir is None:

--- a/gqc/src/gqc/migrate.py
+++ b/gqc/src/gqc/migrate.py
@@ -74,10 +74,10 @@ stages the migrated form in a separate temp directory, compiles that too,
 and requires the two `.gqgame` outputs to be **byte-identical** before
 committing anything to the workspace. Any mismatch (or either compile
 failing) aborts loudly and leaves the original completely untouched.
-Once gamequeer#434 (layout-detected legacy resolution) lands, a flat game
-will compile directly again, and `_compile_flat_baseline`'s symlink
-harness can be simplified to a direct in-place compile of the original
-entry file.
+gqc has exactly one asset-resolution rule (game-dir-relative, #420) and no
+CWD-relative fallback for a flat entry file: a flat game genuinely does
+not compile in place, so `_compile_flat_baseline`'s symlink harness is the
+permanent way to establish the pre-migration baseline, not a stopgap.
 """
 
 import dataclasses

--- a/gqc/src/gqc/migrate.py
+++ b/gqc/src/gqc/migrate.py
@@ -599,8 +599,21 @@ def _compile_flat_baseline(plan: MigrationPlan) -> bytes:
     with tempfile.TemporaryDirectory(prefix="gqc-migrate-pre-") as tmp:
         tmp_path = pathlib.Path(tmp)
         tmp_entry = tmp_path / plan.entry_path.name
-        shutil.copyfile(plan.entry_path, tmp_entry)
-        os.symlink(plan.workspace / "assets", tmp_path / "assets")
+        # Both of these only ever touch the throwaway tmp_path harness (the
+        # symlink's target, plan.workspace / "assets", is read, never
+        # written) -- this whole function runs before execute()'s first
+        # real workspace mutation, so there's nothing to roll back here,
+        # just the same "clean MigrateError, never a raw traceback"
+        # contract this module promises everywhere else (permissions, a
+        # filesystem/OS without symlink support, ...).
+        try:
+            shutil.copyfile(plan.entry_path, tmp_entry)
+            os.symlink(plan.workspace / "assets", tmp_path / "assets")
+        except OSError as exc:
+            raise MigrateError(
+                f"{plan.game_name}: building the pre-migration compile "
+                f"harness in {tmp_path} failed ({exc})"
+            ) from exc
         return _run_compile(tmp_entry, tmp_path / "build", cwd=tmp_path)
 
 

--- a/gqc/src/gqc/parser.py
+++ b/gqc/src/gqc/parser.py
@@ -23,10 +23,23 @@ def _migrate_hint(message):
     # in a shared top-level assets/ tree, or the invocation CWD) that just
     # hasn't been moved onto that layout yet -- point authors at the fix
     # rather than leaving them to guess from the raw resolved path alone.
+    #
+    # Game.game_name is only ever set by gqc.py's `compile` command; it's
+    # still None here for in-process callers that drive parser.parse()
+    # directly without going through it (e.g. tests using
+    # support.reset_compiler_state(), gamequeer#437 review). Fall back to
+    # generic phrasing rather than rendering the literal "None" into the
+    # hint.
+    if Game.game_name:
+        subject = Game.game_name
+        migrate_cmd = f"gqc migrate {Game.game_name}"
+    else:
+        subject = "this game"
+        migrate_cmd = "gqc migrate <name>"
     return (
-        f"{message}\nIf {Game.game_name} is a flat-layout game (its assets "
+        f"{message}\nIf {subject} is a flat-layout game (its assets "
         "haven't been moved into its own directory yet), run "
-        f"`gqc migrate {Game.game_name}` to move it onto the current "
+        f"`{migrate_cmd}` to move it onto the current "
         "game-as-directory layout."
     )
 

--- a/gqc/src/gqc/parser.py
+++ b/gqc/src/gqc/parser.py
@@ -13,7 +13,22 @@ from .commands import CommandPlay, CommandGoStage, CommandCue, CommandCastStr
 from .commands import CommandSetStr, CommandSetInt, CommandWithIntExpressionArgument
 from .commands import CommandTimer, CommandIf, CommandGoto, CommandLoop, Command, CommandType
 from .structs import EventType
-from . import structs, GqcParseError
+from . import structs, GqcAssetNotFoundError, GqcParseError
+
+def _migrate_hint(message):
+    # gqc has exactly one asset-resolution rule: animations{}/lightcues{}
+    # sources resolve relative to the entry file's own parent directory
+    # (game-as-directory layout, gamequeer#420), never the process CWD.
+    # A "does not exist" miss here is very often a still-flat game (assets
+    # in a shared top-level assets/ tree, or the invocation CWD) that just
+    # hasn't been moved onto that layout yet -- point authors at the fix
+    # rather than leaving them to guess from the raw resolved path alone.
+    return (
+        f"{message}\nIf {Game.game_name} is a flat-layout game (its assets "
+        "haven't been moved into its own directory yet), run "
+        f"`gqc migrate {Game.game_name}` to move it onto the current "
+        "game-as-directory layout."
+    )
 
 def parse_game_definition(instring, loc, toks):
     toks = toks[0]
@@ -152,6 +167,8 @@ def parse_animation_definition(instring, loc, toks):
 
     try:
         return Animation(name, source, **kwargs)
+    except GqcAssetNotFoundError as ve:
+        raise GqcParseError(_migrate_hint(str(ve)), instring, loc)
     except ValueError as ve:
         raise GqcParseError(str(ve), instring, loc)
 
@@ -249,7 +266,10 @@ def parse_lightcue_definition_section(instring, loc, toks):
         print(f"[blue]Light cue [italic]{cue_name}[/italic][/blue] from [underline]{cue_source}[/underline]")
         
         if not cue_source.exists():
-            raise GqcParseError(f"Light cue {cue_name} source {cue_source} not found", instring, loc)
+            raise GqcParseError(
+                _migrate_hint(f"Light cue {cue_name} source {cue_source} not found"),
+                instring, loc,
+            )
         
         with open(cue_source, 'r') as f:
             parsed_cue = parse_cue(f)

--- a/gqc/src/gqc/parser.py
+++ b/gqc/src/gqc/parser.py
@@ -283,9 +283,22 @@ def parse_lightcue_definition_section(instring, loc, toks):
                 _migrate_hint(f"Light cue {cue_name} source {cue_source} not found"),
                 instring, loc,
             )
-        
-        with open(cue_source, 'r') as f:
-            parsed_cue = parse_cue(f)
+
+        # gamequeer#437 review: the exists() check above doesn't guard the
+        # open() right below it -- unreadable (permissions) or removed
+        # between the check and the open still hit a raw, unhandled OSError
+        # here otherwise, undercutting the "clean diagnostic, never a raw
+        # traceback" intent this whole missing-asset path exists for. No
+        # migrate hint here: unlike a plain "not found", this is a
+        # filesystem-state problem the migrate flow wouldn't fix.
+        try:
+            with open(cue_source, 'r') as f:
+                parsed_cue = parse_cue(f)
+        except OSError as e:
+            raise GqcParseError(
+                f"Light cue {cue_name} source {cue_source} could not be opened: {e}",
+                instring, loc,
+            )
         try:
             parsed_cue.set_name(cue_name)
         except ValueError as ve:

--- a/gqc/tests/test_game_layout.py
+++ b/gqc/tests/test_game_layout.py
@@ -36,6 +36,7 @@ lightcue counterpart below, and migrate.py's `gqc migrate` for moving an
 old flat-layout game onto this layout.
 """
 
+import io
 import pathlib
 import shutil
 import subprocess
@@ -43,6 +44,10 @@ import sys
 
 import pytest
 from PIL import Image
+
+from gqc import parser
+
+from .support import reset_compiler_state
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 CIRCLE_BMP = REPO_ROOT / "gqc" / "examples" / "skel" / "assets" / "animations" / "circle.bmp"
@@ -293,6 +298,32 @@ def test_missing_lightcue_asset_mentions_resolved_path_and_migrate_hint(compile_
     assert "gqc migrate mygame" in unwrapped
 
 
+def test_missing_lightcue_asset_migrate_hint_falls_back_when_game_name_unset(
+    tmp_path, monkeypatch, capsys
+):
+    # Regression guard (Copilot-suppressed finding on #437, not surfaced as
+    # an inline review comment): _migrate_hint interpolates Game.game_name
+    # into the "gqc migrate <name>" hint, but gqc.py's `compile` command is
+    # the only thing that ever sets it -- an in-process caller that drives
+    # parser.parse() directly via support.reset_compiler_state() (as
+    # test_assets.py and others do) leaves it at its class default of None.
+    # Confirms the hint degrades to generic phrasing instead of rendering
+    # the literal string "None" into the message.
+    monkeypatch.chdir(tmp_path)
+    reset_compiler_state()
+    source = GAME_HEADER + 'lightcues { c1 <- "test.gqcue"; }\n' + STAGE
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse(io.StringIO(source))
+    assert exc_info.value.code == 1
+
+    captured = capsys.readouterr()
+    unwrapped = captured.err.replace("\n", "")
+    assert "None" not in unwrapped
+    assert "this game" in unwrapped
+    assert "gqc migrate <name>" in unwrapped
+
+
 def test_missing_asset_diagnostic_is_silent_when_asset_present(compile_gq):
     # Companion positive control: the hint text is specific to a missing
     # asset, not appended to every compile's stderr unconditionally.
@@ -303,6 +334,41 @@ def test_missing_asset_diagnostic_is_silent_when_asset_present(compile_gq):
     )
     assert exit_code == 0, stderr
     assert "gqc migrate" not in stderr
+
+
+def test_missing_animation_asset_after_digest_cache_hit_gives_diagnostic_not_traceback(
+    compile_gq, tmp_path
+):
+    # Regression guard (gamequeer#437 review): Animation.__init__'s
+    # digest-cache *hit* branch (build/ is CWD-relative, independent of -o
+    # -- see its dst_path) reads self.digest(), which opens self.src_path
+    # directly, without going through anim.make_animation's own existence
+    # check -- that's only reached on a cache *miss*. Recompiling against a
+    # stale cache after the source asset has moved or been deleted (e.g. a
+    # still-flat game whose assets were never migrated) used to surface as
+    # a raw, unhandled FileNotFoundError traceback instead of the same
+    # GqcAssetNotFoundError + `gqc migrate` diagnostic a fresh (no-cache)
+    # compile gets.
+    source = GAME_HEADER + 'animations { c <- "circle.bmp"; }\n' + STAGE
+    asset_path = tmp_path / "assets" / "animations" / "circle.bmp"
+
+    # First compile succeeds and leaves a digest cache behind.
+    exit_code, stderr, _ = compile_gq(
+        source,
+        assets={"assets/animations/circle.bmp": CIRCLE_BMP},
+        game_name="mygame",
+    )
+    assert exit_code == 0, stderr
+    assert asset_path.exists()
+
+    # Remove the asset and recompile with the stale cache still present.
+    asset_path.unlink()
+    exit_code, stderr, _ = compile_gq(source, game_name="mygame")
+    assert exit_code != 0
+    unwrapped = _unwrapped(stderr)
+    assert "Traceback" not in unwrapped
+    assert "does not exist" in unwrapped
+    assert "gqc migrate mygame" in unwrapped
 
 
 # --- `gqc new`: scaffolding a fresh game-as-directory game -------------------

--- a/gqc/tests/test_game_layout.py
+++ b/gqc/tests/test_game_layout.py
@@ -46,6 +46,7 @@ import pytest
 from PIL import Image
 
 from gqc import parser
+from gqc.datamodel import Game
 
 from .support import reset_compiler_state
 
@@ -324,6 +325,33 @@ def test_missing_lightcue_asset_migrate_hint_falls_back_when_game_name_unset(
     assert "None" not in unwrapped
     assert "this game" in unwrapped
     assert "gqc migrate <name>" in unwrapped
+
+
+def test_lightcue_open_failure_after_exists_check_gives_clean_diagnostic(
+    tmp_path, monkeypatch, capsys
+):
+    # Regression guard (Copilot review, gamequeer#437): the lightcue
+    # exists() check doesn't guard the open() right below it -- an
+    # unreadable path (or one removed between the check and the open) used
+    # to surface as a raw, unhandled OSError traceback instead of the same
+    # kind of clean diagnostic a plain "not found" gets. A directory
+    # sitting at the lightcue source path reproduces this deterministically
+    # without needing to race anything: Path.exists() is True for a
+    # directory, but open(dir_path, "r") raises IsADirectoryError.
+    monkeypatch.chdir(tmp_path)
+    reset_compiler_state()
+    Game.game_name = "mygame"
+    (tmp_path / "assets" / "lighting" / "test.gqcue").mkdir(parents=True)
+    source = GAME_HEADER + 'lightcues { c1 <- "test.gqcue"; }\n' + STAGE
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse(io.StringIO(source))
+    assert exc_info.value.code == 1
+
+    captured = capsys.readouterr()
+    unwrapped = _unwrapped(captured.err)
+    assert "Traceback" not in unwrapped
+    assert "could not be opened" in unwrapped
 
 
 def test_missing_asset_diagnostic_is_silent_when_asset_present(compile_gq):

--- a/gqc/tests/test_game_layout.py
+++ b/gqc/tests/test_game_layout.py
@@ -27,17 +27,13 @@ write straight to Game.game.needs_fw_probe/Game.game.needs_random -- all
 three would crash with AttributeError on `NoneType` if the stage in question
 was parsed before game{} itself.
 
-The suite's final section (gamequeer#434) covers layout *detection*: an
-entry file only gets #420's game_dir-relative resolution if its parent
-directory is actually named for it (`<name>/<name>.gq`); anything else --
-including the entire pre-#420 gq-games corpus, whose games live flat in a
-shared `games/` directory next to a sibling top-level `assets/` -- falls
-back to legacy (pre-#420), CWD-relative resolution, with a one-line
-deprecation notice on stderr pointing at `gqc migrate`. There is no
-try-both-and-see fallback: a directory-layout game never consults the CWD
-(see the existing negative-control tests above, unchanged by #434), and a
-flat entry file whose parent coincidentally matches the convention (e.g.
-`games/games.gq`) is treated as directory layout, not flat.
+gqc has exactly one asset-resolution rule: `animations{}`/`lightcues{}`
+sources always resolve relative to the entry file's own parent directory
+(`Game.game_dir = input.parent`), i.e. the game-as-directory layout only.
+There is no CWD-relative fallback for a flat entry file -- see
+test_animation_source_at_old_cwd_relative_location_is_not_found and its
+lightcue counterpart below, and migrate.py's `gqc migrate` for moving an
+old flat-layout game onto this layout.
 """
 
 import pathlib
@@ -67,6 +63,18 @@ def _run(cwd, args, timeout=COMPILE_TIMEOUT_S):
         timeout=timeout,
     )
     return proc.returncode, proc.stderr, proc.stdout
+
+
+def _unwrapped(stderr: str) -> str:
+    # `parser.parse`'s error path prints via `rich.print`, which soft- (and,
+    # for a single long token like an absolute resolved path, hard-) wraps
+    # output to the console width whenever stderr isn't a real terminal --
+    # always true here, under a capture_output subprocess. That can inject a
+    # bare "\n" in the *middle* of a path component (e.g. "animatio\nns"),
+    # so a substring check against the raw text is flaky depending on the
+    # tmp_path's length. Stripping newlines recovers the original text,
+    # since rich's hard-wrap never inserts a space, only "\n".
+    return stderr.replace("\n", "")
 
 
 # --- game{}: anywhere in the top-level section stream (accept) --------------
@@ -214,6 +222,9 @@ def test_animation_source_at_old_cwd_relative_location_is_not_found(tmp_path):
     )
     assert exit_code != 0
     assert "circle.bmp" in stderr
+    # gqc has no CWD-relative fallback, so this is exactly the "old flat
+    # game, assets not moved yet" case the migrate hint below exists for.
+    assert "gqc migrate mygame" in _unwrapped(stderr)
 
 
 def test_lightcue_source_resolves_relative_to_game_dir_not_cwd(tmp_path):
@@ -247,6 +258,51 @@ def test_lightcue_source_at_old_cwd_relative_location_is_not_found(tmp_path):
     )
     assert exit_code != 0
     assert "test.gqcue" in stderr
+    assert "gqc migrate mygame" in _unwrapped(stderr)
+
+
+# --- missing-asset diagnostic: `gqc migrate` hint ---------------------------
+
+
+def test_missing_animation_asset_mentions_resolved_path_and_migrate_hint(compile_gq):
+    # compile_gq puts the entry file directly at its hermetic CWD (no
+    # "assets/" subdirectory created), so this is the plain missing-asset
+    # case -- no relocation trickery needed to trigger it.
+    exit_code, stderr, _ = compile_gq(
+        GAME_HEADER + 'animations { c <- "circle.bmp"; }\n' + STAGE,
+        game_name="mygame",
+    )
+    assert exit_code != 0
+    unwrapped = _unwrapped(stderr)
+    # The resolved (game-dir-relative) path, not just the bare filename --
+    # an author needs to see *where* gqc looked.
+    assert str(pathlib.Path("assets") / "animations" / "circle.bmp") in unwrapped
+    assert "does not exist" in unwrapped
+    assert "gqc migrate mygame" in unwrapped
+
+
+def test_missing_lightcue_asset_mentions_resolved_path_and_migrate_hint(compile_gq):
+    exit_code, stderr, _ = compile_gq(
+        GAME_HEADER + 'lightcues { c1 <- "test.gqcue"; }\n' + STAGE,
+        game_name="mygame",
+    )
+    assert exit_code != 0
+    unwrapped = _unwrapped(stderr)
+    assert str(pathlib.Path("assets") / "lighting" / "test.gqcue") in unwrapped
+    assert "not found" in unwrapped
+    assert "gqc migrate mygame" in unwrapped
+
+
+def test_missing_asset_diagnostic_is_silent_when_asset_present(compile_gq):
+    # Companion positive control: the hint text is specific to a missing
+    # asset, not appended to every compile's stderr unconditionally.
+    exit_code, stderr, _ = compile_gq(
+        GAME_HEADER + 'animations { c <- "circle.bmp"; }\n' + STAGE,
+        assets={"assets/animations/circle.bmp": CIRCLE_BMP},
+        game_name="mygame",
+    )
+    assert exit_code == 0, stderr
+    assert "gqc migrate" not in stderr
 
 
 # --- `gqc new`: scaffolding a fresh game-as-directory game -------------------
@@ -298,152 +354,3 @@ def test_new_force_overwrites_existing_game(tmp_path):
     exit_code, stderr, _ = _run(tmp_path, ["new", "mygame", "--force"])
     assert exit_code == 0, stderr
     assert entry_path.read_text() != "MODIFIED"
-
-
-# --- gamequeer#434: layout detection / legacy flat-layout fallback ---------
-
-
-def test_legacy_flat_layout_compiles_and_resolves_assets_at_cwd(tmp_path):
-    # Flat layout (pre-#420, the shape of the whole pre-migration gq-games
-    # corpus): the entry file lives in a `games/` directory whose name
-    # doesn't match the entry's own stem, with a *sibling* top-level
-    # `assets/` (not nested under `games/`). That fails the
-    # `<name>/<name>.gq` directory-layout check, so resolution falls back
-    # to the process CWD -- exactly how gqc resolved assets before #420.
-    games_dir = tmp_path / "games"
-    games_dir.mkdir()
-    (games_dir / "foo.gq").write_text(
-        GAME_HEADER + 'animations { c <- "circle.bmp"; }\n' + STAGE
-    )
-    assets_dir = tmp_path / "assets" / "animations"
-    assets_dir.mkdir(parents=True)
-    shutil.copyfile(CIRCLE_BMP, assets_dir / "circle.bmp")
-
-    out_dir = tmp_path / "build"
-    exit_code, stderr, _ = _run(
-        tmp_path,
-        ["compile", "-o", str(out_dir), str(games_dir / "foo.gq")],
-    )
-    assert exit_code == 0, stderr
-
-
-def test_legacy_flat_layout_does_not_find_game_dir_relative_assets(tmp_path):
-    # Companion negative control: the same flat entry file, but the asset
-    # sits at the *directory-layout*-style location (nested under the
-    # entry's own parent) instead of the real legacy CWD-relative spot --
-    # pins that legacy mode doesn't also try game_dir-relative as a
-    # fallback.
-    games_dir = tmp_path / "games"
-    games_dir.mkdir()
-    (games_dir / "foo.gq").write_text(
-        GAME_HEADER + 'animations { c <- "circle.bmp"; }\n' + STAGE
-    )
-    dir_layout_style_assets = games_dir / "assets" / "animations"
-    dir_layout_style_assets.mkdir(parents=True)
-    shutil.copyfile(CIRCLE_BMP, dir_layout_style_assets / "circle.bmp")
-
-    out_dir = tmp_path / "build"
-    exit_code, stderr, _ = _run(
-        tmp_path,
-        ["compile", "-o", str(out_dir), str(games_dir / "foo.gq")],
-    )
-    assert exit_code != 0
-    assert "circle.bmp" in stderr
-
-
-def test_directory_layout_game_emits_no_deprecation_notice(tmp_path):
-    # Companion to the animation/lightcue game_dir-relative tests above:
-    # pins that a real directory-layout game gets #420's resolution with no
-    # legacy notice, even when invoked (as here) from its own parent
-    # directory, one level up from the game directory itself.
-    game_dir = _write_game_dir(
-        tmp_path, "mygame", 'animations { c <- "circle.bmp"; }\n'
-    )
-    assets_dir = game_dir / "assets" / "animations"
-    assets_dir.mkdir(parents=True)
-    shutil.copyfile(CIRCLE_BMP, assets_dir / "circle.bmp")
-
-    out_dir = tmp_path / "build"
-    exit_code, stderr, _ = _run(
-        tmp_path,
-        ["compile", "-o", str(out_dir), str(game_dir / "mygame.gq")],
-    )
-    assert exit_code == 0, stderr
-    assert "legacy" not in stderr.lower()
-    assert "gqc migrate" not in stderr
-
-
-def test_flat_entry_matching_directory_convention_is_treated_as_directory_layout(tmp_path):
-    # Edge case (gamequeer#434): a flat entry file whose parent directory
-    # happens to share its own name -- e.g. a top-level `games/games.gq` --
-    # is structurally indistinguishable from a real directory-layout game
-    # (`<name>/<name>.gq`), and there's no fallback to try both: directory
-    # layout wins unconditionally, so its assets must live *inside*
-    # `games/`, not at a sibling top-level `assets/`.
-    games_dir = tmp_path / "games"
-    games_dir.mkdir()
-    (games_dir / "games.gq").write_text(
-        GAME_HEADER + 'animations { c <- "circle.bmp"; }\n' + STAGE
-    )
-    dir_layout_assets = games_dir / "assets" / "animations"
-    dir_layout_assets.mkdir(parents=True)
-    shutil.copyfile(CIRCLE_BMP, dir_layout_assets / "circle.bmp")
-
-    out_dir = tmp_path / "build"
-    exit_code, stderr, _ = _run(
-        tmp_path,
-        ["compile", "-o", str(out_dir), str(games_dir / "games.gq")],
-    )
-    assert exit_code == 0, stderr
-    assert "legacy" not in stderr.lower()
-
-
-def test_flat_entry_matching_directory_convention_ignores_sibling_assets(tmp_path):
-    # Same edge case, but the asset sits at the legacy CWD-relative spot
-    # instead -- must NOT be found, since `games/games.gq` resolved as
-    # directory layout (see test above) never falls back to the CWD.
-    games_dir = tmp_path / "games"
-    games_dir.mkdir()
-    (games_dir / "games.gq").write_text(
-        GAME_HEADER + 'animations { c <- "circle.bmp"; }\n' + STAGE
-    )
-    legacy_style_assets = tmp_path / "assets" / "animations"
-    legacy_style_assets.mkdir(parents=True)
-    shutil.copyfile(CIRCLE_BMP, legacy_style_assets / "circle.bmp")
-
-    out_dir = tmp_path / "build"
-    exit_code, stderr, _ = _run(
-        tmp_path,
-        ["compile", "-o", str(out_dir), str(games_dir / "games.gq")],
-    )
-    assert exit_code != 0
-    assert "circle.bmp" in stderr
-
-
-def test_deprecation_notice_emitted_in_legacy_mode(compile_gq):
-    # compile_gq's entry file is always named "game" by default and sits
-    # directly in the hermetic tmp_path CWD, whose own name never matches
-    # -- always legacy under gamequeer#434's detection rule.
-    exit_code, stderr, _ = compile_gq(GAME_HEADER + STAGE)
-    assert exit_code == 0, stderr
-    assert "legacy" in stderr.lower()
-    assert "gqc migrate" in stderr
-
-
-def test_deprecation_notice_goes_to_stderr_not_stdout(tmp_path):
-    # Uses `_run` (not `compile_gq`) specifically because it's the only
-    # fixture here that captures stdout separately from stderr --
-    # `compile_gq` only returns stderr, so it can't actually prove the
-    # notice *isn't* on stdout.
-    src_path = tmp_path / "game.gq"
-    src_path.write_text(GAME_HEADER + STAGE)
-    out_dir = tmp_path / "build"
-
-    exit_code, stderr, stdout = _run(
-        tmp_path, ["compile", "-o", str(out_dir), str(src_path)]
-    )
-    assert exit_code == 0, stderr
-    assert "legacy" in stderr.lower()
-    assert "legacy" not in stdout.lower()
-    # Machine-parsed output must be untouched by the notice.
-    assert (out_dir / "game.gqgame").exists()

--- a/gqc/tests/test_game_layout.py
+++ b/gqc/tests/test_game_layout.py
@@ -226,10 +226,11 @@ def test_animation_source_at_old_cwd_relative_location_is_not_found(tmp_path):
         ["compile", "-o", str(out_dir), str(game_dir / "mygame.gq")],
     )
     assert exit_code != 0
-    assert "circle.bmp" in stderr
+    unwrapped = _unwrapped(stderr)
+    assert "circle.bmp" in unwrapped
     # gqc has no CWD-relative fallback, so this is exactly the "old flat
     # game, assets not moved yet" case the migrate hint below exists for.
-    assert "gqc migrate mygame" in _unwrapped(stderr)
+    assert "gqc migrate mygame" in unwrapped
 
 
 def test_lightcue_source_resolves_relative_to_game_dir_not_cwd(tmp_path):
@@ -262,8 +263,9 @@ def test_lightcue_source_at_old_cwd_relative_location_is_not_found(tmp_path):
         ["compile", "-o", str(out_dir), str(game_dir / "mygame.gq")],
     )
     assert exit_code != 0
-    assert "test.gqcue" in stderr
-    assert "gqc migrate mygame" in _unwrapped(stderr)
+    unwrapped = _unwrapped(stderr)
+    assert "test.gqcue" in unwrapped
+    assert "gqc migrate mygame" in unwrapped
 
 
 # --- missing-asset diagnostic: `gqc migrate` hint ---------------------------

--- a/gqc/tests/test_migrate.py
+++ b/gqc/tests/test_migrate.py
@@ -551,6 +551,34 @@ def test_migrate_destination_created_after_build_plan_is_not_clobbered(tmp_path)
     assert plan.entry_path.read_bytes() == entry_before
 
 
+def test_migrate_flat_baseline_symlink_failure_raises_clean_migrate_error(
+    tmp_path, monkeypatch
+):
+    # _compile_flat_baseline's os.symlink() (and its shutil.copyfile()
+    # neighbor) were unguarded -- an OSError (permissions, a filesystem/OS
+    # without symlink support) would escape as a raw traceback instead of
+    # the clean MigrateError this module documents everywhere else
+    # (gamequeer#437 review; Copilot flagged this across all four of #433's
+    # review rounds, always suppressed, never fixed). This runs before
+    # execute()'s first real workspace mutation (the whole harness lives in
+    # a throwaway tempdir), so there's nothing to roll back -- just confirm
+    # the clean error and that the original workspace is untouched.
+    plan = _build_single_game_plan(tmp_path)
+    entry_before = plan.entry_path.read_bytes()
+
+    def failing_symlink(*args, **kwargs):
+        raise OSError("simulated symlink failure")
+
+    monkeypatch.setattr(migrate.os, "symlink", failing_symlink)
+
+    with pytest.raises(migrate.MigrateError, match="compile harness"):
+        migrate.execute(plan)
+
+    assert not plan.new_game_dir.exists()
+    assert plan.entry_path.exists()
+    assert plan.entry_path.read_bytes() == entry_before
+
+
 def test_migrate_unlink_failure_rolls_back_move_and_raises_migrate_error(tmp_path, monkeypatch):
     # The *existing* rollback for execute()'s final plan.entry_path.unlink()
     # -- the migrated directory is already verified and moved into place,

--- a/gqc/tests/test_migrate.py
+++ b/gqc/tests/test_migrate.py
@@ -555,14 +555,13 @@ def test_migrate_flat_baseline_symlink_failure_raises_clean_migrate_error(
     tmp_path, monkeypatch
 ):
     # _compile_flat_baseline's os.symlink() (and its shutil.copyfile()
-    # neighbor) were unguarded -- an OSError (permissions, a filesystem/OS
-    # without symlink support) would escape as a raw traceback instead of
-    # the clean MigrateError this module documents everywhere else
-    # (gamequeer#437 review; Copilot flagged this across all four of #433's
-    # review rounds, always suppressed, never fixed). This runs before
-    # execute()'s first real workspace mutation (the whole harness lives in
-    # a throwaway tempdir), so there's nothing to roll back -- just confirm
-    # the clean error and that the original workspace is untouched.
+    # neighbor) are unguarded: an OSError (permissions, a filesystem/OS
+    # without symlink support) would otherwise escape as a raw traceback
+    # instead of the clean MigrateError this module documents everywhere
+    # else. This runs before execute()'s first real workspace mutation (the
+    # whole harness lives in a throwaway tempdir), so there's nothing to
+    # roll back -- just confirm the clean error and that the original
+    # workspace is untouched.
     plan = _build_single_game_plan(tmp_path)
     entry_before = plan.entry_path.read_bytes()
 


### PR DESCRIPTION
## ⚠️ Merge-order dependency (load-bearing)

**Do not merge this PR until the gq-games corpus-migration PR lands** (moving every
still-flat game in `duplico/gq-games` onto the game-as-directory layout via
`gqc migrate`). That PR is now open and adversarially reviewed merge-ready: https://github.com/duplico/gq-games/pull/54 --
once one is opened, link it here before merging. Merging this PR first breaks every
flat game in that corpus outright (no fallback, by design -- see below).

## Summary

gamequeer#434 / PR #435 (merged 2026-08-04) added a CWD-relative "legacy" resolution
mode, auto-detected by a `parent.name == stem` heuristic, so a flat-layout game
(`games/<name>.gq` + a shared top-level `assets/`) kept compiling after #420 switched
default resolution to game-dir-relative. George has ruled that the wrong call: gqc
should keep **exactly one** asset-resolution rule -- game-dir-relative (#420) -- and
the corpus should be migrated onto that layout instead (`gqc migrate`, #432/#433),
not accommodated indefinitely by a second resolution mode in the compiler.

This PR:

1. **Reverts #435's legacy machinery.** Removes `_is_directory_layout()` and its
   branch in `gqc.py`'s `compile` command; `Game.game_dir = input.parent`
   unconditionally again, no CWD fallback, no deprecation notice. Removes the seven
   tests in `test_game_layout.py` that pinned legacy/detection behavior. All other
   `test_game_layout.py` tests -- including the directory-layout CWD-independence
   negative controls, unaffected by the revert -- are kept.

2. **Replaces the failure mode with a real diagnostic.** A missing animation/lightcue
   asset previously surfaced as a bare `"... does not exist"` / `"... not found"`
   message. It now also gets a pointed hint naming the exact fix:

   ```
   Error at line 2, column 14: Animation source file assets/animations/circle.bmp
   does not exist
   If mygame is a flat-layout game (its assets haven't been moved into its own
   directory yet), run `gqc migrate mygame` to move it onto the current
   game-as-directory layout.
   ```

   Implemented as a new `GqcAssetNotFoundError`, but the two asset kinds don't share
   an identical call chain: for **animations**, `Animation.__init__` raises it (via
   `anim.make_animation`'s existence check) and `parser.py`'s
   `parse_animation_definition` catches it there. For **lightcues**,
   `parser.parse_lightcue_definition_section` performs its own separate `exists()`
   check up front and never calls into `cues.py` at all -- `cues.py`'s
   `GqcAssetNotFoundError` (in `make_cue`) is reachable only from the `gqc mkcue` CLI
   command, a library/tooling entry point with no `Game` context and no migrate hint
   (see review-round follow-up below). Both surfaces still end up wrapped in the same
   `_migrate_hint`-bearing `GqcParseError`, just via two different routes. This is a
   diagnostic-only change -- no new resolution behavior, no fallback.

3. **Confirms `gqc migrate` still works end-to-end**, since its `_compile_flat_baseline`
   symlink harness was designed for exactly this no-legacy world (it predates #435).
   Migrated a real flat `bricks.gq` fixture (built from gq-games' current, still-flat
   `games/bricks.gq` + the assets it references) through `gqc migrate bricks`:
   byte-identical `.gqgame` verified before/after by migrate itself, and the migrated
   game-as-directory result compiles cleanly and directly afterward. Also fixed
   `migrate.py`'s docstring sentence (added by #433) that described the symlink
   harness as simplifiable "once #434/#435 lands" -- with the revert, that harness is
   the permanent design, not a stopgap.

## Post-review fix round

An adversarial review pass found four issues, all fixed in this PR (see the PR
comment below for full detail):

- `_migrate_hint` rendered a literal `"None"` into its hint text for any in-process
  caller of `parser.parse()` that never sets `Game.game_name` (e.g. tests). Falls
  back to generic phrasing.
- `Animation.__init__`'s digest-cache-hit branch could hit a raw, unhandled
  `FileNotFoundError` instead of the same `gqc migrate` diagnostic, if the source
  asset moved/was deleted after a previous compile left a cache behind.
- `cues.py`'s `GqcAssetNotFoundError`, corrected above: it's `mkcue`-only, not on the
  compile path.
- `migrate.py`'s `_compile_flat_baseline` had an unguarded `os.symlink`/
  `shutil.copyfile` that could raise a raw `OSError`, contradicting `MigrateError`'s
  documented "never a raw traceback" contract.

## Verification

- `gqc/tests` (pytest): **522 passed, 2 skipped** (started at 519 passed/2 skipped
  post-revert; the post-review fix round added 3 more regression tests).
- `-m golden`: **15 passed, 2 skipped**, untouched by this change.
- Real end-to-end migration of a flat `bricks.gq` fixture: byte-identical `.gqgame`
  before/after `gqc migrate`, migrated result compiles standalone.

## Files changed

- `gqc/src/gqc/gqc.py` -- revert #435's detection branch.
- `gqc/src/gqc/__init__.py`, `anim.py`, `cues.py`, `parser.py` -- new
  `GqcAssetNotFoundError` + `gqc migrate` hint.
- `gqc/src/gqc/datamodel.py` -- animation digest-cache-hit existence check
  (post-review fix round).
- `gqc/src/gqc/migrate.py` -- docstring fix (harness is permanent, not a stopgap);
  guard the flat-baseline compile harness against `OSError` (post-review fix round).
- `gqc/tests/test_game_layout.py`, `test_migrate.py` -- remove legacy tests, add
  diagnostic tests, add post-review regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZKhf6qdJnripjqBapoEan

