### PR TITLE
fix(gqc): pack UNCOMP image bytes continuously, don't row-pad

### DIFF
--- a/gqc/src/gqc/datamodel.py
+++ b/gqc/src/gqc/datamodel.py
@@ -859,30 +859,34 @@ class Frame:
         return structs.GQ_ANIM_FRAME_SIZE
 
     def uncompressed_bytes(self):
+        # NB: packed, NOT row-padded (gamequeer#439) -- every deployed
+        # decoder (2024 fleet firmware, current firmware, and the emulator
+        # alike; see oled.c's gq_image_advance_run()/gq_image_peek_run() for
+        # rle_type == 1) reads UNCOMP data as one continuous bitstream and
+        # never realigns to a byte boundary at a row wrap. Row-padding here
+        # (the old behavior) produced a bitstream those decoders shear
+        # against for any width % 8 != 0. Do not reintroduce a per-row
+        # flush without a matching, lockstep decoder change.
         run = 0
         val = 0
         out_bytes = []
-        row_run = 0
 
         for pixel_raw in self.image.getdata():
             pixel = 1 if pixel_raw else 0
 
-            if run == 8 or row_run == self.image.width:
+            if run == 8:
                 out_bytes.append(val)
                 run = 0
                 val = 0
-                if row_run == self.image.width:
-                    row_run = 0
-            
+
             if pixel:
                 val |= (0b10000000 >> run)
-            
+
             run += 1
-            row_run += 1
 
         # We definitely didn't finish the above with a write-out, so do one:
         out_bytes.append(val)
-        
+
         return bytes(out_bytes)
 
     def rle_bytes(self, bits):

--- a/gqc/tests/test_assets.py
+++ b/gqc/tests/test_assets.py
@@ -83,17 +83,68 @@ def _run_cli(tmp_path, args, timeout=60):
 # --- Frame encoders: uncompressed_bytes() ------------------------------------
 
 
-def test_uncompressed_bytes_pads_each_row_to_its_own_byte():
-    # width=3 doesn't divide evenly into a byte, so each of the 2 rows must
-    # start a fresh output byte rather than packing continuously across the
-    # row boundary (row0 = 1,0,0 -> 0x80; row1 = 1,1,0 -> 0xc0).
+def _decode_uncompressed(data: bytes, width: int, height: int):
+    """Decode packed UNCOMP bytes back into rows of 0/1 pixels, mirroring
+    the deployed C decoder's read behavior (oled.c's
+    gq_image_advance_run()/gq_image_peek_run() for rle_type == 1): pixels
+    are consumed continuously across the bitstream -- there is no
+    realignment to a byte boundary at a row wrap."""
+    bits = []
+    for byte in data:
+        bits.extend((byte >> (7 - i)) & 1 for i in range(8))
+
+    rows = []
+    idx = 0
+    for _ in range(height):
+        rows.append(bits[idx : idx + width])
+        idx += width
+    return rows
+
+
+def test_uncompressed_bytes_packs_continuously_across_row_boundaries():
+    # width=3 doesn't divide evenly into a byte (gamequeer#439): rows must
+    # pack continuously into the bitstream -- NOT start a fresh output byte
+    # at each row -- since that's what every deployed decoder (2024 fleet
+    # firmware, current firmware, and the emulator) actually reads.
+    # row0 = 1,0,0 ; row1 = 1,1,0 -> bitstream 100 110 xxx -> 0x9800... i.e.
+    # byte0 = 1001 1000 = 0x98, no second byte needed (only 6 bits used, the
+    # implementation still flushes one final byte).
     im = Image.new("1", (3, 2), 0)
     im.putpixel((0, 0), 1)
     im.putpixel((0, 1), 1)
     im.putpixel((1, 1), 1)
 
     frame = Frame(img=im)
