### PR TITLE
fix(vm): close load_stage()'s event-clear/timer_active window (#452)

### DIFF
--- a/gamequeer/src/gamequeer.c
+++ b/gamequeer/src/gamequeer.c
@@ -135,6 +135,22 @@ uint8_t load_stage(t_gq_pointer stage_ptr) {
         led_stop();
     }
 
+    // Disarm the outgoing stage's timer *before* clearing GQ_EVENT_TIMER
+    // below, not after. system_tick() is the only place that ever sets
+    // GQ_EVENT_TIMER, and it does so gated on `timer_active` -- if
+    // `timer_active` is still 1 when GQ_EVENT_TIMER is cleared, any
+    // intervening call to system_tick() (today: none can interleave with
+    // load_stage(), since both run in MAIN with no reentrancy; system_tick()
+    // is never called from RTC_ISR -- but that is a call-graph fact, not
+    // something this function can enforce) would re-set GQ_EVENT_TIMER from
+    // the *outgoing* stage's still-armed timer_interval/timer_counter,
+    // handing a same-tick gostage() cascade a stale timer flag several hops
+    // downstream (gamequeer#452). Zeroing `timer_active` first closes the
+    // window structurally: system_tick() no-ops on a disarmed timer, so
+    // nothing can re-set the flag we're about to clear, regardless of
+    // ordering or interleaving. No masking needed.
+    timer_active = 0;
+
     // Clear only the stage-owned synthetic events: they belong to the
     // outgoing stage and have no meaning in the new one. Deliberately do NOT
     // clear the user-input events (BUTTON_A/B/L/R, BUTTON_CLICK) here --
@@ -143,8 +159,7 @@ uint8_t load_stage(t_gq_pointer stage_ptr) {
     // that auto-cascades into another stage) used to wipe a button/dial
     // event that HAL_event_poll() had already OR'd into s_gq_event this
     // tick, before handle_events()'s single forward pass ever reached it --
-    // silently dropping the input. See gamequeer#455. (#452 remains: TIMER
-    // is still stage-owned and still cleared here.)
+    // silently dropping the input. See gamequeer#455.
     GQ_EVENT_CLR(GQ_EVENT_ENTER);
     GQ_EVENT_CLR(GQ_EVENT_BGDONE);
     GQ_EVENT_CLR(GQ_EVENT_MENU);
@@ -169,9 +184,6 @@ uint8_t load_stage(t_gq_pointer stage_ptr) {
         *label_y[i] = 0;
     }
     *label_flags = 0;
-
-    // If a timer is active, stop it.
-    timer_active = 0;
 
     // Set stage entry event flag
     GQ_EVENT_SET(GQ_EVENT_ENTER);


### PR DESCRIPTION
## Summary

Closes https://github.com/duplico/gamequeer/issues/452.

`load_stage()` cleared `GQ_EVENT_TIMER` (as part of its stage-owned
synthetic-event clear, see https://github.com/duplico/gamequeer/pull/456 /
https://github.com/duplico/gamequeer/issues/455) several lines *before* it
zeroed `timer_active`, with nothing in between. `system_tick()` is the sole
place that ever sets `GQ_EVENT_TIMER`, and it does so gated entirely on
`timer_active`:

```c
if (timer_active) {
    timer_counter++;
    if (timer_counter >= timer_interval) {
        timer_active = 0;
        GQ_EVENT_SET(GQ_EVENT_TIMER);
    }
}
```

So any call to `system_tick()` landing in that gap could re-set
`GQ_EVENT_TIMER` from the *outgoing* stage's still-armed
`timer_interval`/`timer_counter`. Because `handle_events()`'s forward pass
dispatches `GQ_EVENT_ENTER` (index 0) before `GQ_EVENT_TIMER` (index 8), a
same-tick `gostage` cascade triggered from `ENTER` could then carry that
stale timer flag to a stage several hops downstream in the same pass.

## Fix

Reorder: zero `timer_active` *before* clearing the stage-owned event bits,
instead of after. This closes the window structurally rather than by
narrowing it with a mask -- once `timer_active` is 0, `system_tick()`
no-ops on the timer entirely, so nothing can re-set `GQ_EVENT_TIMER`
between the disarm and the clear, regardless of instruction-level ordering
or any future reentrancy. No `GIE` masking needed.

## Reachability note (for the record)

On both the firmware and the emulator, `GQ_EVENT_TIMER` is set only inside
`system_tick()`, and `system_tick()` is only ever called from MAIN context
(the firmware's `rtc_ticks_pending`-drain loop in `main.c`, or the
emulator's synchronous tick loop) -- `RTC_ISR` itself only increments a
pending-tick counter, it never touches `s_gq_event`. So today this is a
call-graph fact rather than a live reentrancy path, which is why the issue
was correctly filed as "correctness-of-guarantee" rather than a live
failure. The fix removes the dependency on that call-graph fact entirely,
so it holds even if a future refactor (e.g. a lower-jitter tick path)
makes `system_tick()` interrupt-reachable.

## Same-shape follow-up (not fixed here, out of scope)

`unload_game()` (`gamequeer/gamequeer/src/gamequeer.c`) has the identical
shape: it clears every event (including `GQ_EVENT_TIMER`) via a loop, then
zeroes `timer_active` afterward. The filed issue is scoped to
`load_stage()`, so I left `unload_game()` alone here, but it has the same
theoretical window and the same one-line fix. Flagging for a maintainer
call on whether to file a follow-up issue.

## Verification

- **Build**: `make builder-build` + manual (non-`-it`, this sandbox has no
  TTY) equivalent of `make gamequeer` -- builds clean; only pre-existing
  `grlib`/`gfx` warnings unrelated to this change.
- **Tests**: `make test-headless` -- all 30/30 golden/ctest cases pass, no
  regressions.
- **Format**: `clang-format --dry-run --Werror` on the changed file --
  clean.
- **No new golden-CSV regression test added**: the golden-test harness
  (both firmware MAIN-loop and emulator `main.c`) calls `system_tick()`
  non-reentrantly, strictly before `handle_events()`, every tick -- there
  is no way to script an interleaving that would make the pre-fix and
  post-fix code observably differ under that harness. A test that claimed
  to reproduce the race without actually forcing reentrancy would be
  misleading, so I did not add one; verification here is build + full
  existing suite (no regression) + code-level reasoning on the fix's
  closure of the window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)