### PR TITLE
chore: drop .python-version pinning a nonexistent pyenv env

### DIFF
--- a/.python-version
+++ b/.python-version
@@ -1,1 +1,0 @@
-gamequeer


### PR DESCRIPTION
The tracked `.python-version` pins pyenv env `gamequeer`, which doesn't exist — so **any** `python -m gqc` with CWD inside this repo fails under pyenv (`pyenv: version 'gamequeer' is not installed`). That's been a documented install-time footgun for a while, but the examples/ migration (#443) made `make` from `examples/` an official workflow, and it trips over this immediately: reproduced on the current default (`make` in `examples/` fails on the first title; `PYENV_VERSION=3.14.0 make` builds all 10 carts clean).

Removing the file lets pyenv fall through to the user's global version. If you keep a real `gamequeer` env on some machine, an **untracked** `.python-version` (or `PYENV_VERSION`) gives you the same behavior without breaking everyone else — happy to add it to `.gitignore` instead if you'd prefer that ruling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZKhf6qdJnripjqBapoEan