-    assert frame.uncompressed_bytes() == bytes([0x80, 0xC0])
+    assert frame.uncompressed_bytes() == bytes([0x98])
+
+
+def test_uncompressed_bytes_round_trips_non_byte_aligned_width():
+    # A width that isn't a multiple of 8 must still decode back to the
+    # original pixels when read as a packed (non-row-padded) bitstream --
+    # the regression this issue is about.
+    im = Image.new("1", (3, 2), 0)
+    im.putpixel((0, 0), 1)
+    im.putpixel((0, 1), 1)
+    im.putpixel((1, 1), 1)
+
+    frame = Frame(img=im)
+    decoded = _decode_uncompressed(frame.uncompressed_bytes(), im.width, im.height)
+    expected = [[1 if im.getpixel((x, y)) else 0 for x in range(im.width)] for y in range(im.height)]
+    assert decoded == expected
+
+
+def test_uncompressed_bytes_byte_aligned_width_unchanged():
+    # Regression guard: for a byte-aligned width, packed and row-padded
+    # encodings coincide, so this must stay byte-identical to the
+    # pre-gamequeer#439 output.
+    im = Image.new("1", (8, 2), 0)
+    im.putpixel((0, 0), 1)
+    im.putpixel((7, 0), 1)
+    im.putpixel((0, 1), 1)
+    im.putpixel((1, 1), 1)
+
+    frame = Frame(img=im)
+    assert frame.uncompressed_bytes() == bytes([0x81, 0xC0])
 
 
 # --- Frame encoders: rle_bytes(7) --------------------------------------------


### PR DESCRIPTION
## Summary

- `uncompressed_bytes()` (`gqc/src/gqc/datamodel.py`) row-padded each row of a 1bpp UNCOMP frame to a byte boundary, but every deployed decoder -- 2024 fleet firmware, current firmware, and the emulator alike (`oled.c`'s `gq_image_advance_run()`/`gq_image_peek_run()` for `rle_type == 1`) -- reads UNCOMP data as one continuous packed bitstream and never realigns at a row wrap. Any UNCOMP frame with `width % 8 != 0` rendered with a progressive shear.
- Verified the decoder side directly in `gamequeer/gamequeer/src/oled.c`: `gq_image_advance_run()` only increments `byte_index`/resets `x_bit_offset` at 8-pixel boundaries; the row-wrap branch (`x_pixel_offset >= width`) only resets `x_pixel_offset`, never `x_bit_offset`/`byte_index`. Confirms the issue's read of the decoder.
- Checked `qc2024/ccs_workspace/` for a second/divergent decoder (per repo rule QC2024-5): none exists -- the badge firmware links `oled.c` directly from this submodule (see `ccs_workspace/qc2024/Makefile`), so there's exactly one decoder implementation, and it's the packed-read one.
- Fix direction: since every decoder is frozen (the 2024 fleet is JTAG-only; changing the still-in-service current firmware/emulator decoder would break the 2024 fleet too), the encoder is the wrong side and is the one changed here, to emit exactly what decoders already consume. Byte-aligned widths are unaffected -- packed and row-padded encodings coincide there.

## Test plan

- [x] `cd gqc && make test` -- 545 passed, 2 skipped (pre-existing `ffmpeg`-marked skips), 0 failures.
- [x] Updated `test_uncompressed_bytes_pads_each_row_to_its_own_byte` (pinned the old, buggy row-padded behavior) to `test_uncompressed_bytes_packs_continuously_across_row_boundaries`.
- [x] Added `test_uncompressed_bytes_round_trips_non_byte_aligned_width`: encodes a 3-wide image and decodes it back (mirroring the C decoder's packed-bitstream read) to confirm pixel round-trip for a non-byte-aligned width.
- [x] Added `test_uncompressed_bytes_byte_aligned_width_unchanged`: regression guard that an 8-wide image still encodes exactly as it did before this fix.

## Blast radius (gq-games)

Checked whether already-built `.gqgame` images in `gq-games` (a sibling submodule) contain sheared UNCOMP assets that would need recompiling:

- `alchemy` and `donsol` (the two carts already burned/released per project history) recompile **byte-identical** with this fix -- `cmp` confirms no bytes changed. Neither game's own asset set (nor any shared `common/` icon kit, which they don't reference) contains a non-byte-aligned-width sprite, so neither was ever affected.
- The wider `gq-games` repo does have several non-byte-aligned-width *source* assets (crawl GIFs, some icon sprites), but source width isn't final encoded width (ffmpeg resizes/dithers for the display), and RLE7 is preferred over UNCOMP whenever it's smaller, so source width alone doesn't establish which compiled frames are actually affected. A full before/after rebuild-and-diff across all `gq-games` titles is the reliable way to enumerate any affected frames; that's flagged as a follow-up for whoever owns the next `gq-games` build/cart-burn pass, not fixed in this PR.

Fixes duplico/gamequeer#439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)